### PR TITLE
Add basic workflow selection and result links

### DIFF
--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -9,7 +9,19 @@
     <input type="file" id="audioFile" accept="audio/*" />
     <button id="uploadBtn">Upload</button>
     <div id="status"></div>
+
+    <div id="workflow" style="display:none; margin-top:1em;">
+        <label><input type="checkbox" id="stepStt" /> STT 변환</label>
+        <label><input type="checkbox" id="stepCorrect" /> 텍스트 교정</label>
+        <label><input type="checkbox" id="stepSummary" /> 요약</label>
+        <button id="processBtn">확인</button>
+    </div>
+
+    <div id="downloads" style="margin-top:1em;"></div>
+
     <script>
+        let uploadedPath = null;
+
         document.getElementById('uploadBtn').addEventListener('click', async () => {
             const input = document.getElementById('audioFile');
             const status = document.getElementById('status');
@@ -25,13 +37,52 @@
                     body: formData
                 });
                 if (resp.ok) {
-                    status.textContent = 'Upload complete!';
+                    const data = await resp.json();
+                    uploadedPath = data.file_path;
+                    document.getElementById('workflow').style.display = 'block';
+                    status.textContent = 'Upload complete! Select workflow steps.';
                 } else {
                     status.textContent = 'Upload failed.';
                 }
             } catch (err) {
                 status.textContent = 'Error: ' + err.message;
             }
+        });
+
+        document.getElementById('processBtn').addEventListener('click', async () => {
+            if (!uploadedPath) return;
+
+            const steps = [];
+            if (document.getElementById('stepStt').checked) steps.push('stt');
+            if (document.getElementById('stepCorrect').checked) steps.push('correct');
+            if (document.getElementById('stepSummary').checked) steps.push('summary');
+
+            const resp = await fetch('/process', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ file_path: uploadedPath, steps })
+            });
+
+            const downloads = document.getElementById('downloads');
+            downloads.innerHTML = '';
+
+            if (!resp.ok) {
+                downloads.textContent = 'Processing failed.';
+                return;
+            }
+
+            const result = await resp.json();
+
+            ['stt', 'correct', 'summary'].forEach(step => {
+                if (result[step]) {
+                    const link = document.createElement('a');
+                    link.href = result[step];
+                    link.textContent = step.toUpperCase() + ' 파일 다운로드';
+                    link.download = '';
+                    downloads.appendChild(link);
+                    downloads.appendChild(document.createElement('br'));
+                }
+            });
         });
     </script>
 </body>

--- a/server.py
+++ b/server.py
@@ -1,66 +1,166 @@
-"""Simple HTTP server to handle audio file uploads.
+"""Simple HTTP server for uploading files and running workflow steps.
 
-This server serves the test upload page and accepts file uploads at /upload.
-Files are stored in the local 'uploads' directory.
+The server exposes:
+  * ``GET /`` – serve the upload HTML page.
+  * ``POST /upload`` – accept an audio file and store it under ``uploads/``.
+  * ``POST /process`` – run selected workflow steps for the uploaded file.
+  * ``GET /download/<file>`` – return processed files for download.
+
+Only selected workflow steps return download links.
 """
+
 from http.server import HTTPServer, BaseHTTPRequestHandler
 import cgi
+import json
 import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
 
-UPLOAD_DIR = 'uploads'
+
+BASE_DIR = Path(__file__).parent.resolve()
+UPLOAD_DIR = BASE_DIR / "uploads"
+OUTPUT_DIR = BASE_DIR / "whisper_output"
+WORKFLOW_DIR = BASE_DIR / "sttEngine" / "workflow"
+PYTHON = sys.executable
+
+
+def run_workflow(file_path: Path, steps):
+    """Run the requested workflow steps sequentially.
+
+    Args:
+        file_path: Path to the uploaded audio or text file.
+        steps: list of step names, e.g. ["stt", "correct", "summary"].
+
+    Returns:
+        Dict mapping step name to download URL.
+    """
+
+    results = {}
+    current_file = file_path
+
+    try:
+        if "stt" in steps:
+            subprocess.run(
+                [PYTHON, str(WORKFLOW_DIR / "transcribe.py"), str(current_file.parent), "--output_dir", str(OUTPUT_DIR)],
+                check=True,
+            )
+            stt_file = OUTPUT_DIR / f"{file_path.stem}.md"
+            results["stt"] = f"/download/{stt_file.name}"
+            current_file = stt_file
+
+        if "correct" in steps:
+            subprocess.run([PYTHON, str(WORKFLOW_DIR / "correct.py"), str(current_file)], check=True)
+            corrected_file = current_file.with_name(f"{current_file.stem}.corrected.md")
+            results["correct"] = f"/download/{corrected_file.name}"
+            current_file = corrected_file
+
+        if "summary" in steps:
+            subprocess.run([PYTHON, str(WORKFLOW_DIR / "summarize.py"), str(current_file)], check=True)
+            summary_file = current_file.with_name(f"{current_file.stem}.summary.md")
+            results["summary"] = f"/download/{summary_file.name}"
+
+    except Exception as exc:  # pragma: no cover - best effort error handling
+        return {"error": str(exc)}
+
+    return results
+
 
 class UploadHandler(BaseHTTPRequestHandler):
+    def _serve_upload_page(self):
+        try:
+            with open(BASE_DIR / "frontend" / "upload.html", "rb") as f:
+                content = f.read()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(content)
+        except FileNotFoundError:
+            self.send_response(404)
+            self.end_headers()
+
+    def _serve_download(self, filename: str):
+        file_path = OUTPUT_DIR / filename
+        if file_path.exists():
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Disposition", f"attachment; filename={filename}")
+            self.end_headers()
+            with open(file_path, "rb") as f:
+                self.wfile.write(f.read())
+        else:
+            self.send_response(404)
+            self.end_headers()
+
     def do_GET(self):
-        if self.path == '/':
-            try:
-                with open('frontend/upload.html', 'rb') as f:
-                    content = f.read()
-                self.send_response(200)
-                self.send_header('Content-Type', 'text/html; charset=utf-8')
-                self.end_headers()
-                self.wfile.write(content)
-            except FileNotFoundError:
-                self.send_response(404)
-                self.end_headers()
+        if self.path == "/":
+            self._serve_upload_page()
+        elif self.path.startswith("/download/"):
+            filename = os.path.basename(self.path[len("/download/"):])
+            self._serve_download(filename)
         else:
             self.send_response(404)
             self.end_headers()
 
     def do_POST(self):
-        if self.path != '/upload':
-            self.send_response(404)
+        if self.path == "/upload":
+            form = cgi.FieldStorage(
+                fp=self.rfile,
+                headers=self.headers,
+                environ={
+                    "REQUEST_METHOD": "POST",
+                    "CONTENT_TYPE": self.headers.get("Content-Type"),
+                },
+            )
+
+            file_item = form["file"] if "file" in form else None
+            if not file_item or not file_item.filename:
+                self.send_response(400)
+                self.end_headers()
+                self.wfile.write(b"No file uploaded")
+                return
+
+            uid = uuid.uuid4().hex
+            save_dir = UPLOAD_DIR / uid
+            save_dir.mkdir(parents=True, exist_ok=True)
+            file_path = save_dir / os.path.basename(file_item.filename)
+            with open(file_path, "wb") as output_file:
+                output_file.write(file_item.file.read())
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
             self.end_headers()
+            self.wfile.write(json.dumps({"file_path": str(file_path.relative_to(BASE_DIR))}).encode())
             return
 
-        form = cgi.FieldStorage(
-            fp=self.rfile,
-            headers=self.headers,
-            environ={
-                'REQUEST_METHOD': 'POST',
-                'CONTENT_TYPE': self.headers.get('Content-Type'),
-            },
-        )
+        if self.path == "/process":
+            length = int(self.headers.get("Content-Length", 0))
+            payload = json.loads(self.rfile.read(length)) if length else {}
+            file_path = payload.get("file_path")
+            steps = payload.get("steps", [])
+            if not file_path:
+                self.send_response(400)
+                self.end_headers()
+                self.wfile.write(b"Missing file_path")
+                return
 
-        file_item = form['file'] if 'file' in form else None
-        if not file_item or not file_item.filename:
-            self.send_response(400)
+            results = run_workflow(BASE_DIR / file_path, steps)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
             self.end_headers()
-            self.wfile.write(b'No file uploaded')
+            self.wfile.write(json.dumps(results).encode())
             return
 
-        os.makedirs(UPLOAD_DIR, exist_ok=True)
-        file_path = os.path.join(UPLOAD_DIR, os.path.basename(file_item.filename))
-        with open(file_path, 'wb') as output_file:
-            output_file.write(file_item.file.read())
-
-        self.send_response(200)
+        self.send_response(404)
         self.end_headers()
-        self.wfile.write(b'File uploaded successfully')
 
-if __name__ == '__main__':
-    os.makedirs(UPLOAD_DIR, exist_ok=True)
-    server = HTTPServer(('0.0.0.0', 8000), UploadHandler)
-    print('Serving on http://localhost:8000')
+
+if __name__ == "__main__":
+    UPLOAD_DIR.mkdir(exist_ok=True)
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    server = HTTPServer(("0.0.0.0", 8000), UploadHandler)
+    print("Serving on http://localhost:8000")
     try:
         server.serve_forever()
     except KeyboardInterrupt:


### PR DESCRIPTION
## Summary
- enhance upload page with selectable workflow steps and download links
- extend server to process selected steps and serve resulting files

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689c4c7d34e0832e87b2ce76d98dbaf4