### PR TITLE
feat: add overlay viewer for completed tasks

### DIFF
--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -32,6 +32,47 @@
             display: block;
             margin-bottom: 5px;
         }
+        #textOverlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.5);
+            display: none;
+            align-items: center;
+            justify-content: center;
+        }
+        #textOverlay .content {
+            background: #ffffff;
+            padding: 20px;
+            max-width: 80%;
+            max-height: 80%;
+            overflow: auto;
+            border-radius: 5px;
+            position: relative;
+        }
+        #textOverlay .buttons {
+            margin-bottom: 10px;
+        }
+        #textOverlay .buttons a,
+        #textOverlay .buttons button {
+            display: inline-block;
+            padding: 5px 10px;
+            margin-right: 5px;
+            border: none;
+            border-radius: 3px;
+            text-decoration: none;
+            cursor: pointer;
+        }
+        #overlayDownload {
+            background: #007bff;
+            color: white;
+        }
+        #overlayClose {
+            background: #6c757d;
+            color: white;
+        }
     </style>
 </head>
 <body>
@@ -59,6 +100,16 @@
         <div id="history-list"></div>
     </div>
 
+    <div id="textOverlay">
+        <div class="content">
+            <div class="buttons">
+                <a id="overlayDownload" href="#" download>다운로드</a>
+                <button id="overlayClose">닫기</button>
+            </div>
+            <pre id="overlayContent" style="white-space: pre-wrap;"></pre>
+        </div>
+    </div>
+
     <script>
         let uploadedPath = null;
         let fileType = null;
@@ -68,6 +119,27 @@
         let taskIdCounter = 0;
         const categoryOrder = ['stt', 'correct', 'summary'];
         let currentCategory = null;
+
+        function showTextOverlay(url) {
+            const overlay = document.getElementById('textOverlay');
+            const content = document.getElementById('overlayContent');
+            const download = document.getElementById('overlayDownload');
+            overlay.style.display = 'flex';
+            content.textContent = '로딩중...';
+            download.href = url;
+            fetch(url)
+                .then(resp => resp.text())
+                .then(text => {
+                    content.textContent = text;
+                })
+                .catch(() => {
+                    content.textContent = '파일을 불러오지 못했습니다.';
+                });
+        }
+
+        document.getElementById('overlayClose').addEventListener('click', () => {
+            document.getElementById('textOverlay').style.display = 'none';
+        });
 
         function sortTaskQueue() {
             let startIndex = 0;
@@ -257,14 +329,14 @@
                 span.style.color = 'white';
                 span.style.cursor = 'pointer';
                 span.style.textDecoration = 'underline';
-                span.title = '클릭하여 다운로드';
+                span.title = '클릭하여 내용 보기';
                 span.onclick = () => {
-                    window.open(downloadUrl, '_blank');
+                    showTextOverlay(downloadUrl);
                 };
             } else if (record) {
                 // Check if this task is already in queue
-                const existingTask = taskQueue.find(t => 
-                    t.recordId === record.id && 
+                const existingTask = taskQueue.find(t =>
+                    t.recordId === record.id &&
                     t.task === task
                 );
                 


### PR DESCRIPTION
## Summary
- show completed STT/Correct/Summary results in modal overlay with text
- include download and close buttons in overlay
- wire history items to open overlay instead of direct download

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689dc4730a00832e9757ab6a481f22d4