### PR TITLE
Group queued tasks by category

### DIFF
--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -36,6 +36,22 @@
         let taskQueue = [];
         let currentTask = null;
         let taskIdCounter = 0;
+        const categoryOrder = ['stt', 'correct', 'summary'];
+        let currentCategory = null;
+
+        function sortTaskQueue() {
+            let startIndex = 0;
+            if (currentTask) {
+                startIndex = categoryOrder.indexOf(currentTask.task);
+            } else if (currentCategory) {
+                startIndex = categoryOrder.indexOf(currentCategory);
+            }
+            const order = categoryOrder.slice(startIndex).concat(categoryOrder.slice(0, startIndex));
+            taskQueue.sort((a, b) => {
+                const diff = order.indexOf(a.task) - order.indexOf(b.task);
+                return diff !== 0 ? diff : a.id - b.id;
+            });
+        }
 
         function formatDateTime(isoString) {
             const date = new Date(isoString);
@@ -62,6 +78,7 @@
             };
             
             taskQueue.push(taskItem);
+            sortTaskQueue();
             updateQueueDisplay();
             processNextTask();
             
@@ -83,15 +100,17 @@
                     resetTaskElement(task.taskElement, task.task);
                 }
                 
-                taskQueue.splice(taskIndex, 1);
-                updateQueueDisplay();
+            taskQueue.splice(taskIndex, 1);
+            updateQueueDisplay();
+            currentCategory = taskQueue.length > 0 ? taskQueue[0].task : currentCategory;
             }
             
             // If this was the current task, process next
-            if (currentTask && currentTask.id === taskId) {
-                currentTask = null;
-                processNextTask();
-            }
+        if (currentTask && currentTask.id === taskId) {
+            currentTask = null;
+            currentCategory = taskQueue.length > 0 ? taskQueue[0].task : null;
+            processNextTask();
+        }
         }
 
         function resetTaskElement(taskElement, task) {
@@ -306,6 +325,7 @@
             
             currentTask = taskQueue[0];
             currentTask.status = 'processing';
+            currentCategory = currentTask.task;
             updateQueueDisplay();
             
             try {
@@ -380,8 +400,9 @@
                         taskQueue.splice(taskIndex, 1);
                     }
                 }
-                
+
                 currentTask = null;
+                currentCategory = taskQueue.length > 0 ? taskQueue[0].task : null;
                 updateQueueDisplay();
                 
                 // Reload history to show updated completion status


### PR DESCRIPTION
## Summary
- Automatically reorder task queue by category so identical tasks run together
- Track current processing category and maintain stable FIFO order
- Ensure queue resumes correctly after cancellations or completions

## Testing
- `python -m py_compile server.py sttEngine/run_workflow.py`
- `node - <<'NODE'
const categoryOrder=['stt','correct','summary'];
let currentTask=null, currentCategory=null, taskQueue=[], taskIdCounter=0;
function sortTaskQueue(){
  let startIndex=0;
  if(currentTask){startIndex=categoryOrder.indexOf(currentTask.task);} else if(currentCategory){startIndex=categoryOrder.indexOf(currentCategory);} 
  const order=categoryOrder.slice(startIndex).concat(categoryOrder.slice(0,startIndex));
  taskQueue.sort((a,b)=>{const diff=order.indexOf(a.task)-order.indexOf(b.task);return diff!==0?diff:a.id-b.id;});
}
function add(task){const t={id:++taskIdCounter,task};taskQueue.push(t);sortTaskQueue();}
function logQueue(){console.log(taskQueue.map(t=>({stt:1,correct:2,summary:3}[t.task])).join(' '));}
function startProcessing(){if(currentTask||taskQueue.length===0)return;currentTask=taskQueue[0];currentCategory=currentTask.task;}
function finishCurrent(){if(!currentTask)return;taskQueue=taskQueue.filter(t=>t.id!==currentTask.id);currentTask=null;currentCategory=taskQueue.length>0?taskQueue[0].task:null;}
[1,3,2,3,2,1,3,2,1,3,2,3].forEach(n=>add({1:'stt',2:'correct',3:'summary'}[n]));
logQueue();
startProcessing();finishCurrent();startProcessing();finishCurrent();startProcessing();finishCurrent();
startProcessing();
add('stt');add('stt');add('stt');
logQueue();
NODE`


------
https://chatgpt.com/codex/tasks/task_e_689c969cf0f0832e977d843e259979ff