### PR TITLE
Fix run scripts to load sttEngine package

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -59,8 +59,8 @@ echo.
 echo 서버를 종료하려면 Ctrl+C를 누르세요.
 echo.
 
-REM 오류 발생 시에도 창이 닫히지 않도록 처리
-"%VENV_PYTHON%" "%WEB_SERVER%"
+cd /d "%SCRIPT_DIR%"
+"%VENV_PYTHON%" -m sttEngine.server
 set "EXIT_CODE=%ERRORLEVEL%"
 
 REM 서버 종료 후 일시 정지

--- a/run.command
+++ b/run.command
@@ -35,7 +35,8 @@ echo "서버 URL: http://localhost:8080"
 echo "(웹브라우저에서 http://localhost:8080 에 접속하세요)"
 echo
 
-"$VENV_PYTHON" "$WEB_SERVER"
+cd "$SCRIPT_DIR"
+"$VENV_PYTHON" -m sttEngine.server
 
 echo
 echo "서버가 종료되었습니다."


### PR DESCRIPTION
## Summary
- ensure run.command and run.bat execute server as a Python module
- change working directory before starting server to expose package

## Testing
- `./run.command` *(fails: ModuleNotFoundError: No module named 'whisper')*


------
https://chatgpt.com/codex/tasks/task_e_689ed996918c832eb3da00ec84cd9afe