### PR TITLE
Integrate Cloudflare Tunnel into RecordRoute

### DIFF
--- a/.cloudflared/config.yml
+++ b/.cloudflared/config.yml
@@ -1,0 +1,26 @@
+# Cloudflare Tunnel Configuration for RecordRoute
+# This file defines the services exposed through the Cloudflare Tunnel
+
+# Tunnel will be authenticated using the token from .env file
+# No need to specify tunnel ID or credentials path when using token authentication
+
+ingress:
+  # HTTP Web Server (Main application)
+  - service: http://localhost:8080
+    # Optional: Configure specific hostname for HTTP service
+    # hostname: recordroute-http.example.com
+
+  # WebSocket Server (Real-time communication)
+  - service: http://localhost:8765
+    # Optional: Configure specific hostname for WebSocket service
+    # hostname: recordroute-ws.example.com
+
+  # Catch-all rule (required as the last rule)
+  - service: http_status:404
+
+# Optional: Enable metrics for monitoring
+# metrics: localhost:9090
+
+# Optional: Configure logging
+# loglevel: info
+# logfile: /var/log/cloudflared.log

--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,17 @@
 # EMBEDDING_MAX_PROMPT_CHARS=7500
 # Fallback embedding model if platform specific one isn't found
 # EMBEDDING_MODEL=bge-m3:latest
+
+# --- Cloudflare Tunnel Configuration ---
+# Enable/disable Cloudflare Tunnel integration.
+# Set to 'true' to automatically start cloudflared tunnel on server startup.
+# Requires cloudflared to be installed and CLOUDFLARE_TUNNEL_TOKEN to be set.
+TUNNEL_ENABLED=false
+
+# Cloudflare Tunnel token for authentication.
+# Generate this token from your Cloudflare Zero Trust dashboard:
+# 1. Go to https://one.dash.cloudflare.com/
+# 2. Navigate to Networks > Tunnels
+# 3. Create a new tunnel or select existing one
+# 4. Copy the tunnel token from the configuration
+# CLOUDFLARE_TUNNEL_TOKEN=your_tunnel_token_here

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,3 +228,201 @@ python sttEngine/workflow/summarize.py [입력.md]
 1. `embedding_pipeline.py` 모델설정 수정
 2. `vector_search.py` 검색알고리즘 개선
 3. 메타데이터 기반 필터링 추가
+
+## Cloudflare Tunnel 통합
+
+RecordRoute는 Cloudflare Tunnel을 통해 안전하게 외부 접근이 가능합니다.
+
+### 특징
+- **보안**: 방화벽 포트 개방 없이 서비스 노출
+- **Zero Trust**: Cloudflare Access를 통한 이메일/OTP 인증
+- **자동 시작**: run.sh 실행 시 터널 자동 시작
+- **멀티 서비스**: HTTP(8080) + WebSocket(8765) 동시 노출
+
+### Cloudflared 설치
+
+#### macOS (Homebrew)
+```bash
+brew install cloudflare/cloudflare/cloudflared
+```
+
+#### Linux (Debian/Ubuntu)
+```bash
+# 패키지 다운로드 및 설치
+wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+sudo dpkg -i cloudflared-linux-amd64.deb
+```
+
+#### Linux (일반)
+```bash
+# 바이너리 직접 설치
+wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64
+sudo mv cloudflared-linux-amd64 /usr/local/bin/cloudflared
+sudo chmod +x /usr/local/bin/cloudflared
+```
+
+### 터널 생성 및 설정
+
+#### 1. Cloudflare 로그인
+```bash
+cloudflared tunnel login
+```
+- 브라우저가 열리면 Cloudflare 계정으로 로그인
+- 터널을 연결할 도메인 선택
+
+#### 2. 터널 생성
+```bash
+cloudflared tunnel create recordroute
+```
+- 터널 ID와 credentials 파일 생성됨
+- 출력된 터널 ID를 기록
+
+#### 3. 터널 토큰 생성
+```bash
+# Cloudflare Zero Trust 대시보드에서 생성
+# https://one.dash.cloudflare.com/ 접속
+# Networks > Tunnels > recordroute 선택
+# Configure > Public Hostname 설정 후 토큰 복사
+```
+
+또는 기존 터널의 토큰을 얻으려면:
+```bash
+cloudflared tunnel token recordroute
+```
+
+#### 4. 환경변수 설정
+`.env` 파일 생성 및 설정:
+```bash
+# .env.example 복사
+cp .env.example .env
+
+# 편집기로 .env 열기
+nano .env
+```
+
+다음 변수 설정:
+```bash
+# Cloudflare Tunnel 활성화
+TUNNEL_ENABLED=true
+
+# 터널 토큰 설정 (위에서 복사한 토큰)
+CLOUDFLARE_TUNNEL_TOKEN=your_actual_tunnel_token_here
+```
+
+### Zero Trust Access 정책 설정
+
+#### 1. Cloudflare Zero Trust 대시보드 접속
+https://one.dash.cloudflare.com/
+
+#### 2. Access Application 생성
+- **Access > Applications > Add an application** 선택
+- **Self-hosted** 선택
+- 애플리케이션 정보 입력:
+  - **Application name**: RecordRoute
+  - **Session Duration**: 24 hours (선택사항)
+  - **Application domain**: 터널에서 생성한 도메인 선택
+
+#### 3. 정책(Policy) 생성
+- **Add a policy** 클릭
+- 정책 이름: "Admin Access"
+- **Configure rules**:
+  - **Include**: Emails
+  - 본인 이메일 주소 입력 (예: user@example.com)
+- **Optional**: One-time PIN 추가
+  - **Include**: Emails ending in: @example.com
+  - **Require**: One-time PIN
+
+#### 4. 추가 보안 옵션 (선택사항)
+- **Bypass**: 특정 경로 예외 처리
+- **Require**: 다중 인증 조건 설정
+  - Country: 특정 국가만 허용
+  - IP ranges: 특정 IP 대역만 허용
+
+### 터널 실행
+
+#### 자동 실행 (권장)
+```bash
+# run.sh 실행 시 자동으로 터널 시작됨
+./run.sh
+```
+
+#### 수동 실행
+```bash
+# 포그라운드 실행 (디버깅용)
+cloudflared tunnel --config .cloudflared/config.yml run --token $CLOUDFLARE_TUNNEL_TOKEN
+
+# 백그라운드 실행
+nohup cloudflared tunnel --config .cloudflared/config.yml run --token $CLOUDFLARE_TUNNEL_TOKEN > .cloudflared/tunnel.log 2>&1 &
+```
+
+### 터널 상태 확인
+
+```bash
+# 실행 중인 cloudflared 프로세스 확인
+ps aux | grep cloudflared
+
+# 터널 로그 확인
+tail -f .cloudflared/tunnel.log
+
+# Cloudflare 대시보드에서 확인
+# https://one.dash.cloudflare.com/ > Networks > Tunnels
+```
+
+### 서비스 접근
+
+터널이 활성화되면:
+- **HTTP 서버**: https://your-tunnel-domain.example.com
+- **WebSocket**: wss://your-tunnel-domain.example.com (WebSocket 자동 업그레이드)
+
+Zero Trust Access가 활성화된 경우:
+1. 브라우저에서 터널 도메인 접속
+2. Cloudflare Access 로그인 화면 표시
+3. 이메일 입력 후 OTP 코드 수신
+4. OTP 입력하여 인증 완료
+
+### 트러블슈팅
+
+#### 터널이 시작되지 않음
+```bash
+# cloudflared 설치 확인
+which cloudflared
+
+# 터널 토큰 확인
+echo $CLOUDFLARE_TUNNEL_TOKEN
+
+# config.yml 문법 확인
+cloudflared tunnel ingress validate --config .cloudflared/config.yml
+```
+
+#### 연결 오류
+```bash
+# 로그 확인
+cat .cloudflared/tunnel.log
+
+# 터널 상태 확인 (Cloudflare 대시보드)
+# https://one.dash.cloudflare.com/ > Networks > Tunnels
+```
+
+#### Access 정책 오류
+- Zero Trust 대시보드에서 정책 확인
+- 이메일 주소 철자 확인
+- OTP 이메일 수신 확인 (스팸함 확인)
+
+### 보안 주의사항
+
+1. **127.0.0.1 바인딩 유지**: server.py는 localhost만 바인딩, 터널을 통해서만 외부 접근
+2. **토큰 보안**: `.env` 파일을 `.gitignore`에 추가, 토큰 노출 방지
+3. **Access 정책**: 반드시 인증된 사용자만 접근하도록 정책 설정
+4. **정기적 검토**: Access 로그 주기적 확인, 이상 접근 감지
+
+### 설정 파일 구조
+
+```
+RecordRoute/
+├── .env                          # 환경변수 (TUNNEL_ENABLED, CLOUDFLARE_TUNNEL_TOKEN)
+├── .env.example                  # 환경변수 템플릿
+├── .cloudflared/
+│   ├── config.yml                # 터널 설정 (서비스 매핑)
+│   └── tunnel.log                # 터널 실행 로그
+└── run.sh                        # 터널 자동 시작 로직 포함
+```


### PR DESCRIPTION
Add Cloudflare Tunnel support to enable secure external access to RecordRoute services without opening firewall ports. The integration includes automatic tunnel startup, configuration management, and comprehensive documentation.

Changes:
- Add TUNNEL_ENABLED and CLOUDFLARE_TUNNEL_TOKEN to .env.example
- Create .cloudflared/config.yml for HTTP (8080) and WebSocket (8765) services
- Add automatic tunnel startup logic in run.sh (after Ollama server check)
- Add comprehensive Cloudflare Tunnel setup guide to CLAUDE.md including:
  * Installation instructions for macOS and Linux
  * Tunnel creation and token generation steps
  * Zero Trust Access policy configuration with email/OTP
  * Troubleshooting guide and security best practices

Security features:
- Maintains 127.0.0.1 binding (localhost-only)
- Token-based authentication
- Optional Zero Trust Access with email/OTP
- Background execution with logging

The tunnel is disabled by default (TUNNEL_ENABLED=false) and requires explicit configuration to enable.