### PR TITLE
feat: add websocket progress updates

### DIFF
--- a/sttEngine/requirements.txt
+++ b/sttEngine/requirements.txt
@@ -4,3 +4,4 @@ multipart
 python-dotenv
 sentence-transformers
 pypdf>=3.0.0
+websockets>=10.0


### PR DESCRIPTION
## Summary
- broadcast task progress over WebSocket and start server alongside HTTP backend
- listen for WebSocket progress events on frontend instead of polling
- add websockets dependency

## Testing
- `python -m py_compile sttEngine/server.py`
- `node --check frontend/upload.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba818343a8832ebf71614ab5c5f0c6