### PR TITLE
refactor(stt): package sttEngine, modularize server routes, extract shared workflow CLI utils

### DIFF
--- a/sttEngine/__init__.py
+++ b/sttEngine/__init__.py
@@ -1,0 +1,1 @@
+"""RecordRoute STT engine package."""

--- a/sttEngine/http_api/handler.py
+++ b/sttEngine/http_api/handler.py
@@ -13,6 +13,9 @@ from urllib.parse import unquote
 from ..search_cache import cleanup_expired_cache, delete_cache_record, get_cache_stats
 from ..vector_search import search as search_vectors
 from ..ollama_utils import ensure_ollama_server
+from ..server.routes import history as history_route
+from ..server.routes import process as process_route
+from ..server.routes import progress as progress_route
 
 from .embedding import run_incremental_embedding
 from .history import (
@@ -32,12 +35,11 @@ from .records import (
 )
 from .registry import get_file_by_uuid, load_file_registry, update_filename
 from .search import collect_keyword_matches, collect_searchable_documents
-from .state import cancel_task, get_running_tasks, get_task_progress
+from .state import cancel_task, get_running_tasks
 from .workflow import (
     find_existing_stt_file,
     get_audio_duration,
     get_file_type,
-    run_workflow,
 )
 
 
@@ -182,12 +184,12 @@ class UploadHandler(BaseHTTPRequestHandler):
             file_identifier = unquote(self.path[len("/download/") :])
             self._serve_download(file_identifier)
         elif self.path == "/history":
-            self._serve_history()
+            history_route.handle(self)
         elif self.path == "/tasks":
             self._serve_running_tasks()
         elif self.path.startswith("/progress/"):
             task_id = self.path[len("/progress/") :]
-            self._serve_task_progress(task_id)
+            progress_route.handle(self, task_id)
         elif self.path.startswith("/file_search"):
             from urllib.parse import parse_qs, urlparse
 
@@ -310,18 +312,6 @@ class UploadHandler(BaseHTTPRequestHandler):
             self.send_response(404)
             self.end_headers()
 
-    def _serve_history(self):
-        try:
-            history = get_active_history()
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps(history, ensure_ascii=False).encode())
-        except Exception as e:
-            self.send_response(500)
-            self.end_headers()
-            self.wfile.write(f"Error loading history: {str(e)}".encode())
-
     def _serve_running_tasks(self):
         try:
             tasks = get_running_tasks()
@@ -333,18 +323,6 @@ class UploadHandler(BaseHTTPRequestHandler):
             self.send_response(500)
             self.end_headers()
             self.wfile.write(f"Error getting running tasks: {str(e)}".encode())
-
-    def _serve_task_progress(self, task_id: str):
-        try:
-            progress = get_task_progress(task_id)
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps(progress, ensure_ascii=False).encode())
-        except Exception as e:
-            self.send_response(500)
-            self.end_headers()
-            self.wfile.write(f"Error getting task progress: {str(e)}".encode())
 
     def _resolve_text_file_for_similar(self, full_path: Path):
         TEXT_SUFFIXES = {".md", ".txt", ".text", ".markdown"}
@@ -845,38 +823,7 @@ class UploadHandler(BaseHTTPRequestHandler):
                 return
 
         if self.path == "/process":
-            length = int(self.headers.get("Content-Length", 0))
-            try:
-                payload = json.loads(self.rfile.read(length)) if length else {}
-            except json.JSONDecodeError:
-                self.send_response(400)
-                self.end_headers()
-                self.wfile.write(b"Invalid JSON payload")
-                return
-            file_path = payload.get("file_path")
-            steps = payload.get("steps", [])
-            record_id = payload.get("record_id")
-            task_id = payload.get("task_id")
-            model_settings = payload.get("model_settings", {})
-
-            if not file_path:
-                self.send_response(400)
-                self.end_headers()
-                self.wfile.write(b"Missing file_path")
-                return
-
-            if not task_id:
-                task_id = str(uuid.uuid4())
-
-            print(f"Processing task {task_id} with steps {steps} and model settings {model_settings}")
-            normalized_path = normalize_record_path(file_path)
-            absolute_path = resolve_record_path(normalized_path)
-
-            results = run_workflow(absolute_path, steps, record_id, task_id, model_settings)
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps(results).encode())
+            process_route.handle(self)
             return
 
         if self.path == "/cancel":

--- a/sttEngine/server.py
+++ b/sttEngine/server.py
@@ -9,18 +9,13 @@ The server exposes:
 Only selected workflow steps return download links.
 """
 
-try:
-    from .logger import setup_logging
-except ImportError:  # pragma: no cover - fallback for script execution
-    from logger import setup_logging
-
+from sttEngine.logger import setup_logging
+from sttEngine.http_api.app import main as run_app
 
 setup_logging()
 
 
 def main() -> None:
-    from .http_api.app import main as run_app
-
     run_app()
 
 

--- a/sttEngine/server/__init__.py
+++ b/sttEngine/server/__init__.py
@@ -1,0 +1,1 @@
+"""Server routing/task/service package."""

--- a/sttEngine/server/routes/__init__.py
+++ b/sttEngine/server/routes/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP route handlers for core APIs."""

--- a/sttEngine/server/routes/history.py
+++ b/sttEngine/server/routes/history.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from ...http_api.history import get_active_history
+from ..services.errors import send_error, send_json
+
+
+def handle(handler) -> None:
+    try:
+        history = get_active_history()
+        send_json(handler, 200, history)
+    except Exception as exc:
+        send_error(handler, exc)

--- a/sttEngine/server/routes/process.py
+++ b/sttEngine/server/routes/process.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from ..services.errors import send_error, send_json
+from ..services.file_service import parse_process_payload
+from ..tasks.queue import run_process_task
+
+
+def handle(handler) -> None:
+    try:
+        task_request = parse_process_payload(handler)
+        results = run_process_task(task_request)
+        send_json(handler, 200, results)
+    except Exception as exc:
+        send_error(handler, exc)

--- a/sttEngine/server/routes/progress.py
+++ b/sttEngine/server/routes/progress.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from ...http_api.state import get_task_progress
+from ..services.errors import send_error, send_json
+
+
+def handle(handler, task_id: str) -> None:
+    try:
+        progress = get_task_progress(task_id)
+        send_json(handler, 200, progress)
+    except Exception as exc:
+        send_error(handler, exc)

--- a/sttEngine/server/services/__init__.py
+++ b/sttEngine/server/services/__init__.py
@@ -1,0 +1,1 @@
+"""Server services for payload/error/file management."""

--- a/sttEngine/server/services/errors.py
+++ b/sttEngine/server/services/errors.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+
+@dataclass
+class ApiError(Exception):
+    message: str
+    status_code: int = 400
+    code: str = "bad_request"
+
+
+def send_json(handler, status_code: int, payload: dict) -> None:
+    handler.send_response(status_code)
+    handler.send_header("Content-Type", "application/json")
+    handler.end_headers()
+    handler.wfile.write(json.dumps(payload, ensure_ascii=False).encode())
+
+
+def send_error(handler, error: Exception) -> None:
+    if isinstance(error, ApiError):
+        send_json(
+            handler,
+            error.status_code,
+            {"success": False, "error": {"code": error.code, "message": error.message}},
+        )
+        return
+
+    send_json(
+        handler,
+        500,
+        {
+            "success": False,
+            "error": {"code": "internal_error", "message": "Internal server error"},
+        },
+    )

--- a/sttEngine/server/services/file_service.py
+++ b/sttEngine/server/services/file_service.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+import uuid
+
+from ...http_api.paths import normalize_record_path, resolve_record_path
+from .errors import ApiError
+
+
+def parse_process_payload(handler) -> dict:
+    length = int(handler.headers.get("Content-Length", 0))
+    try:
+        payload = json.loads(handler.rfile.read(length)) if length else {}
+    except json.JSONDecodeError as exc:
+        raise ApiError("Invalid JSON payload", 400, "invalid_json") from exc
+
+    file_path = payload.get("file_path")
+    if not file_path:
+        raise ApiError("Missing file_path", 400, "missing_file_path")
+
+    normalized_path = normalize_record_path(file_path)
+    absolute_path = resolve_record_path(normalized_path)
+
+    return {
+        "absolute_path": absolute_path,
+        "steps": payload.get("steps", []),
+        "record_id": payload.get("record_id"),
+        "task_id": payload.get("task_id") or str(uuid.uuid4()),
+        "model_settings": payload.get("model_settings", {}),
+    }

--- a/sttEngine/server/tasks/__init__.py
+++ b/sttEngine/server/tasks/__init__.py
@@ -1,0 +1,1 @@
+"""Task execution components."""

--- a/sttEngine/server/tasks/queue.py
+++ b/sttEngine/server/tasks/queue.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from ...http_api.workflow import run_workflow
+
+
+def run_process_task(task_request: dict) -> dict:
+    return run_workflow(
+        task_request["absolute_path"],
+        task_request["steps"],
+        task_request["record_id"],
+        task_request["task_id"],
+        task_request["model_settings"],
+    )

--- a/sttEngine/workflow/__init__.py
+++ b/sttEngine/workflow/__init__.py
@@ -1,0 +1,1 @@
+"""Workflow modules for transcribe, correct, summarize."""

--- a/sttEngine/workflow/cli_utils.py
+++ b/sttEngine/workflow/cli_utils.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+
+def add_verbose_argument(parser) -> None:
+    parser.add_argument("-v", "--verbose", action="store_true", help="상세 로그 출력")
+
+
+def add_encoding_argument(parser, default: str = "utf-8") -> None:
+    parser.add_argument("--encoding", default=default, help=f"입력 파일 인코딩 (기본: {default})")
+
+
+def read_text_with_fallback(path: Path, encoding: str = "utf-8", extra_encodings: list[str] | None = None) -> str:
+    encodings = [encoding]
+    if extra_encodings:
+        encodings.extend(extra_encodings)
+
+    if encoding == "utf-8":
+        encodings.extend(["utf-8-sig", "cp949", "euc-kr", "latin-1"])
+
+    deduped: list[str] = []
+    for enc in encodings:
+        if enc not in deduped:
+            deduped.append(enc)
+
+    last_error: Exception | None = None
+    for enc in deduped:
+        try:
+            content = path.read_text(encoding=enc)
+            if enc != encoding:
+                logging.info("인코딩 %s로 파일을 성공적으로 읽었습니다.", enc)
+            return content
+        except UnicodeDecodeError as exc:
+            last_error = exc
+            logging.debug("인코딩 %s 실패: %s", enc, exc)
+        except Exception as exc:  # pragma: no cover
+            last_error = exc
+            logging.debug("파일 읽기 실패 (%s): %s", enc, exc)
+
+    raise RuntimeError(f"모든 인코딩 시도 실패: {path} ({last_error})")
+
+
+def configure_cli_logging(verbose: bool, fmt: str = "%(levelname)s: %(message)s", datefmt: str | None = None) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format=fmt, datefmt=datefmt)
+

--- a/sttEngine/workflow/correct.py
+++ b/sttEngine/workflow/correct.py
@@ -9,14 +9,16 @@ import platform
 import ollama
 from typing import List, Optional
 
-# 설정 모듈 임포트
-sys.path.append(str(Path(__file__).parent.parent))
-from config import get_model_for_task, get_default_model, get_config_value, get_db_base_path
-from ollama_utils import safe_ollama_call
-from logger import setup_logging
-from vocabulary_manager import VocabularyManager
+from sttEngine.config import get_model_for_task, get_default_model, get_config_value, get_db_base_path
+from sttEngine.ollama_utils import safe_ollama_call
+from sttEngine.vocabulary_manager import VocabularyManager
+from sttEngine.workflow.cli_utils import (
+    add_encoding_argument,
+    add_verbose_argument,
+    configure_cli_logging,
+    read_text_with_fallback,
+)
 
-setup_logging()
 
 # 플랫폼별 기본 모델 설정 (.env 파일에서 로드)
 try:
@@ -48,32 +50,6 @@ CORRECTION_INSTRUCTIONS = (
     "주의: 설명, 사과, 인사, 메타 코멘트, 요약을 출력하지 마세요. "
     "오직 교정 결과 텍스트만 반환하세요."
 )
-
-def setup_logging(verbose: bool = False):
-    """로깅 설정"""
-    level = logging.DEBUG if verbose else logging.INFO
-    format_str = "%(levelname)s: %(message)s"
-    logging.basicConfig(level=level, format=format_str)
-
-def read_text(path: Path, encoding: str = "utf-8") -> str:
-    """안전한 텍스트 파일 읽기 (인코딩 후퇴 전략 포함)"""
-    encodings_to_try = [encoding]
-    if encoding == "utf-8":
-        encodings_to_try.extend(["utf-8-sig", "cp949", "euc-kr"])
-    
-    last_error = None
-    for enc in encodings_to_try:
-        try:
-            content = path.read_text(encoding=enc)
-            if enc != encoding:
-                logging.info("인코딩 %s로 파일을 성공적으로 읽었습니다.", enc)
-            return content
-        except UnicodeDecodeError as e:
-            last_error = e
-            logging.debug("인코딩 %s 실패: %s", enc, e)
-            continue
-    
-    raise UnicodeDecodeError(f"모든 인코딩 시도 실패. 마지막 오류: {last_error}")
 
 def maybe_strip_heading(text: str, strip_heading: bool) -> str:
     """옵션에 따라 첫 번째 H1 헤더만 제거"""
@@ -244,7 +220,7 @@ def correct_text_file(input_file: Path, output_file: Optional[Path] = None,
             return False
 
         # 텍스트 읽기
-        original_text = read_text(input_file, encoding=encoding)
+        original_text = read_text_with_fallback(input_file, encoding=encoding)
         
         if not original_text.strip():
             logging.warning("입력 파일이 비어있거나 공백만 포함되어 있습니다.")
@@ -377,21 +353,19 @@ def main():
                        help="컨텍스트 길이 (기본: 8192)")
     
     # 텍스트 처리 옵션
-    parser.add_argument("--encoding", default="utf-8", 
-                       help="입력 파일 인코딩 (기본: utf-8, 자동 후퇴 지원)")
+    add_encoding_argument(parser)
     parser.add_argument("--strip-heading", action="store_true", 
                        help="맨 앞 H1 헤더(# )만 제거")
     parser.add_argument("--max-chars", type=int, default=8000, 
                        help="청크 최대 문자수 (기본: 8000)")
     
     # 로깅 옵션
-    parser.add_argument("-v", "--verbose", action="store_true", 
-                       help="상세 로그 출력")
+    add_verbose_argument(parser)
     
     args = parser.parse_args()
     
     # 로깅 설정
-    setup_logging(args.verbose)
+    configure_cli_logging(args.verbose)
     
     # 입력 검증
     input_files = []

--- a/sttEngine/workflow/summarize.py
+++ b/sttEngine/workflow/summarize.py
@@ -16,14 +16,15 @@ except ImportError:
     print("오류: ollama 패키지가 설치되지 않았습니다. 'pip install ollama'로 설치하세요.")
     sys.exit(1)
 
-# 설정 모듈 임포트
-sys.path.append(str(Path(__file__).parent.parent))
-from config import get_model_for_task, get_default_model, get_config_value
-from logger import setup_logging
-from obsidian_mcp import send_summary_to_obsidian_sync
-
-setup_logging()
-from ollama_utils import ensure_ollama_server, check_ollama_model_available, safe_ollama_call
+from sttEngine.config import get_model_for_task, get_default_model, get_config_value
+from sttEngine.obsidian_mcp import send_summary_to_obsidian_sync
+from sttEngine.ollama_utils import ensure_ollama_server, check_ollama_model_available, safe_ollama_call
+from sttEngine.workflow.cli_utils import (
+    add_encoding_argument,
+    add_verbose_argument,
+    configure_cli_logging,
+    read_text_with_fallback,
+)
 
 # 설정 상수 - .env 파일에서 로드
 try:
@@ -75,12 +76,6 @@ REDUCE_PROMPT = BASE_PROMPT + """
 class SummarizationError(Exception):
     """요약 처리 중 발생하는 예외"""
     pass
-
-def setup_logging(verbose: bool) -> None:
-    """로깅 설정"""
-    level = logging.DEBUG if verbose else logging.INFO
-    format_str = "%(asctime)s - %(levelname)s: %(message)s"
-    logging.basicConfig(level=level, format=format_str, datefmt="%H:%M:%S")
 
 def validate_model(model: str) -> bool:
     """모델 존재 여부 확인"""
@@ -220,24 +215,6 @@ def strip_prefix_before_bracket(text: str) -> str:
         else:
             processed_lines.append(line)
     return "\n".join(processed_lines)
-
-def read_text_with_fallback(path: Path, encoding: str = "utf-8") -> str:
-    """인코딩 fallback을 지원하는 텍스트 읽기"""
-    encodings = [encoding, "utf-8", "cp949", "euc-kr", "latin-1"]
-    
-    for enc in encodings:
-        try:
-            content = path.read_text(encoding=enc)
-            if enc != encoding:
-                logging.info(f"인코딩 변경: {encoding} → {enc}")
-            return content
-        except UnicodeDecodeError:
-            continue
-        except Exception as e:
-            logging.error(f"파일 읽기 실패 ({enc}): {e}")
-            continue
-    
-    raise SummarizationError(f"모든 인코딩으로 파일 읽기 실패: {path}")
 
 def chunk_text(text: str, max_bytes: int, target_chunks: Optional[int] = None) -> List[str]:
     """텍스트를 바이트 단위로 청크 분할 (안전한 방식)"""
@@ -605,21 +582,13 @@ def main() -> None:
         action="store_true",
         help="JSON 형식으로 섹션별 구조화된 출력"
     )
-    parser.add_argument(
-        "--verbose", "-v",
-        action="store_true",
-        help="상세한 진행 로그 출력"
-    )
+    add_verbose_argument(parser)
     parser.add_argument(
         "--stdin",
         action="store_true",
         help="표준 입력에서 텍스트 읽기"
     )
-    parser.add_argument(
-        "--encoding",
-        default="utf-8",
-        help="입력 파일 인코딩 (기본값: utf-8)"
-    )
+    add_encoding_argument(parser)
     parser.add_argument(
         "--target-chunks",
         type=int,
@@ -629,7 +598,7 @@ def main() -> None:
     args = parser.parse_args()
     
     # 로깅 설정
-    setup_logging(args.verbose)
+    configure_cli_logging(args.verbose, fmt="%(asctime)s - %(levelname)s: %(message)s", datefmt="%H:%M:%S")
     
     try:
         # 입력 검증

--- a/sttEngine/workflow/transcribe.py
+++ b/sttEngine/workflow/transcribe.py
@@ -22,14 +22,11 @@ except ImportError:
     pass
 
 # 설정 모듈 임포트
-import sys
-sys.path.append(str(Path(__file__).parent.parent))
-from config import get_db_base_path, get_default_model, get_model_for_task
-from logger import setup_logging
-from vocabulary_manager import VocabularyManager
-from obsidian_mcp import send_stt_to_obsidian_sync
-
-setup_logging()
+from sttEngine.config import get_db_base_path, get_default_model, get_model_for_task
+from sttEngine.logger import setup_logging
+from sttEngine.vocabulary_manager import VocabularyManager
+from sttEngine.obsidian_mcp import send_stt_to_obsidian_sync
+from sttEngine.workflow.cli_utils import add_verbose_argument, configure_cli_logging
 
 DB_BASE_PATH = get_db_base_path()
 DEFAULT_OUTPUT_DIR = DB_BASE_PATH / "whisper_output"
@@ -820,7 +817,11 @@ def main():
         help="과도한 연속 마침표를 '...'로 정규화"
     )
 
+    add_verbose_argument(parser)
+
     args = parser.parse_args()
+
+    configure_cli_logging(args.verbose)
 
     # 모델 경로 결정 (플랫폼별 캐시 경로 지원)
     model_to_use = args.model_size


### PR DESCRIPTION
### Motivation
- Make `sttEngine` an importable Python package and remove fragile `sys.path` workarounds. 
- Separate HTTP routing, task queue and file/payload handling to simplify server responsibilities and make handlers testable. 
- Eliminate duplicated CLI/IO handling across workflow scripts and unify error/response formatting for consistent API behavior.

### Description
- Converted `sttEngine` into a proper package by adding `__init__.py` files and changing local imports to package-qualified imports (e.g. `from sttEngine.*`), removing `sys.path` hacks in workflow modules.
- Split server logic into route/service/task layers under `sttEngine/server/` with new modules: `server/routes/{process,progress,history}.py`, `server/services/{errors,file_service}.py`, and `server/tasks/queue.py`.
- Delegated existing `http_api/handler.py` endpoints to the new route handlers to preserve compatibility for `/process`, `/progress/<task_id>`, and `/history` while centralizing JSON/error responses.
- Introduced a common error and response helper (`ApiError`, `send_json`, `send_error`) in `server/services/errors.py` to standardize failure payloads.
- Extracted shared CLI and text I/O utilities into `sttEngine/workflow/cli_utils.py` (functions: `add_verbose_argument`, `add_encoding_argument`, `read_text_with_fallback`, `configure_cli_logging`) and updated `transcribe.py`, `correct.py`, and `summarize.py` to use them for unified argument parsing, logging setup, and robust file reading.
- Kept API entry points and behavior intact by having `http_api/handler.py` call the new route handlers so existing clients for `/process`, `/progress/<task_id>`, and `/history` continue to work.

### Testing
- Compiled key modules with `python -m py_compile ...` (including `sttEngine/server.py`, `sttEngine/http_api/handler.py`, new route/service/task modules, and updated workflow scripts`), and compilation succeeded.
- Performed an import sanity check with `python -c "import sttEngine; import sttEngine.server; from sttEngine.server.routes import process, progress, history; from sttEngine.workflow import transcribe, correct, summarize, cli_utils"` and it returned successfully (`imports_ok`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eb2b85a5c832eb8f285ef15803dbf)