### PR TITLE
feat: allow PDF uploads for summarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ python sttEngine/workflow/summarize.py input.corrected.md --model gpt-oss:20b --
 - `.flac`, `.m4a`, `.mp3`, `.mp4`, `.mpeg`, `.mpga`, `.oga`, `.ogg`, `.wav`, `.webm`
 - **M4A 자동 변환**: m4a 파일을 wav로 자동 변환하여 처리
 
+## 지원 문서 포맷
+
+- `.md`, `.txt`, `.text`, `.markdown`
+- `.pdf` (요약 전용)
+
 ## 플랫폼별 최적화
 
 ### Windows

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -101,7 +101,7 @@
 </head>
 <body>
     <h1>Upload File</h1>
-    <input type="file" id="fileInput" accept="audio/*,.md,.txt,.text,.markdown" multiple />
+    <input type="file" id="fileInput" accept="audio/*,.md,.txt,.text,.markdown,.pdf" multiple />
     <button id="uploadBtn">Upload</button>
     <div id="status"></div>
 
@@ -485,7 +485,7 @@
                     background-color: #f8f9fa;
                 `;
 
-                const typeLabel = record.file_type === 'audio' ? '오디오' : '텍스트';
+                const typeLabel = record.file_type === 'audio' ? '오디오' : record.file_type === 'pdf' ? 'PDF' : '텍스트';
                 const dateTime = formatDateTime(record.timestamp);
                 const duration = record.duration ? ` ${record.duration}` : '';
 
@@ -572,8 +572,10 @@
                     tasks.appendChild(taskElements.stt);
                 }
 
-                taskElements.correct = createTaskElement('correct', record.completed_tasks.correct, record.download_links.correct, record);
-                tasks.appendChild(taskElements.correct);
+                if (record.file_type !== 'pdf') {
+                    taskElements.correct = createTaskElement('correct', record.completed_tasks.correct, record.download_links.correct, record);
+                    tasks.appendChild(taskElements.correct);
+                }
                 taskElements.summary = createTaskElement('summary', record.completed_tasks.summary, record.download_links.summary, record);
                 tasks.appendChild(taskElements.summary);
 
@@ -584,8 +586,15 @@
                 } else {
                     batchBtn.onclick = () => {
                         const steps = [];
-                        if (record.file_type === 'audio') steps.push('stt');
-                        steps.push('correct', 'summary');
+                        if (record.file_type === 'audio') {
+                            steps.push('stt', 'correct', 'summary');
+                        } else if (record.file_type === 'text') {
+                            steps.push('correct', 'summary');
+                        } else if (record.file_type === 'pdf') {
+                            steps.push('summary');
+                        } else {
+                            steps.push('correct', 'summary');
+                        }
 
                         steps.forEach(step => {
                             const alreadyCompleted = record.completed_tasks[step];
@@ -743,29 +752,53 @@
         function updateWorkflowOptions(fileType) {
             const sttCheckbox = document.getElementById('stepStt');
             const sttLabel = sttCheckbox.parentElement;
-            
+            const correctCheckbox = document.getElementById('stepCorrect');
+            const correctLabel = correctCheckbox.parentElement;
+
             if (fileType === 'audio') {
                 // Show all checkboxes for audio files
                 sttLabel.style.display = 'block';
                 sttLabel.style.visibility = 'visible';
                 sttCheckbox.checked = false;
                 sttCheckbox.disabled = false;
+
+                correctLabel.style.display = 'block';
+                correctLabel.style.visibility = 'visible';
+                correctCheckbox.disabled = false;
             } else if (fileType === 'text') {
                 // Hide STT checkbox for text files
                 sttLabel.style.display = 'none';
                 sttLabel.style.visibility = 'hidden';
                 sttCheckbox.checked = false;
                 sttCheckbox.disabled = true;
+
+                correctLabel.style.display = 'block';
+                correctLabel.style.visibility = 'visible';
+                correctCheckbox.disabled = false;
+            } else if (fileType === 'pdf') {
+                // Only allow summary for PDF files
+                sttLabel.style.display = 'none';
+                sttLabel.style.visibility = 'hidden';
+                sttCheckbox.checked = false;
+                sttCheckbox.disabled = true;
+
+                correctLabel.style.display = 'none';
+                correctLabel.style.visibility = 'hidden';
+                correctCheckbox.checked = false;
+                correctCheckbox.disabled = true;
             } else {
                 // For unknown types, show all options
                 sttLabel.style.display = 'block';
                 sttLabel.style.visibility = 'visible';
                 sttCheckbox.checked = false;
                 sttCheckbox.disabled = false;
+
+                correctLabel.style.display = 'block';
+                correctLabel.style.visibility = 'visible';
+                correctCheckbox.disabled = false;
             }
-            
-            // Reset other checkboxes
-            document.getElementById('stepCorrect').checked = false;
+
+            // Reset summary checkbox
             document.getElementById('stepSummary').checked = false;
         }
 
@@ -801,6 +834,8 @@
                             status.textContent = 'Upload complete! Select workflow steps.';
                         } else if (fileType === 'text') {
                             status.textContent = 'Upload complete! Select text processing steps.';
+                        } else if (fileType === 'pdf') {
+                            status.textContent = 'Upload complete! Select summary step.';
                         } else {
                             status.textContent = 'Upload complete! File type not fully supported, but you can try processing.';
                         }

--- a/sttEngine/requirements.txt
+++ b/sttEngine/requirements.txt
@@ -2,3 +2,4 @@ openai-whisper>=20231117
 ollama>=0.1.0
 multipart
 python-dotenv
+pypdf>=3.0.0


### PR DESCRIPTION
## Summary
- enable PDF text extraction for summarization workflow
- expose PDF-only summary option in the web UI and document new support
- declare pypdf dependency

## Testing
- `python -m py_compile server.py`
- `python -c "import server"`
- `python -m pip install pypdf` *(fails: Could not find a version that satisfies the requirement pypdf)*

------
https://chatgpt.com/codex/tasks/task_e_689e5f1b0fac832e81ca66d00b6fee94