### PR TITLE
feat: add summary popup close control

### DIFF
--- a/frontend/upload.css
+++ b/frontend/upload.css
@@ -84,6 +84,9 @@
     border-radius: 5px;
     text-align: center;
 }
+#summaryPopup .buttons {
+    margin-top: 10px;
+}
 #summaryPopup button {
     margin: 0 5px;
     padding: 5px 10px;

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -59,8 +59,11 @@
     <div id="summaryPopup">
         <div class="content">
             <p>교정 작업을 진행한 뒤에 요약 작업을 시작하시겠습니까?</p>
-            <button id="summaryOnlyBtn">요약만 진행</button>
-            <button id="correctThenSummaryBtn">교정&gt;요약 순으로 진행</button>
+            <div class="buttons">
+                <button id="summaryCancelBtn">닫기</button>
+                <button id="summaryOnlyBtn">요약만 진행</button>
+                <button id="correctThenSummaryBtn">교정&gt;요약 순으로 진행</button>
+            </div>
         </div>
     </div>
 

--- a/frontend/upload.js
+++ b/frontend/upload.js
@@ -9,6 +9,7 @@ let currentCategory = null;
 const summaryPopup = document.getElementById('summaryPopup');
 const summaryOnlyBtn = document.getElementById('summaryOnlyBtn');
 const correctThenSummaryBtn = document.getElementById('correctThenSummaryBtn');
+const summaryCancelBtn = document.getElementById('summaryCancelBtn');
 
 function showTextOverlay(url) {
     const overlay = document.getElementById('textOverlay');
@@ -63,12 +64,17 @@ document.addEventListener('keydown', (e) => {
         if (textOverlay.style.display === 'flex') {
             textOverlay.style.display = 'none';
         }
+        if (summaryPopup.style.display === 'flex') {
+            hideSummaryPopup();
+        }
     }
 });
 
 function hideSummaryPopup() {
     summaryPopup.style.display = 'none';
 }
+
+summaryCancelBtn.addEventListener('click', hideSummaryPopup);
 
 function editFilename(recordId, currentFilename) {
     const filenameElement = document.getElementById(`filename-${recordId}`);


### PR DESCRIPTION
## Summary
- add cancel option to summary popup so users can dismiss summarization step
- style popup button container and enable Esc key close behavior

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689f0a3dda2c832e9c65a2350ffaf230