### PR TITLE
feat: add one-line summary after processing steps

### DIFF
--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -596,6 +596,12 @@
                 };
 
                 item.appendChild(header);
+                if (record.title_summary) {
+                    const summary = document.createElement('div');
+                    summary.style.cssText = 'margin:4px 0; color:#333; font-size:13px;';
+                    summary.textContent = record.title_summary;
+                    item.appendChild(summary);
+                }
                 item.appendChild(tasks);
                 historyList.appendChild(item);
             });

--- a/sttEngine/one_line_summary.py
+++ b/sttEngine/one_line_summary.py
@@ -1,0 +1,24 @@
+"""Utility for generating one-line summaries using Ollama."""
+
+from pathlib import Path
+import ollama
+from sttEngine.workflow.summarize import read_text_with_fallback, DEFAULT_MODEL
+
+
+def generate_one_line_summary(file_path: Path) -> str:
+    """Generate a single-line Korean summary for the given text file.
+
+    Args:
+        file_path: Path to the text file to summarize.
+
+    Returns:
+        A one-line summary string.
+    """
+    text = read_text_with_fallback(file_path)
+    prompt = "다음 텍스트를 한 줄로 한국어로 요약해 주세요:\n" + text[:4000]
+    response = ollama.generate(
+        model=DEFAULT_MODEL,
+        prompt=prompt,
+        options={"temperature": 0},
+    )
+    return response.get("response", "").strip().splitlines()[0]


### PR DESCRIPTION
## Summary
- generate concise title summaries via Ollama after STT, correction, or summary steps
- display generated summaries under each record's title in the web UI
- clear stored summaries when records are reset
- refactor summary generation into dedicated `sttEngine` module for reuse

## Testing
- `python -m py_compile server.py`
- `python -m py_compile sttEngine/workflow/*.py`
- `python -m py_compile sttEngine/one_line_summary.py`


------
https://chatgpt.com/codex/tasks/task_e_689dedacef68832e8436eaf4b19668be