### PR TITLE
docs: update ai model instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ python transcribe.py /path/to/audio/folder --model_size large-v3-turbo --languag
 
 **플랫폼별 기본 모델**:
 - Windows: `gemma3:4b`
-- macOS/Linux: `gpt-oss:20b`
+- macOS/Linux: `gemma3:12b-it-qat`
 
 **교정 규칙**:
 - 원문 의미와 사실 보존
@@ -141,7 +141,7 @@ run.bat
 - Python 실행파일: 자동 감지
 
 ### macOS/Linux
-- 모델: `gpt-oss:20b` (교정 및 요약 공용)
+- 모델: 교정 `gemma3:12b-it-qat`, 요약 `gpt-oss:20b`
 - 캐시: `~/.cache/whisper/`
 - Python 실행파일: `venv/bin/python` (가상환경 사용)
 - 환경변수: `.env` 파일에서 자동 로드

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -13,7 +13,7 @@
 -   **언어:** Python 3
 -   **음성 인식:** `openai-whisper`
 -   **화자 구분:** `pyannote.audio` (GPU/MPS 최적화)
--   **LLM (텍스트 교정/요약):** `Ollama` (gemma3:4b, gpt-oss:20b 등)
+-   **LLM (텍스트 교정/요약):** `Ollama` (gemma3:4b, gemma3:12b-it-qat, gpt-oss:20b 등)
 -   **핵심 의존성:**
     -   `openai-whisper`: Python 라이브러리
     -   `ollama`: Python 라이브러리
@@ -79,6 +79,10 @@ run_shell_command(command="sttEngine\run.bat")
 ```
 run_shell_command(command="./run.sh")
 ```
+
+**플랫폼별 기본 모델:**
+- Windows: `gemma3:4b`
+- macOS/Linux: 교정 `gemma3:12b-it-qat`, 요약 `gpt-oss:20b`
 
 *참고: `run_workflow.py`는 대화형 입력(실행할 단계, 파일 경로 등)을 요구하므로, AI 에이전트가 직접 실행하기보다는 사용자의 입력을 전달하는 방식으로 사용해야 합니다.*
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ brew install ollama
 ollama pull gemma3:4b
 
 # macOS/Linux 사용자
+ollama pull gemma3:12b-it-qat
 ollama pull gpt-oss:20b
 ```
 
@@ -142,12 +143,14 @@ python sttEngine/workflow/transcribe.py [audio_folder] --model_size large-v3-tur
 
 #### 2단계: 텍스트 교정
 ```bash
-python sttEngine/workflow/correct.py input.md --model gemma3:4b --temperature 0.0
+python sttEngine/workflow/correct.py input.md --model gemma3:4b --temperature 0.0  # Windows
+python sttEngine/workflow/correct.py input.md --model gemma3:12b-it-qat --temperature 0.0  # macOS/Linux
 ```
 
 #### 3단계: 텍스트 요약
 ```bash
-python sttEngine/workflow/summarize.py input.corrected.md --model gemma3:4b --temperature 0.0
+python sttEngine/workflow/summarize.py input.corrected.md --model gemma3:4b --temperature 0.0  # Windows
+python sttEngine/workflow/summarize.py input.corrected.md --model gpt-oss:20b --temperature 0.0  # macOS/Linux
 ```
 
 ## 지원 오디오 포맷
@@ -163,7 +166,7 @@ python sttEngine/workflow/summarize.py input.corrected.md --model gemma3:4b --te
 - Python 실행파일: 자동 감지
 
 ### macOS/Linux
-- 모델: `gpt-oss:20b` (교정 및 요약 공용)
+- 모델: 교정 `gemma3:12b-it-qat`, 요약 `gpt-oss:20b`
 - 캐시: `~/.cache/whisper/`
 - Python 실행파일: `venv/bin/python` (가상환경 사용)
 - 환경변수: `.env` 파일에서 자동 로드
@@ -222,6 +225,6 @@ python sttEngine/workflow/summarize.py input.corrected.md --model gemma3:4b --te
 
 ### 추가 참고사항
 
-- 본 레포지토리는 문과 출신 기획자에 의해 운영됩니다. LLM 자체에 대한 학습을 목적으로 합니다. 
+- 본 레포지토리는 문과 출신 기획자에 의해 운영됩니다. LLM 자체에 대한 학습을 목적으로 합니다.
 - 대부분의 코드는 LLM(Claude > Gemini > ChatGPT 순)으로 작성되었습니다.
 - 구현 예정사항은 [Todo List](/TodoList.md)로 정리합니다.


### PR DESCRIPTION
## Summary
- document macOS/Linux default model `gemma3:12b-it-qat` alongside `gpt-oss:20b`
- show platform-specific examples for correction and summarization
- note default models for Gemini agent usage

## Testing
- `python -m py_compile sttEngine/run_workflow.py sttEngine/workflow/*.py`


------
https://chatgpt.com/codex/tasks/task_e_689bd5d73c6c832e86e0fdf6b34d087b