### PR TITLE
feat: prompt STT before correction or summary

### DIFF
--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -322,6 +322,11 @@
             span.style.padding = '2px 6px';
             span.style.borderRadius = '3px';
             span.style.fontSize = '12px';
+
+            if (record) {
+                span.dataset.recordId = record.id;
+                span.dataset.task = task;
+            }
             
             if (isCompleted && downloadUrl) {
                 // Completed task - green with download link
@@ -355,14 +360,40 @@
                     span.title = '클릭하여 작업 시작';
                     span.onclick = () => {
                         // Double-check if this task is already in queue (in case of race condition)
-                        const existingTaskCheck = taskQueue.find(t => 
-                            t.recordId === record.id && 
+                        const existingTaskCheck = taskQueue.find(t =>
+                            t.recordId === record.id &&
                             t.task === task
                         );
-                        
+
                         if (!existingTaskCheck) {
+                            if (record.file_type === 'audio' && (task === 'correct' || task === 'summary')) {
+                                const sttDone = record.completed_tasks.stt;
+                                const sttQueued = taskQueue.some(t =>
+                                    t.recordId === record.id &&
+                                    t.task === 'stt'
+                                );
+                                if (!sttDone && !sttQueued) {
+                                    const actionName = task === 'correct' ? '교정' : '요약';
+                                    const confirmMessage = `${actionName}을 진행하기 위해서는 먼저 STT 작업이 필요합니다. STT 이후 ${actionName} 작업을 시작하시겠습니까?`;
+                                    if (!confirm(confirmMessage)) {
+                                        return;
+                                    }
+                                    const sttElement = document.querySelector(`span[data-record-id="${record.id}"][data-task="stt"]`);
+                                    if (sttElement) {
+                                        addTaskToQueue(record.id, record.file_path, 'stt', sttElement, record.filename);
+                                        sttElement.style.backgroundColor = '#17a2b8';
+                                        sttElement.style.color = 'white';
+                                        sttElement.title = '큐에 추가됨';
+                                        sttElement.onclick = null;
+                                    } else {
+                                        const tempElement = document.createElement('span');
+                                        addTaskToQueue(record.id, record.file_path, 'stt', tempElement, record.filename);
+                                    }
+                                }
+                            }
+
                             addTaskToQueue(record.id, record.file_path, task, span, record.filename);
-                            
+
                             // Show queued state
                             span.style.backgroundColor = '#17a2b8';
                             span.style.color = 'white';


### PR DESCRIPTION
## Summary
- ask to run STT first when launching correction or summary on audio without STT
- queue STT and requested tasks when confirmed

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689de3c60cc0832e95b7f8f62c07f4d4