### PR TITLE
feat: add whisper language selection

### DIFF
--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -121,6 +121,16 @@
                     </select>
                 </div>
                 <div class="setting-group">
+                    <label for="whisperLanguage">Whisper 언어:</label>
+                    <select id="whisperLanguage">
+                        <option value="">자동 감지</option>
+                        <option value="ko" selected>한국어</option>
+                        <option value="en">English</option>
+                        <option value="ja">日本語</option>
+                        <option value="zh">中文</option>
+                    </select>
+                </div>
+                <div class="setting-group">
                     <label for="summarizeModel">요약 모델:</label>
                     <select id="summarizeModel">
                         <option value="">로딩 중...</option>

--- a/frontend/upload.js
+++ b/frontend/upload.js
@@ -326,6 +326,9 @@ async function loadAvailableModels() {
             if (savedSettings.whisper) {
                 document.getElementById('whisperModel').value = savedSettings.whisper;
             }
+            if (savedSettings.language) {
+                document.getElementById('whisperLanguage').value = savedSettings.language;
+            }
             if (savedSettings.summarize) {
                 document.getElementById('summarizeModel').value = savedSettings.summarize;
             }
@@ -352,6 +355,7 @@ async function loadAvailableModels() {
 function saveModelSettings() {
     const settings = {
         whisper: document.getElementById('whisperModel').value,
+        language: document.getElementById('whisperLanguage').value,
         summarize: document.getElementById('summarizeModel').value,
         embedding: document.getElementById('embeddingModel').value
     };

--- a/sttEngine/server.py
+++ b/sttEngine/server.py
@@ -718,13 +718,22 @@ def run_workflow(file_path: Path, steps, record_id: str = None, task_id: str = N
             whisper_model = "large-v3-turbo"
             if model_settings and model_settings.get("whisper"):
                 whisper_model = model_settings["whisper"]
-            
+
+            # Get Whisper language from settings, default to Korean
+            language = "ko"
+            if model_settings and model_settings.get("language") is not None:
+                lang = model_settings.get("language")
+                if lang in ("", "auto"):
+                    language = None
+                else:
+                    language = lang
+
             try:
                 transcribe_audio_files(
                     input_dir=str(current_file.parent),
                     output_dir=str(individual_output_dir),
                     model_identifier=whisper_model,
-                    language=None,
+                    language=language,
                     initial_prompt="",
                     workers=1,
                     recursive=False,
@@ -788,12 +797,21 @@ def run_workflow(file_path: Path, steps, record_id: str = None, task_id: str = N
                         whisper_model = "large-v3-turbo"
                         if model_settings and model_settings.get("whisper"):
                             whisper_model = model_settings["whisper"]
-                            
+
+                        # Get Whisper language from settings, default to Korean
+                        language = "ko"
+                        if model_settings and model_settings.get("language") is not None:
+                            lang = model_settings.get("language")
+                            if lang in ("", "auto"):
+                                language = None
+                            else:
+                                language = lang
+
                         transcribe_audio_files(
                             input_dir=str(current_file.parent),
                             output_dir=str(individual_output_dir),
                             model_identifier=whisper_model,
-                            language=None,
+                            language=language,
                             initial_prompt="",
                             workers=1,
                             recursive=False,
@@ -867,12 +885,21 @@ def run_workflow(file_path: Path, steps, record_id: str = None, task_id: str = N
                         whisper_model = "large-v3-turbo"
                         if model_settings and model_settings.get("whisper"):
                             whisper_model = model_settings["whisper"]
-                            
+
+                        # Get Whisper language from settings, default to Korean
+                        language = "ko"
+                        if model_settings and model_settings.get("language") is not None:
+                            lang = model_settings.get("language")
+                            if lang in ("", "auto"):
+                                language = None
+                            else:
+                                language = lang
+
                         transcribe_audio_files(
                             input_dir=str(current_file.parent),
                             output_dir=str(individual_output_dir),
                             model_identifier=whisper_model,
-                            language=None,
+                            language=language,
                             initial_prompt="",
                             workers=1,
                             recursive=False,


### PR DESCRIPTION
## Summary
- allow choosing Whisper transcription language in settings popup
- persist chosen language and pass it to server
- default STT language to Korean, with option for auto detection

## Testing
- `python -m py_compile sttEngine/server.py`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cb949224832eba93a19860c079d5