### PR TITLE
Add simple audio upload test page and Python server

### DIFF
--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Audio Upload Test</title>
+</head>
+<body>
+    <h1>Upload Audio File</h1>
+    <input type="file" id="audioFile" accept="audio/*" />
+    <button id="uploadBtn">Upload</button>
+    <div id="status"></div>
+    <script>
+        document.getElementById('uploadBtn').addEventListener('click', async () => {
+            const input = document.getElementById('audioFile');
+            const status = document.getElementById('status');
+            if (!input.files.length) {
+                status.textContent = 'Please select an audio file first.';
+                return;
+            }
+            const formData = new FormData();
+            formData.append('file', input.files[0]);
+            try {
+                const resp = await fetch('/upload', {
+                    method: 'POST',
+                    body: formData
+                });
+                if (resp.ok) {
+                    status.textContent = 'Upload complete!';
+                } else {
+                    status.textContent = 'Upload failed.';
+                }
+            } catch (err) {
+                status.textContent = 'Error: ' + err.message;
+            }
+        });
+    </script>
+</body>
+</html>

--- a/server.py
+++ b/server.py
@@ -1,0 +1,69 @@
+"""Simple HTTP server to handle audio file uploads.
+
+This server serves the test upload page and accepts file uploads at /upload.
+Files are stored in the local 'uploads' directory.
+"""
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import cgi
+import os
+
+UPLOAD_DIR = 'uploads'
+
+class UploadHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/':
+            try:
+                with open('frontend/upload.html', 'rb') as f:
+                    content = f.read()
+                self.send_response(200)
+                self.send_header('Content-Type', 'text/html; charset=utf-8')
+                self.end_headers()
+                self.wfile.write(content)
+            except FileNotFoundError:
+                self.send_response(404)
+                self.end_headers()
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_POST(self):
+        if self.path != '/upload':
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        form = cgi.FieldStorage(
+            fp=self.rfile,
+            headers=self.headers,
+            environ={
+                'REQUEST_METHOD': 'POST',
+                'CONTENT_TYPE': self.headers.get('Content-Type'),
+            },
+        )
+
+        file_item = form['file'] if 'file' in form else None
+        if not file_item or not file_item.filename:
+            self.send_response(400)
+            self.end_headers()
+            self.wfile.write(b'No file uploaded')
+            return
+
+        os.makedirs(UPLOAD_DIR, exist_ok=True)
+        file_path = os.path.join(UPLOAD_DIR, os.path.basename(file_item.filename))
+        with open(file_path, 'wb') as output_file:
+            output_file.write(file_item.file.read())
+
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b'File uploaded successfully')
+
+if __name__ == '__main__':
+    os.makedirs(UPLOAD_DIR, exist_ok=True)
+    server = HTTPServer(('0.0.0.0', 8000), UploadHandler)
+    print('Serving on http://localhost:8000')
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()


### PR DESCRIPTION
## Summary
- Add `frontend/upload.html` test page with JavaScript to POST audio files
- Implement `server.py` to serve page and accept uploads, storing files in `uploads`

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689c3d166ee0832ea84d9fae8c613a2e