### PR TITLE
docs: update guides for web UI and remove diarization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md - RecordRoute 프로젝트 가이드
 
 ## 프로젝트 개요
-RecordRoute는 음성 파일을 회의록으로 변환하는 통합 워크플로우 시스템입니다. STT(Speech-to-Text), 텍스트 교정, 요약 기능을 단계적으로 제공합니다.
+RecordRoute는 음성 파일을 회의록으로 변환하는 통합 워크플로우 시스템입니다. STT(Speech-to-Text), 텍스트 교정, 요약 기능을 단계적으로 제공합니다. 최근에는 웹 기반 인터페이스가 추가되어 파일 업로드와 단계별 작업 선택, 작업 큐 및 업로드 기록(개별 초기화), 결과 오버레이 뷰어, 요약 전 확인 팝업을 지원합니다.
 
 ## 아키텍처 구조
 
@@ -13,14 +13,13 @@ RecordRoute/
 ├── LICENSE              # 라이선스 정보
 ├── CLAUDE.md             # Claude AI 전용 프로젝트 가이드
 ├── GEMINI.md             # Gemini AI 전용 프로젝트 가이드
-├── run.sh               # Unix/macOS/Linux 실행 스크립트
-├── venv/                # Python 가상환경
-├── test/                # 테스트 오디오 파일 디렉토리
-├── whisper_output/      # STT 변환 결과 저장소
+├── run.bat               # Windows 웹 서버 실행 스크립트
+├── run.command           # macOS/Linux 웹 서버 실행 스크립트
+├── server.py             # 업로드 처리 및 워크플로우 실행 서버
+├── frontend/             # 웹 인터페이스 (upload.html)
 └── sttEngine/           # STT 엔진 메인 모듈
     ├── requirements.txt    # Python 의존성
     ├── setup.bat          # Windows 설치 스크립트
-    ├── run.bat           # Windows 실행 스크립트
     ├── run_workflow.py   # 워크플로우 통합 실행기
     └── workflow/         # 핵심 처리 모듈들
         ├── transcribe.py   # 음성→텍스트 변환
@@ -98,6 +97,16 @@ python correct.py input.md --model gemma3:4b --temperature 0.0
 - 연속 처리 파이프라인
 - 실시간 진행 상황 출력
 
+### 5. server.py - 웹 업로드 및 워크플로우 서버
+**기능**: 파일 업로드와 선택된 단계(STT, 교정, 요약)의 백그라운드 실행을 처리하는 HTTP 서버.
+
+**주요 특징**:
+- 작업 큐 및 업로드 기록 관리 (개별 초기화 가능)
+- 결과 다운로드 링크와 텍스트 오버레이 뷰어 제공
+- 요약 실행 전 확인 팝업 지원
+- 작업 취소 및 진행 중인 작업 조회 API(`/cancel`, `/tasks`, `/reset`)
+- ThreadingHTTPServer 기반의 동시 요청 처리
+
 ## 의존성 및 환경 설정
 
 ### Python 패키지
@@ -115,16 +124,19 @@ ollama>=0.1.0
 **Windows:**
 ```bash
 # 1단계: 환경 설정
-setup.bat
+sttEngine\setup.bat
 
-# 2단계: 워크플로우 실행  
+# 2단계: 웹 서버 실행
 run.bat
 ```
 
 **Unix/macOS/Linux:**
 ```bash
-# 워크플로우 실행 (.env 파일에서 환경변수 자동 로드)
-./run.sh
+# 1단계: 의존성 설치
+pip install -r sttEngine/requirements.txt
+
+# 2단계: 웹 서버 실행 (.env 파일에서 환경변수 자동 로드)
+./run.command
 ```
 
 ## 플랫폼별 설정
@@ -181,7 +193,7 @@ run.bat
 
 ## 확장 계획 (TodoList.md 기준)
 - [ ] 임베딩 및 RAG 질의 시스템
-- [ ] 웹 UI 개발
+- [x] 웹 UI 개발 (완료)
 - [ ] LLM API 연동 확장
 - [ ] 다국어 지원 강화
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,9 +4,11 @@
 
 이 프로젝트는 오디오/비디오 파일로부터 텍스트를 추출하고, 이를 교정 및 요약하는 자동화된 워크플로우를 제공합니다. STT(Speech-to-Text) 엔진을 중심으로 구성되어 있으며, 다음과 같은 3단계 파이프라인을 통해 작동합니다.
 
-1.  **음성 -> 텍스트 변환 (Transcribe):** `openai-whisper`를 사용하여 미디어 파일에서 텍스트를 추출합니다.
-2.  **텍스트 교정 (Correct):** `Ollama`를 통해 추출된 텍스트의 오탈자, 문법 등을 교정합니다.
-3.  **텍스트 요약 (Summarize):** 교정된 텍스트를 `Ollama`를 사용해 구조화된 형식으로 요약합니다.
+ 1.  **음성 -> 텍스트 변환 (Transcribe):** `openai-whisper`를 사용하여 미디어 파일에서 텍스트를 추출합니다.
+ 2.  **텍스트 교정 (Correct):** `Ollama`를 통해 추출된 텍스트의 오탈자, 문법 등을 교정합니다.
+ 3.  **텍스트 요약 (Summarize):** 교정된 텍스트를 `Ollama`를 사용해 구조화된 형식으로 요약합니다.
+
+간단한 웹 업로드 페이지를 통해 이러한 작업을 선택적으로 실행할 수 있으며, 작업 큐와 업로드 기록 관리, 결과 오버레이 뷰어, 요약 전 확인 팝업, 업로드 기록 초기화 기능을 제공합니다.
 
 ## 2. 기술 스택 (Tech Stack)
 
@@ -23,21 +25,21 @@
 
 ```
 RecordRoute/
+├── run.bat                # Windows 웹 서버 실행 스크립트
+├── run.command            # macOS/Linux 웹 서버 실행 스크립트
+├── server.py              # 업로드 처리 및 워크플로우 실행 서버
+├── frontend/
+│   └── upload.html        # 웹 업로드 및 작업 관리 UI
 ├── sttEngine/
 │   ├── requirements.txt      # Python 의존성 목록
 │   ├── setup.bat             # Windows 설치 스크립트
-│   ├── run.bat               # Windows 실행 스크립트
 │   ├── run_workflow.py       # 메인 워크플로우 오케스트레이션 스크립트
 │   └── workflow/
 │       ├── transcribe.py     # 1단계: 음성 변환 로직
 │       ├── correct.py        # 2단계: 텍스트 교정 로직
 │       └── summarize.py      # 3단계: 텍스트 요약 로직
-├── run.sh                    # Unix/macOS/Linux 실행 스크립트
-├── venv/                     # Python 가상환경
-├── test/                     # 테스트 오디오 파일 디렉토리
-├── whisper_output/           # STT 변환 결과 저장소
-├── CLAUDE.md                 # Claude AI 전용 프로젝트 가이드
-└── GEMINI.md                 # Gemini AI 에이전트 및 개발자 가이드
+├── CLAUDE.md              # Claude AI 전용 프로젝트 가이드
+└── GEMINI.md              # Gemini AI 에이전트 및 개발자 가이드
 ```
 
 ## 4. 설치 및 설정 (Setup)
@@ -59,30 +61,28 @@ run_shell_command(command="cd sttEngine && setup.bat")
 
 ## 5. 실행 방법 (How to Run)
 
-`run.bat` 스크립트를 사용하여 메인 워크플로우를 시작합니다.
+루트 디렉토리에서 제공하는 실행 스크립트로 웹 서버를 시작합니다.
 
-1.  `sttEngine` 디렉토리로 이동합니다.
-2.  `run.bat`를 실행합니다.
-
-스크립트가 실행되면 가상환경을 활성화하고 `run_workflow.py`를 실행합니다. 사용자에게 어떤 단계를 실행할지(변환, 교정, 요약) 묻고, 선택에 따라 작업을 진행합니다.
+1. 의존성 설치 후 실행 스크립트를 호출합니다.
+2. 브라우저에서 `http://localhost:8080` 에 접속하여 파일 업로드, 단계 선택(STT, 교정, 요약), 작업 큐·업로드 기록 관리, 결과 오버레이 뷰어, 요약 전 확인 팝업, 업로드 기록 초기화 기능을 사용합니다.
 
 **AI 에이전트 명령어:**
 
 **Windows:**
 ```
-run_shell_command(command="sttEngine\run.bat")
+run_shell_command(command="run.bat")
 ```
 
-**Unix/macOS/Linux:**
+**macOS/Linux:**
 ```
-run_shell_command(command="./run.sh")
+run_shell_command(command="./run.command")
 ```
 
 **플랫폼별 기본 모델:**
 - Windows: `gemma3:4b`
 - macOS/Linux: 교정 `gemma3:12b-it-qat`, 요약 `gpt-oss:20b`
 
-*참고: `run_workflow.py`는 대화형 입력(실행할 단계, 파일 경로 등)을 요구하므로, AI 에이전트가 직접 실행하기보다는 사용자의 입력을 전달하는 방식으로 사용해야 합니다.*
+*참고: 기존 `sttEngine/run_workflow.py`는 CLI용으로 남아 있으며 대화형 입력을 요구합니다.*
 
 ## 6. AI 에이전트 활용 가이드 (Gemini Usage Guide)
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
  - **텍스트 교정**: Ollama LLM을 활용한 문법/어법 개선
  - **구조화된 요약**: 회의록 형태의 체계적 요약 생성
  - **통합 워크플로우**: 1단계부터 3단계까지 자동화된 처리 파이프라인
+ - **웹 기반 인터페이스**: 파일 업로드와 단계별 작업 선택, 작업 큐·업로드 기록 관리, 결과 오버레이 뷰어, 요약 전 확인 팝업, 기록 초기화 지원
 
 ## 디렉토리 구조
 
@@ -17,14 +18,13 @@ RecordRoute/
 ├── LICENSE              # 라이선스 정보
 ├── CLAUDE.md             # Claude AI 전용 프로젝트 가이드
 ├── GEMINI.md             # Gemini AI 전용 프로젝트 가이드
-├── run.sh               # Unix/macOS/Linux 실행 스크립트
-├── venv/                # Python 가상환경
-├── test/                # 테스트 오디오 파일 디렉토리
-├── whisper_output/      # STT 변환 결과 저장소
+├── run.bat               # Windows 웹 서버 실행 스크립트
+├── run.command           # macOS/Linux 웹 서버 실행 스크립트
+├── server.py             # 업로드 처리 및 워크플로우 실행 서버
+├── frontend/             # 웹 인터페이스 (upload.html)
 └── sttEngine/           # STT 엔진 메인 모듈
     ├── requirements.txt    # Python 의존성
     ├── setup.bat          # Windows 설치 스크립트
-    ├── run.bat           # Windows 실행 스크립트
     ├── run_workflow.py   # 워크플로우 통합 실행기
     └── workflow/         # 핵심 처리 모듈들
         ├── transcribe.py   # 음성→텍스트 변환
@@ -39,16 +39,19 @@ RecordRoute/
 #### Windows
 ```bash
 # 1단계: 환경 설정
-setup.bat
+sttEngine\setup.bat
 
-# 2단계: 워크플로우 실행
+# 2단계: 웹 서버 실행
 run.bat
 ```
 
-#### Unix/macOS/Linux
+#### macOS/Linux
 ```bash
-# 워크플로우 실행 (.env 파일에서 환경변수 자동 로드)
-./run.sh
+# 1단계: 의존성 설치
+pip install -r sttEngine/requirements.txt
+
+# 2단계: 웹 서버 실행 (.env 파일에서 환경변수 자동 로드)
+./run.command
 ```
 
 ### 2. 수동 설치
@@ -97,31 +100,21 @@ ollama pull gemma3:12b-it-qat
 ollama pull gpt-oss:20b
 ```
 
-### 4. 화자 구분 설정
-
-화자 구분 기능 사용을 위해:
-
-1. [Hugging Face](https://huggingface.co/)에서 토큰 발급
-2. 환경변수 설정:
-   ```bash
-   # Windows
-   set PYANNOTE_TOKEN=your_token_here
-   
-   # Unix/macOS/Linux
-   export PYANNOTE_TOKEN=your_token_here
-   ```
 
 ## 사용법
 
-### 통합 워크플로우 실행
+### 웹 인터페이스 실행
 ```bash
 # Windows
 run.bat
 
-# Unix/macOS/Linux
-./run.sh
+# macOS/Linux
+./run.command
+```
+웹 브라우저에서 <http://localhost:8080> 에 접속하여 파일을 업로드하고 STT, 교정, 요약 작업을 선택합니다. 작업 큐, 업로드 기록(개별 초기화 가능), 결과 오버레이 뷰어, 요약 전 확인 팝업을 제공합니다.
 
-# 또는 직접 실행
+### CLI 워크플로우 실행
+```bash
 python sttEngine/run_workflow.py
 ```
 
@@ -173,7 +166,6 @@ python sttEngine/workflow/summarize.py input.corrected.md --model gpt-oss:20b --
 
 ### 1단계: 음성→텍스트
 - OpenAI Whisper `large-v3-turbo` 모델 사용
-- 화자 구분 기능 (기본 활성화)
 - 세그먼트 병합 및 필러 단어 필터링
 - 결과: `.md` 파일
 
@@ -208,9 +200,6 @@ python sttEngine/workflow/summarize.py input.corrected.md --model gpt-oss:20b --
 - **Ollama 연결 오류**: Ollama 서비스 실행 상태 점검
 - **FFmpeg 오류**: 시스템 PATH 환경변수에 FFmpeg 경로 추가
 - **인코딩 문제**: UTF-8, CP949, EUC-KR 순으로 자동 시도
-
-### 화자 구분 관련
-- **PYANNOTE_TOKEN**: Hugging Face 토큰 환경변수 설정 확인
 - **MPS 오류**: Apple Silicon에서 GPU 실패 시 CPU로 자동 전환
 - **M4A 변환 오류**: FFmpeg 설치 및 PATH 설정 확인
 


### PR DESCRIPTION
## Summary
- document new browser-based upload interface with task queue, overlay viewer, confirmation popup, and per-item reset
- replace obsolete run.sh and pyannote references with run.command/run.bat and updated usage instructions
- add server.py details and mark web UI development as complete

## Testing
- `python -m py_compile server.py sttEngine/workflow/transcribe.py sttEngine/workflow/correct.py sttEngine/workflow/summarize.py`


------
https://chatgpt.com/codex/tasks/task_e_689de73e9434832e928fdcf858e42f6c