### PR TITLE
Refactor workflow invocation for PyInstaller

### DIFF
--- a/sttEngine/run_workflow.py
+++ b/sttEngine/run_workflow.py
@@ -10,7 +10,7 @@ from pathlib import Path
 # 이 스크립트가 있는 디렉토리를 기준으로 경로 설정
 BASE_DIR = Path(__file__).parent.resolve()
 # Python 실행 파일 자동 감지 (Windows 호환)
-PYTHON_EXEC = sys.executable
+PYTHON_EXEC = Path(os.environ.get("PYTHON_EXEC", sys.executable))
 OUTPUT_DIR = BASE_DIR.parent / "whisper_output"
 
 # 실행할 스크립트 경로


### PR DESCRIPTION
## Summary
- Import workflow functions directly and resolve paths via `sys._MEIPASS`
- Replace subprocess workflow calls with direct Python calls
- Allow `run_workflow.py` to override interpreter via `PYTHON_EXEC` env var

## Testing
- `python -m py_compile server.py sttEngine/run_workflow.py`

------
https://chatgpt.com/codex/tasks/task_e_689da3966f2c832e8092fad36f78c0fc