### PR TITLE
Refactor frontend to externalize inline styles

### DIFF
--- a/frontend/history.js
+++ b/frontend/history.js
@@ -7,7 +7,7 @@ function editFilename(recordId, currentFilename) {
     input.value = currentFilename;
     input.className = 'filename-input';
 
-    filenameElement.style.display = 'none';
+    filenameElement.classList.add('hidden');
     filenameElement.parentNode.insertBefore(input, filenameElement.nextSibling);
 
     input.focus();
@@ -41,12 +41,12 @@ function editFilename(recordId, currentFilename) {
         }
 
         input.remove();
-        filenameElement.style.display = '';
+        filenameElement.classList.remove('hidden');
     };
 
     const cancelEdit = () => {
         input.remove();
-        filenameElement.style.display = '';
+        filenameElement.classList.remove('hidden');
     };
 
     input.addEventListener('keydown', (e) => {
@@ -81,26 +81,20 @@ function displayHistory(history) {
     historyList.innerHTML = '';
 
     if (history.length === 0) {
-        historyList.innerHTML = '<p style="color: #6c757d; font-style: italic;">업로드 기록이 없습니다.</p>';
+        historyList.innerHTML = '<p class="text-muted">업로드 기록이 없습니다.</p>';
         return;
     }
 
     history.forEach((record) => {
         const item = document.createElement('div');
-        item.style.cssText = `
-            border: 1px solid #dee2e6;
-            border-radius: 5px;
-            padding: 10px;
-            margin-bottom: 10px;
-            background-color: #f8f9fa;
-        `;
+        item.className = 'history-item';
 
         const typeLabel = record.file_type === 'audio' ? '오디오' : record.file_type === 'pdf' ? 'PDF' : '텍스트';
         const dateTime = formatDateTime(record.timestamp);
         const duration = record.duration ? ` ${record.duration}` : '';
 
         const header = document.createElement('div');
-        header.style.cssText = 'display:flex; justify-content:space-between; align-items:center; margin-bottom:5px;';
+        header.className = 'history-header';
 
         const info = document.createElement('span');
         info.innerHTML = `
@@ -119,10 +113,10 @@ function displayHistory(history) {
         header.appendChild(info);
 
         const actions = document.createElement('div');
-        actions.style.cssText = 'display:flex; gap:10px;';
+        actions.className = 'history-actions';
 
         const tasks = document.createElement('div');
-        tasks.style.cssText = 'margin-top:8px;';
+        tasks.className = 'history-tasks';
 
         const createTaskSpan = (taskName, isCompleted, downloadUrl) => {
             const span = createTaskElement(taskName, isCompleted, downloadUrl, record);

--- a/frontend/overlay.js
+++ b/frontend/overlay.js
@@ -3,7 +3,7 @@ function showTextOverlay(url) {
     const content = document.getElementById('overlayContent');
     const download = document.getElementById('overlayDownload');
     const similar = document.getElementById('similarDocs');
-    overlay.style.display = 'flex';
+    overlay.classList.add('show-flex');
     content.textContent = '로딩중...';
     download.href = url;
     if (similar) similar.innerHTML = '';
@@ -22,7 +22,7 @@ function showEmbeddingOverlay(url) {
     const content = document.getElementById('overlayContent');
     const download = document.getElementById('overlayDownload');
     const similar = document.getElementById('similarDocs');
-    overlay.style.display = 'flex';
+    overlay.classList.add('show-flex');
     content.textContent = '로딩중...';
     download.href = url;
     if (similar) similar.innerHTML = '<p>유사 문서를 불러오는 중...</p>';
@@ -65,19 +65,19 @@ function showEmbeddingOverlay(url) {
 }
 
 document.getElementById('overlayClose').addEventListener('click', () => {
-    document.getElementById('textOverlay').style.display = 'none';
+    document.getElementById('textOverlay').classList.remove('show-flex');
 });
 
 document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') {
         const textOverlay = document.getElementById('textOverlay');
-        if (textOverlay.style.display === 'flex') {
-            textOverlay.style.display = 'none';
+        if (textOverlay.classList.contains('show-flex')) {
+            textOverlay.classList.remove('show-flex');
         }
-        if (typeof summaryPopup !== 'undefined' && summaryPopup.style.display === 'flex' && typeof hideSummaryPopup === 'function') {
+        if (typeof summaryPopup !== 'undefined' && summaryPopup.classList.contains('show-flex') && typeof hideSummaryPopup === 'function') {
             hideSummaryPopup();
         }
-        if (typeof sttConfirmPopup !== 'undefined' && sttConfirmPopup.style.display === 'flex' && typeof hideSttConfirmPopup === 'function') {
+        if (typeof sttConfirmPopup !== 'undefined' && sttConfirmPopup.classList.contains('show-flex') && typeof hideSttConfirmPopup === 'function') {
             hideSttConfirmPopup();
         }
     }

--- a/frontend/queue.js
+++ b/frontend/queue.js
@@ -36,29 +36,32 @@ function stopProgressPolling() {
 }
 
 function hideSummaryPopup() {
-    summaryPopup.style.display = 'none';
+    summaryPopup.classList.remove('show-flex');
+    summaryPopup.classList.add('hidden');
 }
 
 function showSttConfirmPopup() {
-    sttConfirmPopup.style.display = 'flex';
+    sttConfirmPopup.classList.remove('hidden');
+    sttConfirmPopup.classList.add('show-flex');
 }
 
 function hideSttConfirmPopup() {
-    sttConfirmPopup.style.display = 'none';
+    sttConfirmPopup.classList.remove('show-flex');
+    sttConfirmPopup.classList.add('hidden');
 }
 
 summaryCancelBtn.addEventListener('click', hideSummaryPopup);
 sttConfirmCancelBtn.addEventListener('click', hideSttConfirmPopup);
 
 function setQueuedState(span) {
-    span.style.backgroundColor = '#17a2b8';
-    span.style.color = 'white';
+    span.classList.add('bg-info');
     span.title = '큐에 추가됨';
     span.onclick = null;
 }
 
 function showSummaryPopup(record, span) {
-    summaryPopup.style.display = 'flex';
+    summaryPopup.classList.remove('hidden');
+    summaryPopup.classList.add('show-flex');
     summaryOnlyBtn.onclick = () => {
         addTaskToQueue(record.id, record.file_path, 'summary', span, record.filename);
         setQueuedState(span);
@@ -181,9 +184,7 @@ function resetTaskElement(taskElement, task) {
     };
 
     taskElement.textContent = taskNames[task] || task;
-    taskElement.style.backgroundColor = '#6c757d';
-    taskElement.style.color = 'white';
-    taskElement.style.cursor = 'pointer';
+    taskElement.classList.add('bg-secondary', 'pointer');
     taskElement.title = '클릭하여 작업 시작';
 }
 
@@ -194,12 +195,12 @@ function updateQueueDisplay() {
     queueList.innerHTML = '';
 
     if (taskQueue.length === 0 && !currentTask) {
-        queueList.innerHTML = '<p style="color: #6c757d; font-style: italic;">진행 중인 작업이 없습니다.</p>';
-        cancelAllBtn.style.display = 'none';
+        queueList.innerHTML = '<p class="text-muted">진행 중인 작업이 없습니다.</p>';
+        cancelAllBtn.classList.add('hidden');
         return;
     }
 
-    cancelAllBtn.style.display = 'inline-block';
+    cancelAllBtn.classList.remove('hidden');
 
     const taskNames = {
         'stt': 'STT 변환',
@@ -224,34 +225,26 @@ function updateQueueDisplay() {
 
         allTasks.forEach((task, index) => {
             const item = document.createElement('div');
-            item.style.cssText = `
-                border: 1px solid #dee2e6;
-                border-radius: 5px;
-                padding: 8px 12px;
-                margin-bottom: 8px;
-                background-color: ${task.status === 'processing' ? '#fff3cd' : '#f8f9fa'};
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-            `;
+            item.className = 'queue-item mb-8';
+            if (task.status === 'processing') item.classList.add('processing');
 
             const statusText = task.status === 'processing' ? '진행중' : `대기중 (${index + 1}번째)`;
-            const statusColor = task.status === 'processing' ? '#856404' : '#6c757d';
+            const statusClass = task.status === 'processing' ? 'status-processing' : 'status-queued';
             const taskName = taskNames[task.task] || task.task;
 
             const info = document.createElement('span');
             info.innerHTML = `
                 <strong>${task.filename}</strong> - ${taskName}
-                <span style="color: ${statusColor}; font-size: 12px; margin-left: 10px;">[${statusText}]</span>
+                <span class="status-span ${statusClass}">[${statusText}]</span>
             `;
 
             const infoContainer = document.createElement('div');
-            infoContainer.style.flex = '1';
+            infoContainer.className = 'flex-1';
             infoContainer.appendChild(info);
 
             if (task.status === 'processing' && task.progress) {
                 const progressDiv = document.createElement('div');
-                progressDiv.style.cssText = 'color: #856404; font-size: 12px; margin-top: 4px;';
+                progressDiv.className = 'progress-text';
 
                 // 진행률 퍼센트 추출
                 const percentMatch = task.progress.match(/(\d+)%/);
@@ -260,22 +253,11 @@ function updateQueueDisplay() {
 
                     // 진행률 바 생성
                     const progressContainer = document.createElement('div');
-                    progressContainer.style.cssText = `
-                        width: 100%;
-                        height: 4px;
-                        background-color: #e9ecef;
-                        border-radius: 2px;
-                        margin: 2px 0;
-                        overflow: hidden;
-                    `;
+                    progressContainer.className = 'progress-container';
 
                     const progressBar = document.createElement('div');
-                    progressBar.style.cssText = `
-                        width: ${percent}%;
-                        height: 100%;
-                        background-color: #007bff;
-                        transition: width 0.3s ease;
-                    `;
+                    progressBar.className = 'progress-bar';
+                    progressBar.style.width = `${percent}%`;
 
                     progressContainer.appendChild(progressBar);
                     progressDiv.appendChild(progressContainer);
@@ -290,19 +272,7 @@ function updateQueueDisplay() {
 
             const cancelBtn = document.createElement('button');
             cancelBtn.textContent = '×';
-            cancelBtn.style.cssText = `
-                background: #dc3545;
-                color: white;
-                border: none;
-                border-radius: 3px;
-                width: 24px;
-                height: 24px;
-                cursor: pointer;
-                font-size: 16px;
-                display: flex;
-                align-items: center;
-                justify-content: center;
-            `;
+            cancelBtn.className = 'cancel-btn';
             cancelBtn.title = '작업 취소';
             cancelBtn.onclick = () => removeTaskFromQueue(task.id);
 
@@ -337,50 +307,34 @@ function updateQueueDisplay() {
 
             // Create category header
             const categoryHeader = document.createElement('div');
-            categoryHeader.style.cssText = `
-                background: #007bff;
-                color: white;
-                padding: 6px 12px;
-                margin: 10px 0 5px 0;
-                border-radius: 5px 5px 0 0;
-                font-weight: bold;
-                font-size: 14px;
-            `;
+            categoryHeader.className = 'category-header';
             categoryHeader.textContent = `${categoryNames[category]} (${categoryTasks.length}개)`;
             queueList.appendChild(categoryHeader);
 
             // Add tasks in this category
             categoryTasks.forEach((task, index) => {
                 const item = document.createElement('div');
-                item.style.cssText = `
-                    border: 1px solid #dee2e6;
-                    border-top: none;
-                    padding: 8px 12px;
-                    margin-bottom: ${index === categoryTasks.length - 1 ? '10px' : '0'};
-                    background-color: ${task.status === 'processing' ? '#fff3cd' : '#f8f9fa'};
-                    display: flex;
-                    justify-content: space-between;
-                    align-items: center;
-                    ${index === categoryTasks.length - 1 ? 'border-radius: 0 0 5px 5px;' : ''}
-                `;
+                item.className = 'queue-item';
+                if (task.status === 'processing') item.classList.add('processing');
+                if (index === categoryTasks.length - 1) item.classList.add('last');
 
                 const globalIndex = taskQueue.findIndex(t => t.id === task.id);
                 const statusText = task.status === 'processing' ? '진행중' : `대기중 (${globalIndex + 1}번째)`;
-                const statusColor = task.status === 'processing' ? '#856404' : '#6c757d';
+                const statusClass = task.status === 'processing' ? 'status-processing' : 'status-queued';
 
                 const info = document.createElement('span');
                 info.innerHTML = `
                     <strong>${task.filename}</strong>
-                    <span style="color: ${statusColor}; font-size: 12px; margin-left: 10px;">[${statusText}]</span>
+                    <span class="status-span ${statusClass}">[${statusText}]</span>
                 `;
 
                 const infoContainer = document.createElement('div');
-                infoContainer.style.flex = '1';
+                infoContainer.className = 'flex-1';
                 infoContainer.appendChild(info);
 
                 if (task.status === 'processing' && task.progress) {
                     const progressDiv = document.createElement('div');
-                    progressDiv.style.cssText = 'color: #856404; font-size: 12px; margin-top: 4px;';
+                    progressDiv.className = 'progress-text';
 
                     // 진행률 퍼센트 추출
                     const percentMatch = task.progress.match(/(\d+)%/);
@@ -389,22 +343,11 @@ function updateQueueDisplay() {
 
                         // 진행률 바 생성
                         const progressContainer = document.createElement('div');
-                        progressContainer.style.cssText = `
-                            width: 100%;
-                            height: 4px;
-                            background-color: #e9ecef;
-                            border-radius: 2px;
-                            margin: 2px 0;
-                            overflow: hidden;
-                        `;
+                        progressContainer.className = 'progress-container';
 
                         const progressBar = document.createElement('div');
-                        progressBar.style.cssText = `
-                            width: ${percent}%;
-                            height: 100%;
-                            background-color: #007bff;
-                            transition: width 0.3s ease;
-                        `;
+                        progressBar.className = 'progress-bar';
+                        progressBar.style.width = `${percent}%`;
 
                         progressContainer.appendChild(progressBar);
                         progressDiv.appendChild(progressContainer);
@@ -419,19 +362,7 @@ function updateQueueDisplay() {
 
                 const cancelBtn = document.createElement('button');
                 cancelBtn.textContent = '×';
-                cancelBtn.style.cssText = `
-                    background: #dc3545;
-                    color: white;
-                    border: none;
-                    border-radius: 3px;
-                    width: 24px;
-                    height: 24px;
-                    cursor: pointer;
-                    font-size: 16px;
-                    display: flex;
-                    align-items: center;
-                    justify-content: center;
-                `;
+                cancelBtn.className = 'cancel-btn';
                 cancelBtn.title = '작업 취소';
                 cancelBtn.onclick = () => removeTaskFromQueue(task.id);
 
@@ -452,17 +383,11 @@ function createTaskElement(task, isCompleted, downloadUrl, record = null) {
 
     const span = document.createElement('span');
     span.textContent = taskNames[task] || task;
-    span.style.margin = '0 5px';
-    span.style.padding = '2px 6px';
-    span.style.borderRadius = '3px';
-    span.style.fontSize = '12px';
+    span.className = 'task-label';
     span.dataset.task = task;
 
     if (isCompleted && downloadUrl) {
-        span.style.backgroundColor = '#28a745';
-        span.style.color = 'white';
-        span.style.cursor = 'pointer';
-        span.style.textDecoration = 'underline';
+        span.classList.add('bg-success', 'pointer', 'underline');
         if (task === 'embedding') {
             span.title = '클릭하여 내용 및 유사 문서 보기';
             span.onclick = () => {
@@ -481,19 +406,14 @@ function createTaskElement(task, isCompleted, downloadUrl, record = null) {
         );
 
         if (existingTask) {
-            span.style.backgroundColor = '#17a2b8';
-            span.style.color = 'white';
-            span.style.cursor = 'default';
+            span.classList.add('bg-info', 'cursor-default');
             span.title = '큐에 추가됨';
             span.onclick = null;
         } else {
-            span.style.backgroundColor = '#6c757d';
-            span.style.color = 'white';
-            span.style.cursor = 'pointer';
+            span.classList.add('bg-secondary', 'pointer');
             span.title = '클릭하여 작업 시작';
             span.onclick = () => {
-                span.style.pointerEvents = 'none';
-                span.style.opacity = '0.7';
+                span.classList.add('no-pointer', 'opacity-70');
 
                 const existingTaskCheck = taskQueue.find(t =>
                     t.recordId === record.id &&
@@ -501,16 +421,14 @@ function createTaskElement(task, isCompleted, downloadUrl, record = null) {
                 );
 
                 if (existingTaskCheck) {
-                    span.style.pointerEvents = 'auto';
-                    span.style.opacity = '1';
+                    span.classList.remove('no-pointer', 'opacity-70');
                     console.log(`Task ${task} for record ${record.id} already in queue, skipping`);
                     return;
                 }
 
                 if (!existingTaskCheck) {
                     if (task === 'summary' && record.file_type === 'audio' && !record.completed_tasks.stt) {
-                        span.style.pointerEvents = 'auto';
-                        span.style.opacity = '1';
+                        span.classList.remove('no-pointer', 'opacity-70');
                         showSttConfirmPopup();
                         const handleConfirm = () => {
                             hideSttConfirmPopup();
@@ -537,8 +455,7 @@ function createTaskElement(task, isCompleted, downloadUrl, record = null) {
                     }
 
                     if (task === 'embedding' && record.file_type === 'audio' && !record.completed_tasks.stt) {
-                        span.style.pointerEvents = 'auto';
-                        span.style.opacity = '1';
+                        span.classList.remove('no-pointer', 'opacity-70');
                         fetch('/check_existing_stt', {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json' },
@@ -564,14 +481,12 @@ function createTaskElement(task, isCompleted, downloadUrl, record = null) {
                     addTaskToQueue(record.id, record.file_path, task, span, record.filename);
                     setQueuedState(span);
                 } else {
-                    span.style.pointerEvents = 'auto';
-                    span.style.opacity = '1';
+                    span.classList.remove('no-pointer', 'opacity-70');
                 }
             };
         }
     } else {
-        span.style.backgroundColor = '#e9ecef';
-        span.style.color = '#6c757d';
+        span.classList.add('bg-light');
     }
 
     return span;
@@ -620,9 +535,7 @@ async function processNextTask() {
         const taskElement = currentTask.taskElement;
         const originalText = taskElement.textContent;
         taskElement.textContent = '처리중...';
-        taskElement.style.backgroundColor = '#ffc107';
-        taskElement.style.color = 'black';
-        taskElement.style.cursor = 'default';
+        taskElement.classList.add('bg-warning', 'cursor-default');
         taskElement.onclick = null;
 
         // Initialize progress message and start polling for updates
@@ -657,8 +570,7 @@ async function processNextTask() {
                     if (currentTask.retryCount < 20) {
                         taskQueue.push(currentTask);
                         taskElement.textContent = 'STT 대기';
-                        taskElement.style.backgroundColor = '#ffc107';
-                        taskElement.style.color = 'black';
+                        taskElement.classList.add('bg-warning', 'cursor-default');
                         taskElement.title = result.message || 'STT 작업 완료 대기 중';
                         currentTask = null;
                         currentCategory = taskQueue.length > 0 ? taskQueue[0].task : null;
@@ -668,22 +580,17 @@ async function processNextTask() {
                         return;
                     } else {
                         taskElement.textContent = '오류';
-                        taskElement.style.backgroundColor = '#dc3545';
-                        taskElement.style.color = 'white';
+                        taskElement.classList.add('bg-danger');
                         taskElement.title = 'STT 작업을 기다리는 중 시간 초과';
                     }
                 } else {
                     taskElement.textContent = '오류';
-                    taskElement.style.backgroundColor = '#dc3545';
-                    taskElement.style.color = 'white';
+                    taskElement.classList.add('bg-danger');
                     taskElement.title = `오류: ${result.error}`;
                 }
             } else if (result[currentTask.task]) {
                 taskElement.textContent = originalText;
-                taskElement.style.backgroundColor = '#28a745';
-                taskElement.style.color = 'white';
-                taskElement.style.cursor = 'pointer';
-                taskElement.style.textDecoration = 'underline';
+                taskElement.classList.add('bg-success', 'pointer', 'underline');
                 taskElement.title = '클릭하여 다운로드';
                 taskElement.onclick = () => {
                     window.open(result[currentTask.task], '_blank');
@@ -691,8 +598,7 @@ async function processNextTask() {
             }
         } else {
             taskElement.textContent = '오류';
-            taskElement.style.backgroundColor = '#dc3545';
-            taskElement.style.color = 'white';
+            taskElement.classList.add('bg-danger');
             taskElement.title = '처리 중 오류가 발생했습니다';
         }
     } catch (error) {
@@ -701,8 +607,7 @@ async function processNextTask() {
         } else {
             const taskElement = currentTask.taskElement;
             taskElement.textContent = '오류';
-            taskElement.style.backgroundColor = '#dc3545';
-            taskElement.style.color = 'white';
+            taskElement.classList.add('bg-danger');
             taskElement.title = `오류: ${error.message}`;
             console.error('Error processing task:', error);
         }
@@ -748,7 +653,7 @@ async function checkRunningTasks() {
                     <div class="warning-box">
                         <strong>⚠️ 백그라운드에서 실행 중인 작업이 있습니다!</strong><br>
                         페이지를 새로고침했지만 서버에서 ${taskCount}개의 작업이 계속 실행 중입니다.<br>
-                        <ul style="margin: 5px 0;">${taskDetails}</ul>
+                        <ul class="list-compact">${taskDetails}</ul>
                         작업 완료 후 히스토리를 자동으로 업데이트됩니다.
                     </div>
                 `;
@@ -782,7 +687,7 @@ function startTaskMonitoring() {
                         const status = document.getElementById('status');
                         if (status.innerHTML.includes('백그라운드에서 실행 중인')) {
                             status.innerHTML = `
-                                <div style="background: #d4edda; border: 1px solid #c3e6cb; padding: 10px; border-radius: 5px; margin: 10px 0; color: #155724;">
+                                <div class="alert-success">
                                     ✅ 모든 백그라운드 작업이 완료되었습니다!
                                 </div>
                             `;

--- a/frontend/search.js
+++ b/frontend/search.js
@@ -17,12 +17,12 @@ document.getElementById('searchBtn').addEventListener('click', async () => {
 
         if (!resp.ok) {
             const errorMsg = data.error || '검색 중 오류가 발생했습니다.';
-            list.innerHTML = `<li style="color: #dc3545; font-weight: bold;">${errorMsg}</li>`;
+            list.innerHTML = `<li class="error-text">${errorMsg}</li>`;
             if (data.details) {
                 console.error('검색 오류 상세:', data.details);
             }
         } else if (Array.isArray(data) && data.length === 0) {
-            list.innerHTML = '<li style="color: #6c757d; font-style: italic;">검색 결과가 없습니다.</li>';
+            list.innerHTML = '<li class="text-muted">검색 결과가 없습니다.</li>';
         } else if (Array.isArray(data)) {
             data.forEach(item => {
                 const li = document.createElement('li');
@@ -30,19 +30,16 @@ document.getElementById('searchBtn').addEventListener('click', async () => {
                 a.href = item.link;
                 a.textContent = `${item.file} (유사도: ${item.score.toFixed(3)})`;
                 a.target = '_blank';
-                a.style.textDecoration = 'none';
-                a.style.color = '#007bff';
-                a.onmouseover = () => a.style.textDecoration = 'underline';
-                a.onmouseout = () => a.style.textDecoration = 'none';
+                a.classList.add('link');
                 li.appendChild(a);
                 list.appendChild(li);
             });
         } else {
-            list.innerHTML = '<li style="color: #dc3545;">예상치 못한 응답 형식입니다.</li>';
+            list.innerHTML = '<li class="error-plain">예상치 못한 응답 형식입니다.</li>';
         }
     } catch (err) {
         const list = document.getElementById('searchResults');
-        list.innerHTML = `<li style="color: #dc3545; font-weight: bold;">네트워크 오류: ${err.message}</li>`;
+        list.innerHTML = `<li class="error-text">네트워크 오류: ${err.message}</li>`;
         console.error('검색 네트워크 오류:', err);
     } finally {
         searchBtn.textContent = originalText;

--- a/frontend/upload.css
+++ b/frontend/upload.css
@@ -1,3 +1,270 @@
+.hidden {
+    display: none;
+}
+
+.invisible {
+    visibility: hidden;
+}
+
+.btn {
+    border: none;
+    border-radius: 3px;
+    padding: 4px 8px;
+    cursor: pointer;
+    font-size: 14px;
+}
+
+.btn-danger {
+    background: #dc3545;
+    color: white;
+}
+
+.btn-success {
+    background: #28a745;
+    color: white;
+}
+
+.select-input {
+    padding: 4px 8px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    font-size: 14px;
+}
+
+.flex-between {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.flex-center-gap {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.text-info {
+    color: blue;
+    font-weight: bold;
+}
+
+.text-success {
+    color: green;
+}
+
+.text-muted {
+    color: #6c757d;
+    font-style: italic;
+}
+
+.error-text {
+    color: #dc3545;
+    font-weight: bold;
+}
+
+.error-plain {
+    color: #dc3545;
+}
+
+.link {
+    color: #007bff;
+    text-decoration: none;
+}
+.link:hover {
+    text-decoration: underline;
+}
+
+.pre-wrap {
+    white-space: pre-wrap;
+}
+
+.list-compact {
+    margin: 5px 0;
+}
+
+.alert-success {
+    background: #d4edda;
+    border: 1px solid #c3e6cb;
+    padding: 10px;
+    border-radius: 5px;
+    margin: 10px 0;
+    color: #155724;
+}
+
+.status-span {
+    font-size: 12px;
+    margin-left: 10px;
+}
+
+.status-processing {
+    color: #856404;
+}
+
+.status-queued {
+    color: #6c757d;
+}
+
+.history-item {
+    border: 1px solid #dee2e6;
+    border-radius: 5px;
+    padding: 10px;
+    margin-bottom: 10px;
+    background-color: #f8f9fa;
+}
+
+.history-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 5px;
+}
+
+.history-actions {
+    display: flex;
+    gap: 10px;
+}
+
+.history-tasks {
+    margin-top: 8px;
+}
+
+.flex-1 {
+    flex: 1;
+}
+
+.progress-text {
+    color: #856404;
+    font-size: 12px;
+    margin-top: 4px;
+}
+
+.progress-container {
+    width: 100%;
+    height: 4px;
+    background-color: #e9ecef;
+    border-radius: 2px;
+    margin: 2px 0;
+    overflow: hidden;
+}
+
+.progress-bar {
+    height: 100%;
+    background-color: #007bff;
+    transition: width 0.3s ease;
+}
+
+.bg-info {
+    background-color: #17a2b8;
+    color: white;
+}
+
+.bg-secondary {
+    background-color: #6c757d;
+    color: white;
+}
+
+.bg-danger {
+    background-color: #dc3545;
+    color: white;
+}
+
+.bg-success {
+    background-color: #28a745;
+    color: white;
+}
+
+.bg-warning {
+    background-color: #ffc107;
+    color: black;
+}
+
+.bg-light {
+    background-color: #e9ecef;
+    color: #6c757d;
+}
+
+.show-flex {
+    display: flex !important;
+}
+
+.pointer {
+    cursor: pointer;
+}
+
+.cursor-default {
+    cursor: default;
+}
+
+.underline {
+    text-decoration: underline;
+}
+
+.no-pointer {
+    pointer-events: none;
+}
+
+.opacity-70 {
+    opacity: 0.7;
+}
+
+.task-label {
+    margin: 0 5px;
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 12px;
+}
+
+.cancel-btn {
+    background: #dc3545;
+    color: white;
+    border: none;
+    border-radius: 3px;
+    width: 24px;
+    height: 24px;
+    cursor: pointer;
+    font-size: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.category-header {
+    background: #007bff;
+    color: white;
+    padding: 6px 12px;
+    margin: 10px 0 5px 0;
+    border-radius: 5px 5px 0 0;
+    font-weight: bold;
+    font-size: 14px;
+}
+
+.queue-item {
+    border: 1px solid #dee2e6;
+    padding: 8px 12px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background-color: #f8f9fa;
+    border-radius: 5px;
+}
+
+.queue-item.processing {
+    background-color: #fff3cd;
+}
+
+.queue-item + .queue-item {
+    border-top: none;
+}
+
+.queue-item.last {
+    margin-bottom: 10px;
+    border-radius: 0 0 5px 5px;
+}
+
+.mb-8 {
+    margin-bottom: 8px;
+}
+
 .warning-box {
     background: #fff3cd;
     border: 1px solid #ffeaa7;
@@ -21,6 +288,62 @@
 .status-completed {
     background: #d4edda;
     color: #155724;
+}
+#workflow {
+    margin-top: 1em;
+}
+
+#downloads {
+    margin-top: 1em;
+}
+
+#queue-section,
+#history-section,
+#search-section {
+    margin-top: 2em;
+}
+
+#queue-section h2,
+#history-section h2 {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+#queue-section h2 .controls {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+#queueSortSelect {
+    padding: 4px 8px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    font-size: 14px;
+}
+
+#cancelAllBtn,
+#processAllBtn {
+    border: none;
+    border-radius: 3px;
+    padding: 4px 8px;
+    cursor: pointer;
+    font-size: 14px;
+}
+
+#cancelAllBtn {
+    background: #dc3545;
+    color: white;
+}
+
+#processAllBtn {
+    background: #28a745;
+    color: white;
+}
+
+#overlayContent {
+    white-space: pre-wrap;
 }
 #workflow label {
     display: block;

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -11,38 +11,38 @@
     <button id="uploadBtn">Upload</button>
     <div id="status"></div>
 
-    <div id="workflow" style="display:none; margin-top:1em;">
+    <div id="workflow" class="hidden">
         <label><input type="checkbox" id="stepStt" /> STT 변환</label>
         <label><input type="checkbox" id="stepEmbedding" /> 색인</label>
         <label><input type="checkbox" id="stepSummary" /> 요약</label>
         <button id="processBtn">확인</button>
     </div>
 
-    <div id="downloads" style="margin-top:1em;"></div>
+    <div id="downloads"></div>
 
-    <div id="queue-section" style="margin-top:2em;">
-        <h2 style="display:flex; align-items:center; justify-content:space-between;">
+    <div id="queue-section">
+        <h2>
             작업 큐
-            <div style="display:flex; align-items:center; gap:10px;">
-                <select id="queueSortSelect" style="padding:4px 8px; border:1px solid #ccc; border-radius:3px; font-size:14px;">
+            <div class="controls">
+                <select id="queueSortSelect" class="select-input">
                     <option value="default">기본값 (카테고리별)</option>
                     <option value="oldest">추가순 (오래된 순)</option>
                 </select>
-                <button id="cancelAllBtn" style="display:none; background:#dc3545; color:white; border:none; border-radius:3px; padding:4px 8px; cursor:pointer; font-size:14px;">모두 취소</button>
+                <button id="cancelAllBtn" class="btn btn-danger hidden">모두 취소</button>
             </div>
         </h2>
         <div id="queue-list"></div>
     </div>
 
-    <div id="history-section" style="margin-top:2em;">
-        <h2 style="display:flex; align-items:center; justify-content:space-between;">
+    <div id="history-section">
+        <h2>
             업로드 기록
-            <button id="processAllBtn" style="background:#28a745; color:white; border:none; border-radius:3px; padding:4px 8px; cursor:pointer; font-size:14px;">전체 진행</button>
+            <button id="processAllBtn" class="btn btn-success">전체 진행</button>
         </h2>
         <div id="history-list"></div>
     </div>
 
-    <div id="search-section" style="margin-top:2em;">
+    <div id="search-section">
         <h2>키워드 검색</h2>
         <input type="text" id="searchInput" placeholder="검색어를 입력하세요" />
         <button id="searchBtn">검색</button>
@@ -55,7 +55,7 @@
                 <a id="overlayDownload" href="#" download>다운로드</a>
                 <button id="overlayClose">닫기</button>
             </div>
-            <pre id="overlayContent" style="white-space: pre-wrap;"></pre>
+            <pre id="overlayContent" class="pre-wrap"></pre>
             <div id="similarDocs"></div>
         </div>
     </div>

--- a/frontend/upload.js
+++ b/frontend/upload.js
@@ -6,13 +6,11 @@ function updateWorkflowOptions(fileType) {
     const sttCheckbox = document.getElementById('stepStt');
     const sttLabel = sttCheckbox.parentElement;
     if (fileType === 'audio') {
-        sttLabel.style.display = 'block';
-        sttLabel.style.visibility = 'visible';
+        sttLabel.classList.remove('hidden', 'invisible');
         sttCheckbox.checked = false;
         sttCheckbox.disabled = false;
     } else {
-        sttLabel.style.display = 'none';
-        sttLabel.style.visibility = 'hidden';
+        sttLabel.classList.add('hidden', 'invisible');
         sttCheckbox.checked = false;
         sttCheckbox.disabled = true;
     }
@@ -47,7 +45,7 @@ document.getElementById('uploadBtn').addEventListener('click', async () => {
                 recordId = fileData.record_id;
 
                 updateWorkflowOptions(fileType);
-                document.getElementById('workflow').style.display = 'block';
+                document.getElementById('workflow').classList.remove('hidden');
 
                 if (fileType === 'audio') {
                     status.textContent = 'Upload complete! Select workflow steps.';
@@ -60,7 +58,7 @@ document.getElementById('uploadBtn').addEventListener('click', async () => {
                 }
             } else {
                 status.textContent = `${data.length}개의 파일이 업로드되었습니다. 히스토리에서 작업을 선택하세요.`;
-                document.getElementById('workflow').style.display = 'none';
+                document.getElementById('workflow').classList.add('hidden');
             }
 
             loadHistory();
@@ -87,7 +85,7 @@ document.getElementById('processBtn').addEventListener('click', async () => {
     }
 
     const downloads = document.getElementById('downloads');
-    downloads.innerHTML = '<p style="color: blue; font-weight: bold;">작업을 큐에 추가합니다...</p>';
+    downloads.innerHTML = '<p class="text-info">작업을 큐에 추가합니다...</p>';
 
     const history = await loadHistorySync();
     const currentRecord = history.find(record => record.id === recordId);
@@ -103,12 +101,12 @@ document.getElementById('processBtn').addEventListener('click', async () => {
         }
     });
 
-    downloads.innerHTML = `<p style="color: green;">선택한 작업들이 큐에 추가되었습니다.</p>`;
+    downloads.innerHTML = '<p class="text-success">선택한 작업들이 큐에 추가되었습니다.</p>';
 
     uploadedPath = null;
     fileType = null;
     recordId = null;
-    document.getElementById('workflow').style.display = 'none';
+    document.getElementById('workflow').classList.add('hidden');
     document.getElementById('fileInput').value = '';
 });
 


### PR DESCRIPTION
## Summary
- Move inline styles from HTML and JS into dedicated CSS classes
- Introduce utility classes for buttons, layout, status badges and overlay toggling
- Replace direct style manipulation with class-based show/hide and state updates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a13b123048832e977ee456cec22e52