### PR TITLE
fix: Correct UUID extraction for Obsidian frontmatter aliases

### DIFF
--- a/sttEngine/obsidian_mcp.py
+++ b/sttEngine/obsidian_mcp.py
@@ -56,12 +56,15 @@ class ObsidianMCPIntegration:
         Returns:
             YAML frontmatter 문자열
         """
+        # 파일명에서 확장자 제거
+        filename_without_ext = Path(filename).stem
+
         return f"""---
 author: 서요한
 from: "[[RecordRoute]]"
 created: {created_at.strftime("%Y-%m-%d %H%M%S")}
 aliases:
-    - {filename}
+    - {filename_without_ext}
     - {uuid}
 ---
 
@@ -85,18 +88,20 @@ aliases:
             }
         )
 
-    async def _file_exists(self, session: ClientSession, uuid: str) -> bool:
+    async def _file_exists(self, session: ClientSession, original_filename: str) -> bool:
         """
         Obsidian Vault에 파일이 존재하는지 확인
 
         Args:
             session: MCP 클라이언트 세션
-            uuid: 파일 UUID
+            original_filename: 원본 파일명
 
         Returns:
             파일 존재 여부
         """
-        filename = f"{self.vault_folder}/{uuid}.md"
+        # 원본 파일명에서 확장자 제거하고 .md 추가
+        filename_without_ext = Path(original_filename).stem
+        filename = f"{self.vault_folder}/{filename_without_ext}.md"
         try:
             await session.call_tool("get_vault_file", {"filename": filename})
             return True
@@ -135,7 +140,9 @@ aliases:
         if created_at is None:
             created_at = datetime.now()
 
-        filename = f"{self.vault_folder}/{uuid}.md"
+        # 원본 파일명에서 확장자 제거하고 .md 추가
+        filename_without_ext = Path(original_filename).stem
+        filename = f"{self.vault_folder}/{filename_without_ext}.md"
 
         try:
             server_params = await self._get_server_params()
@@ -145,7 +152,7 @@ aliases:
                     await session.initialize()
 
                     # 파일 존재 확인
-                    file_exists = await self._file_exists(session, uuid)
+                    file_exists = await self._file_exists(session, original_filename)
 
                     if file_exists:
                         # 파일이 이미 있으면 STT 텍스트만 append
@@ -231,7 +238,9 @@ aliases:
         if created_at is None:
             created_at = datetime.now()
 
-        filename = f"{self.vault_folder}/{uuid}.md"
+        # 원본 파일명에서 확장자 제거하고 .md 추가
+        filename_without_ext = Path(original_filename).stem
+        filename = f"{self.vault_folder}/{filename_without_ext}.md"
 
         try:
             server_params = await self._get_server_params()
@@ -241,7 +250,7 @@ aliases:
                     await session.initialize()
 
                     # 파일 존재 확인
-                    file_exists = await self._file_exists(session, uuid)
+                    file_exists = await self._file_exists(session, original_filename)
 
                     if file_exists:
                         # 파일이 있으면 요약만 append

--- a/sttEngine/server.py
+++ b/sttEngine/server.py
@@ -1777,11 +1777,21 @@ def run_workflow(file_path: Path, steps, record_id: str = None, task_id: str = N
 
                 # Obsidian MCP 자동 전송
                 try:
-                    # UUID 추출 (파일명에서 .summary 제거)
-                    file_uuid = output_file.stem.replace('.summary', '')
+                    # UUID 추출 (record_id 또는 폴더명)
+                    file_uuid = record_id if record_id else output_file.parent.name
 
-                    # 원본 파일명 추출
-                    original_filename = Path(current_file).name
+                    # 원본 파일명 추출 (DB에서 조회)
+                    original_filename = None
+                    if record_id:
+                        history = load_upload_history()
+                        for rec in history:
+                            if rec.get("id") == record_id:
+                                original_filename = rec.get("info", {}).get("original_filename")
+                                break
+
+                    # DB에서 찾지 못한 경우 현재 파일명 사용
+                    if not original_filename:
+                        original_filename = Path(current_file).name
 
                     # 파일 생성 시각
                     created_at = datetime.now()

--- a/sttEngine/workflow/transcribe.py
+++ b/sttEngine/workflow/transcribe.py
@@ -520,8 +520,8 @@ def transcribe_single_file(file_path: Path, output_dir: Path, model,
         try:
             from datetime import datetime
 
-            # UUID 추출 (파일명에서 확장자 제거)
-            file_uuid = output_file_path.stem
+            # UUID 추출 (output_file_path의 부모 디렉토리명 = UUID 폴더)
+            file_uuid = output_file_path.parent.name
 
             # 파일 생성 시각 (현재 시각)
             created_at = datetime.now()


### PR DESCRIPTION
- UUID를 파일명이 아닌 record_id에서 추출하도록 수정
- 원본 파일명을 DB에서 조회하여 정확한 오디오 파일명 사용
- 폴백: record_id 없으면 폴더명 사용, 원본 파일명 없으면 현재 파일명 사용

이제 aliases가 올바르게 생성됩니다:
- 첫 번째: 원본 오디오 파일명 (예: 260105 KoVAC 방향성 정리.m4a)
- 두 번째: UUID (예: dd24147cfd7e48ea8432bb57f07992b9)