### PR TITLE
feat: show progress in queue instead of popup

### DIFF
--- a/frontend/upload.css
+++ b/frontend/upload.css
@@ -22,50 +22,6 @@
     background: #d4edda;
     color: #155724;
 }
-.progress-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.5);
-    display: none;
-    align-items: center;
-    justify-content: center;
-    z-index: 1000;
-}
-.progress-modal {
-    background: white;
-    padding: 30px;
-    border-radius: 10px;
-    text-align: center;
-    min-width: 400px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-}
-.progress-bar {
-    width: 100%;
-    height: 20px;
-    background-color: #f0f0f0;
-    border-radius: 10px;
-    overflow: hidden;
-    margin: 20px 0;
-}
-.progress-fill {
-    height: 100%;
-    background: linear-gradient(90deg, #007bff, #0056b3);
-    width: 0%;
-    transition: width 0.3s ease;
-}
-.progress-text {
-    margin: 10px 0;
-    font-size: 14px;
-    color: #666;
-}
-.progress-filename {
-    font-weight: bold;
-    margin-bottom: 15px;
-    color: #333;
-}
 #workflow label {
     display: block;
     margin-bottom: 5px;

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -64,20 +64,6 @@
         </div>
     </div>
 
-    <!-- Progress Modal -->
-    <div id="progressOverlay" class="progress-overlay">
-        <div class="progress-modal">
-            <div class="progress-filename" id="progressFilename"></div>
-            <div class="progress-bar">
-                <div class="progress-fill" id="progressFill"></div>
-            </div>
-            <div class="progress-text" id="progressText">작업 준비 중...</div>
-            <button onclick="hideProgressModal()" style="margin-top: 20px; padding: 8px 16px; background: #6c757d; color: white; border: none; border-radius: 4px; cursor: pointer;">
-                백그라운드로 실행
-            </button>
-        </div>
-    </div>
-
     <script src="upload.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- display task progress inline within queue items
- remove progress modal and related styles

## Testing
- `python -m py_compile server.py` *(fails: No such file or directory)*
- `python -m py_compile sttEngine/workflow/transcribe.py`


------
https://chatgpt.com/codex/tasks/task_e_689efa55e868832eb2de48763259d6f4