### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/frontend/upload.css
+++ b/frontend/upload.css
@@ -348,3 +348,43 @@
 #modelSettingsConfirmBtn:hover {
     background: #0056b3;
 }
+
+/* Light/Dark mode */
+body {
+    background: #ffffff;
+    color: #212529;
+}
+.theme-toggle {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    background: #6c757d;
+    color: white;
+    border: none;
+    border-radius: 3px;
+    padding: 8px;
+    cursor: pointer;
+}
+body.dark-mode {
+    background: #121212;
+    color: #e9ecef;
+}
+body.dark-mode .theme-toggle {
+    background: #adb5bd;
+    color: #000;
+}
+body.dark-mode input,
+body.dark-mode select,
+body.dark-mode button {
+    background: #333;
+    color: #e9ecef;
+    border-color: #555;
+}
+body.dark-mode #textOverlay .content,
+body.dark-mode #summaryPopup .content,
+body.dark-mode #sttConfirmPopup .content,
+body.dark-mode #modelSettingsPopup .content {
+    background: #1e1e1e;
+    color: #e9ecef;
+}
+

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="upload.css" />
 </head>
 <body>
+    <button id="themeToggle" class="theme-toggle" aria-label="Toggle dark mode">🌙</button>
     <h1>Upload File</h1>
     <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
         <div>

--- a/frontend/upload.js
+++ b/frontend/upload.js
@@ -26,6 +26,39 @@ const modelSettingsPopup = document.getElementById('modelSettingsPopup');
 const modelSettingsCloseBtn = document.getElementById('modelSettingsCloseBtn');
 const modelSettingsCancelBtn = document.getElementById('modelSettingsCancelBtn');
 const modelSettingsConfirmBtn = document.getElementById('modelSettingsConfirmBtn');
+const themeToggle = document.getElementById('themeToggle');
+
+function applyTheme(theme) {
+    if (theme === 'dark') {
+        document.body.classList.add('dark-mode');
+        themeToggle.textContent = '☀️';
+    } else {
+        document.body.classList.remove('dark-mode');
+        themeToggle.textContent = '🌙';
+    }
+    localStorage.setItem('theme', theme);
+}
+
+function initTheme() {
+    const saved = localStorage.getItem('theme');
+    if (saved) {
+        applyTheme(saved);
+    } else {
+        const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        applyTheme(prefersDark ? 'dark' : 'light');
+    }
+
+    themeToggle.addEventListener('click', () => {
+        const isDark = document.body.classList.contains('dark-mode');
+        applyTheme(isDark ? 'light' : 'dark');
+    });
+
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
+        if (!localStorage.getItem('theme')) {
+            applyTheme(e.matches ? 'dark' : 'light');
+        }
+    });
+}
 
 function showTextOverlay(url, fileType = null) {
     const overlay = document.getElementById('textOverlay');
@@ -1711,6 +1744,7 @@ document.getElementById('processAllBtn').addEventListener('click', processAllInc
 document.getElementById('settingsBtn').addEventListener('click', showModelSettingsPopup);
 
 document.addEventListener('DOMContentLoaded', function() {
+    initTheme();
     loadHistory();
     checkRunningTasks();
     startTaskMonitoring();


### PR DESCRIPTION
## Summary
- add theme toggle button and apply OS dark mode preference
- support light/dark mode styles for interface

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a4811afc80832e953e2db51d9e6c48