### PR TITLE
Enhance search cache keying and expose richer search metadata

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -131,11 +131,23 @@ export async function resetSummaryEmbedding(recordId: string): Promise<any> {
 export async function search(
   query: string,
   startDate?: string,
-  endDate?: string
+  endDate?: string,
+  options?: {
+    sortBy?: string;
+    sortOrder?: "asc" | "desc";
+    minScore?: number;
+    page?: number;
+    pageSize?: number;
+  }
 ): Promise<SearchResponse> {
   const params = new URLSearchParams({ q: query });
   if (startDate) params.set('start', startDate);
   if (endDate) params.set('end', endDate);
+  if (options?.sortBy) params.set('sort_by', options.sortBy);
+  if (options?.sortOrder) params.set('sort_order', options.sortOrder);
+  if (options?.minScore !== undefined) params.set('min_score', String(options.minScore));
+  if (options?.page !== undefined) params.set('page', String(options.page));
+  if (options?.pageSize !== undefined) params.set('page_size', String(options.pageSize));
   const res = await fetch(`/search?${params}`);
   if (!res.ok) throw new Error('Search failed');
   return res.json();

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -34,6 +34,12 @@ export interface ProcessResult {
 export interface SearchResponse {
   keywordMatches: KeywordMatch[];
   similarDocuments: SimilarDocument[];
+  sort?: { by: string; order: string };
+  scoreBreakdown?: { keywordWeight: number; vectorWeight: number };
+  pagination?: { page: number; pageSize: number; returned: number; hasNext: boolean };
+  timing?: Record<string, number>;
+  performanceTargetMs?: Record<string, number>;
+  cache?: { hit: boolean };
 }
 
 export interface KeywordMatch {
@@ -54,6 +60,11 @@ export interface SimilarDocument {
   source_filename?: string;
   link: string;
   record_id?: string;
+  score_breakdown?: {
+    vector_similarity: number;
+    keyword_overlap: number;
+    composite: number;
+  };
 }
 
 // Models from GET /models

--- a/frontend/src/components/SearchPanel.tsx
+++ b/frontend/src/components/SearchPanel.tsx
@@ -7,7 +7,7 @@ import { Badge } from './ui/badge';
 import { ScrollArea } from './ui/scroll-area';
 import { useTheme } from '../contexts/ThemeContext';
 import * as api from '../api/client';
-import type { KeywordMatch, SimilarDocument } from '../api/types';
+import type { KeywordMatch, SimilarDocument, SearchResponse } from '../api/types';
 import { TextOverlay } from './TextOverlay';
 
 export function SearchPanel() {
@@ -17,6 +17,7 @@ export function SearchPanel() {
   const [keywordResults, setKeywordResults] = useState<KeywordMatch[]>([]);
   const [similarResults, setSimilarResults] = useState<SimilarDocument[]>([]);
   const [hasSearched, setHasSearched] = useState(false);
+  const [searchMeta, setSearchMeta] = useState<SearchResponse | null>(null);
 
   const [detailOpen, setDetailOpen] = useState(false);
   const [detailFileIdentifier, setDetailFileIdentifier] = useState<string | null>(null);
@@ -31,6 +32,7 @@ export function SearchPanel() {
       setKeywordResults(data.keywordMatches || []);
       setSimilarResults(data.similarDocuments || []);
       setHasSearched(true);
+      setSearchMeta(data);
     } catch (e) {
       console.error('Search failed:', e);
     } finally {
@@ -108,6 +110,15 @@ export function SearchPanel() {
             </div>
           ) : (
             <div className="space-y-6">
+
+              {searchMeta?.pagination && (
+                <div className={`text-xs ${theme === 'dark' ? 'text-slate-400' : 'text-slate-600'}`}>
+                  정렬: {(searchMeta.sort?.by || 'similarity')} / {(searchMeta.sort?.order || 'desc')} ·
+                  페이지: {searchMeta.pagination.page} ·
+                  반환: {searchMeta.pagination.returned}
+                  {searchMeta.cache?.hit ? ' · 캐시 히트' : ''}
+                </div>
+              )}
               {keywordResults.length > 0 && (
                 <div className="space-y-3">
                   <h3 className={`text-sm font-semibold ${theme === 'dark' ? 'text-slate-300' : 'text-slate-700'}`}>키워드 일치 문서</h3>

--- a/search_api_contract.md
+++ b/search_api_contract.md
@@ -1,0 +1,82 @@
+# Search API Contract (Frontend 연동용)
+
+## 엔드포인트
+- `GET /search?q=<query>&start=<iso>&end=<iso>&sort_by=<similarity|date>&sort_order=<asc|desc>&min_score=<float>&page=<int>&page_size=<int>`
+
+## 응답 스키마
+기존 하위호환 필드(`keywordMatches`, `similarDocuments`)는 유지합니다.
+
+```ts
+interface SearchResponse {
+  keywordMatches: KeywordMatch[];            // 기존 필드 (호환)
+  similarDocuments: SimilarDocument[];       // 기존 필드 (호환)
+
+  sort?: {
+    by: string;      // similarity | date
+    order: string;   // asc | desc
+  };
+
+  scoreBreakdown?: {
+    keywordWeight: number; // 현재 0.0
+    vectorWeight: number;  // 현재 1.0
+  };
+
+  pagination?: {
+    page: number;
+    pageSize: number;
+    returned: number;
+    hasNext: boolean;
+  };
+
+  timing?: Record<string, number>; // ms 단위
+  performanceTargetMs?: {
+    keyword_only_p95: number;
+    vector_only_p95: number;
+    hybrid_with_date_filter_p95: number;
+  };
+
+  cache?: {
+    hit: boolean;
+  };
+}
+
+interface SimilarDocument {
+  file_uuid?: string;
+  file: string;
+  display_name?: string;
+  score: number;
+  uploaded_at?: string;
+  source_filename?: string;
+  link: string;
+  record_id?: string;
+  score_breakdown?: {
+    vector_similarity: number;
+    keyword_overlap: number;
+    composite: number;
+  };
+}
+```
+
+## 호출 경로 및 병목 포인트
+`/search` 요청은 다음 순서로 처리됩니다.
+1. `sttEngine/http_api/handler.py`에서 쿼리 파라미터 파싱.
+2. 키워드 검색: `collect_searchable_documents` + `collect_keyword_matches`.
+3. 벡터 검색: `sttEngine/vector_search.py::search`.
+4. 캐시 확인/저장: `sttEngine/search_cache.py`.
+
+관측된 핵심 병목:
+- 키워드 검색의 파일 본문 반복 읽기(I/O)
+- 벡터 검색의 임베딩 생성(`embed_text_ollama`)과 벡터 파일 스캔(`np.load` 반복)
+
+## 성능 목표 (P95)
+- 키워드만 사용: `<= 120ms`
+- 유사도 검색만 사용: `<= 450ms`
+- 날짜 필터 + 유사도 조합: `<= 650ms`
+
+## 캐시 키 정책
+다음 요소를 모두 포함해 캐시 오염을 방지합니다.
+- query, top_k
+- date filter(start/end)
+- min_score
+- sort(by/order)
+- pagination(page/page_size)

--- a/sttEngine/http_api/handler.py
+++ b/sttEngine/http_api/handler.py
@@ -218,9 +218,38 @@ class UploadHandler(BaseHTTPRequestHandler):
             query = params.get("q", [""])[0].strip()
             start_date = params.get("start", [None])[0]
             end_date = params.get("end", [None])[0]
+            sort_by = params.get("sort_by", ["similarity"])[0]
+            sort_order = params.get("sort_order", ["desc"])[0]
+            min_score_raw = params.get("min_score", [None])[0]
+            page_raw = params.get("page", ["1"])[0]
+            page_size_raw = params.get("page_size", ["5"])[0]
+
+            min_score = None
+            if min_score_raw not in (None, ""):
+                try:
+                    min_score = float(min_score_raw)
+                except ValueError:
+                    min_score = None
 
             try:
-                response_data = {"keywordMatches": [], "similarDocuments": []}
+                page = max(1, int(page_raw))
+            except (TypeError, ValueError):
+                page = 1
+
+            try:
+                page_size = max(1, int(page_size_raw))
+            except (TypeError, ValueError):
+                page_size = 5
+
+            try:
+                response_data = {
+                    "keywordMatches": [],
+                    "similarDocuments": [],
+                    "sort": {"by": sort_by, "order": sort_order},
+                    "pagination": {"page": page, "pageSize": page_size, "returned": 0, "hasNext": False},
+                    "scoreBreakdown": {"keywordWeight": 0.0, "vectorWeight": 1.0},
+                    "timing": {},
+                }
 
                 if query:
                     documents, path_index = collect_searchable_documents()
@@ -233,14 +262,22 @@ class UploadHandler(BaseHTTPRequestHandler):
                     keyword_paths = {item["file"] for item in keyword_matches}
                     keyword_uuids = {item["file_uuid"] for item in keyword_matches}
 
-                    hits = search_vectors(
+                    search_payload = search_vectors(
                         query,
                         BASE_DIR,
-                        top_k=10,
+                        top_k=max(10, page * page_size),
                         start_date=start_date,
                         end_date=end_date,
+                        sort_by=sort_by,
+                        sort_order=sort_order,
+                        min_score=min_score,
+                        page=page,
+                        page_size=page_size,
+                        include_timing=True,
                     )
 
+                    hits = search_payload.get("results", [])
+                    response_data["timing"] = search_payload.get("timing", {})
                     similar_documents = []
                     for hit in hits:
                         rel_path = hit.get("file")
@@ -273,16 +310,29 @@ class UploadHandler(BaseHTTPRequestHandler):
                                 "file": rel_path,
                                 "display_name": display_name,
                                 "score": hit.get("score"),
+                                "score_breakdown": {
+                                    "vector_similarity": hit.get("score"),
+                                    "keyword_overlap": 0.0,
+                                    "composite": hit.get("score"),
+                                },
                                 "uploaded_at": uploaded_at,
                                 "source_filename": source_filename,
                                 "link": link,
                             }
                         )
 
-                        if len(similar_documents) >= 5:
+                        if len(similar_documents) >= page_size:
                             break
 
                     response_data["similarDocuments"] = similar_documents
+                    response_data["pagination"]["returned"] = len(similar_documents)
+                    response_data["pagination"]["hasNext"] = len(hits) >= page_size
+                    response_data["cache"] = {"hit": bool(search_payload.get("cache_hit"))}
+                    response_data["performanceTargetMs"] = {
+                        "keyword_only_p95": 120.0,
+                        "vector_only_p95": 450.0,
+                        "hybrid_with_date_filter_p95": 650.0,
+                    }
 
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")

--- a/sttEngine/search_cache.py
+++ b/sttEngine/search_cache.py
@@ -42,11 +42,58 @@ CACHE_DIR = _resolve_cache_directory()
 CACHE_EXPIRY_HOURS = 24
 
 
+def _build_cache_key_payload(
+    query: str,
+    top_k: int,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    sort_by: Optional[str] = None,
+    sort_order: Optional[str] = None,
+    min_score: Optional[float] = None,
+    page: Optional[int] = None,
+    page_size: Optional[int] = None,
+) -> Dict[str, Any]:
+    """검색 캐시 키를 구성하는 정규화된 페이로드를 반환한다."""
+    return {
+        "query": query,
+        "top_k": int(top_k),
+        "filters": {
+            "start_date": start_date or "",
+            "end_date": end_date or "",
+            "min_score": float(min_score) if min_score is not None else None,
+        },
+        "sort": {
+            "by": (sort_by or "similarity").lower(),
+            "order": (sort_order or "desc").lower(),
+        },
+        "pagination": {
+            "page": int(page) if page is not None else None,
+            "page_size": int(page_size) if page_size is not None else None,
+        },
+    }
+
+
 def get_query_hash(query: str, top_k: int,
                    start_date: Optional[str] = None,
-                   end_date: Optional[str] = None) -> str:
+                   end_date: Optional[str] = None,
+                   sort_by: Optional[str] = None,
+                   sort_order: Optional[str] = None,
+                   min_score: Optional[float] = None,
+                   page: Optional[int] = None,
+                   page_size: Optional[int] = None) -> str:
     """검색 쿼리와 파라미터에 대한 해시값 생성"""
-    query_data = f"{query}:{top_k}:{start_date or ''}:{end_date or ''}"
+    payload = _build_cache_key_payload(
+        query,
+        top_k,
+        start_date=start_date,
+        end_date=end_date,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        min_score=min_score,
+        page=page,
+        page_size=page_size,
+    )
+    query_data = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
     return hashlib.md5(query_data.encode('utf-8')).hexdigest()
 
 
@@ -89,12 +136,27 @@ def is_cache_expired(timestamp_str: str) -> bool:
 
 def get_cached_search_result(query: str, top_k: int,
                              start_date: Optional[str] = None,
-                             end_date: Optional[str] = None) -> Optional[List[Dict[str, Any]]]:
+                             end_date: Optional[str] = None,
+                             sort_by: Optional[str] = None,
+                             sort_order: Optional[str] = None,
+                             min_score: Optional[float] = None,
+                             page: Optional[int] = None,
+                             page_size: Optional[int] = None) -> Optional[List[Dict[str, Any]]]:
     """캐시된 검색 결과 조회"""
     # 캐시 사용 전 만료된 항목을 정리하여 디스크 사용량을 관리
     cleanup_expired_cache()
 
-    query_hash = get_query_hash(query, top_k, start_date, end_date)
+    query_hash = get_query_hash(
+        query,
+        top_k,
+        start_date,
+        end_date,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        min_score=min_score,
+        page=page,
+        page_size=page_size,
+    )
     record = load_cache_record(query_hash)
     
     if not record:
@@ -109,9 +171,24 @@ def get_cached_search_result(query: str, top_k: int,
 def cache_search_result(query: str, top_k: int, results: List[Dict[str, Any]],
                        existing_uuid: Optional[str] = None,
                        start_date: Optional[str] = None,
-                       end_date: Optional[str] = None) -> str:
+                       end_date: Optional[str] = None,
+                       sort_by: Optional[str] = None,
+                       sort_order: Optional[str] = None,
+                       min_score: Optional[float] = None,
+                       page: Optional[int] = None,
+                       page_size: Optional[int] = None) -> str:
     """검색 결과를 캐시에 저장"""
-    query_hash = get_query_hash(query, top_k, start_date, end_date)
+    query_hash = get_query_hash(
+        query,
+        top_k,
+        start_date,
+        end_date,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        min_score=min_score,
+        page=page,
+        page_size=page_size,
+    )
     
     # 기존 UUID 유지하거나 새로 생성
     if existing_uuid:
@@ -132,7 +209,12 @@ def cache_search_result(query: str, top_k: int, results: List[Dict[str, Any]],
         "query_hash": query_hash,
         "results": results,
         "start_date": start_date,
-        "end_date": end_date
+        "end_date": end_date,
+        "sort_by": sort_by,
+        "sort_order": sort_order,
+        "min_score": min_score,
+        "page": page,
+        "page_size": page_size,
     }
     
     save_cache_record(query_hash, record)
@@ -141,9 +223,24 @@ def cache_search_result(query: str, top_k: int, results: List[Dict[str, Any]],
 
 def delete_cache_record(query: str, top_k: int,
                         start_date: Optional[str] = None,
-                        end_date: Optional[str] = None) -> bool:
+                        end_date: Optional[str] = None,
+                        sort_by: Optional[str] = None,
+                        sort_order: Optional[str] = None,
+                        min_score: Optional[float] = None,
+                        page: Optional[int] = None,
+                        page_size: Optional[int] = None) -> bool:
     """Delete cached search result for a given query."""
-    query_hash = get_query_hash(query, top_k, start_date, end_date)
+    query_hash = get_query_hash(
+        query,
+        top_k,
+        start_date,
+        end_date,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        min_score=min_score,
+        page=page,
+        page_size=page_size,
+    )
     cache_file = CACHE_DIR / f"{query_hash}.json"
     try:
         cache_file.unlink()

--- a/sttEngine/vector_search.py
+++ b/sttEngine/vector_search.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from typing import List, Dict, Any, Optional
+import time
 
 import numpy as np
 import json
@@ -22,16 +23,52 @@ from .config import get_default_model, get_model_for_task, normalize_db_record_p
 
 def search(query: str, base_dir: Path, top_k: int = 10,
            start_date: Optional[str] = None,
-           end_date: Optional[str] = None) -> List[Dict[str, Any]]:
+           end_date: Optional[str] = None,
+           sort_by: str = "similarity",
+           sort_order: str = "desc",
+           min_score: Optional[float] = None,
+           page: int = 1,
+           page_size: int = 5,
+           include_timing: bool = False) -> List[Dict[str, Any]] | Dict[str, Any]:
     """Return top_k most similar documents for the given query.
 
     날짜/시간 필터링을 위해 ISO 형식의 ``start_date``와 ``end_date``를
     선택적으로 받을 수 있다.
     """
     # 캐시된 결과 확인
-    cached_results = get_cached_search_result(query, top_k, start_date, end_date)
+    overall_start = time.perf_counter()
+    normalized_sort_by = (sort_by or "similarity").lower()
+    normalized_sort_order = (sort_order or "desc").lower()
+    page = max(1, int(page or 1))
+    page_size = max(1, int(page_size or 5))
+
+    timing = {
+        "cache_lookup_ms": 0.0,
+        "embedding_ms": 0.0,
+        "index_load_ms": 0.0,
+        "vector_scan_ms": 0.0,
+        "postprocess_ms": 0.0,
+        "total_ms": 0.0,
+    }
+
+    cache_lookup_start = time.perf_counter()
+    cached_results = get_cached_search_result(
+        query,
+        top_k,
+        start_date,
+        end_date,
+        sort_by=normalized_sort_by,
+        sort_order=normalized_sort_order,
+        min_score=min_score,
+        page=page,
+        page_size=page_size,
+    )
+    timing["cache_lookup_ms"] = (time.perf_counter() - cache_lookup_start) * 1000
     if cached_results is not None:
         print(f"캐시에서 검색 결과 반환: {len(cached_results)}개 항목")
+        timing["total_ms"] = (time.perf_counter() - overall_start) * 1000
+        if include_timing:
+            return {"results": cached_results, "timing": timing, "cache_hit": True}
         return cached_results
     
     try:
@@ -41,13 +78,19 @@ def search(query: str, base_dir: Path, top_k: int = 10,
         model_name = os.environ.get("EMBEDDING_MODEL", "bge-m3:latest")
     
     try:
+        embedding_start = time.perf_counter()
         query_vec = embed_text_ollama(query, model_name)
+        timing["embedding_ms"] = (time.perf_counter() - embedding_start) * 1000
+
+        index_load_start = time.perf_counter()
         index = load_index()
+        timing["index_load_ms"] = (time.perf_counter() - index_load_start) * 1000
         results: List[Dict[str, Any]] = []
 
         start_dt = datetime.fromisoformat(start_date) if start_date else None
         end_dt = datetime.fromisoformat(end_date) if end_date else None
 
+        vector_scan_start = time.perf_counter()
         for path_str, meta in index.items():
             if isinstance(meta, dict) and meta.get("deleted"):
                 continue
@@ -73,6 +116,8 @@ def search(query: str, base_dir: Path, top_k: int = 10,
             if denom == 0:
                 continue
             score = float(np.dot(query_vec, doc_vec) / denom)
+            if min_score is not None and score < float(min_score):
+                continue
             try:
                 resolved_path = resolve_index_path(path_str, meta if isinstance(meta, dict) else None)
             except Exception:
@@ -83,19 +128,56 @@ def search(query: str, base_dir: Path, top_k: int = 10,
                 rel_path = resolved_path.as_posix()
 
             rel_path = normalize_db_record_path(rel_path, base_dir)
-            results.append({"file": rel_path, "score": score})
+            results.append({"file": rel_path, "score": score, "uploaded_at": timestamp_str})
         
-        results.sort(key=lambda x: x["score"], reverse=True)
-        final_results = results[:top_k]
-        
+        timing["vector_scan_ms"] = (time.perf_counter() - vector_scan_start) * 1000
+
+        postprocess_start = time.perf_counter()
+        reverse = normalized_sort_order != "asc"
+        if normalized_sort_by == "date":
+            def _date_key(item: Dict[str, Any]) -> datetime:
+                value = item.get("uploaded_at")
+                if not value:
+                    return datetime.min
+                try:
+                    return datetime.fromisoformat(value)
+                except ValueError:
+                    return datetime.min
+
+            results.sort(key=_date_key, reverse=reverse)
+        else:
+            results.sort(key=lambda x: x["score"], reverse=reverse)
+
+        offset = (page - 1) * page_size
+        truncated_results = results[:top_k]
+        final_results = truncated_results[offset: offset + page_size]
+
+        timing["postprocess_ms"] = (time.perf_counter() - postprocess_start) * 1000
+
         # 결과를 캐시에 저장
-        cache_search_result(query, top_k, final_results,
-                            start_date=start_date, end_date=end_date)
+        cache_search_result(
+            query,
+            top_k,
+            final_results,
+            start_date=start_date,
+            end_date=end_date,
+            sort_by=normalized_sort_by,
+            sort_order=normalized_sort_order,
+            min_score=min_score,
+            page=page,
+            page_size=page_size,
+        )
         print(f"새로운 검색 결과를 캐시에 저장: {len(final_results)}개 항목")
-        
+
+        timing["total_ms"] = (time.perf_counter() - overall_start) * 1000
+        if include_timing:
+            return {"results": final_results, "timing": timing, "cache_hit": False, "total_candidates": len(results)}
         return final_results
     
     except Exception as e:
         print(f"검색 중 오류 발생: {e}")
         # 오류 발생 시 빈 결과 반환
+        if include_timing:
+            timing["total_ms"] = (time.perf_counter() - overall_start) * 1000
+            return {"results": [], "timing": timing, "cache_hit": False, "total_candidates": 0}
         return []


### PR DESCRIPTION
### Motivation
- Reduce cache pollution by including sort/filter/pagination options in cache keys and make search behavior deterministic across parameter combinations.
- Make the vector search call path observable (timing) and support sorting, min-score filtering and pagination so performance bottlenecks can be quantified.
- Keep the existing search response fields for backwards compatibility while adding richer metadata to drive the frontend UI and SLAs.

### Description
- Reworked cache key generation in `sttEngine/search_cache.py` to build a normalized payload that includes `query`, `top_k`, date filters, `min_score`, `sort` (by/order) and `pagination` (page/page_size), and included those fields in stored cache records to avoid cache contamination.
- Extended `sttEngine/vector_search.py` to accept `sort_by`, `sort_order`, `min_score`, `page`, `page_size` and `include_timing`; added per-stage timing (`cache_lookup_ms`, `embedding_ms`, `index_load_ms`, `vector_scan_ms`, `postprocess_ms`, `total_ms`), date-based sorting, score filtering and pagination; preserved cache lookup/save using the expanded key.
- Updated HTTP handler `sttEngine/http_api/handler.py` `/search` parsing to accept new query params, pass them to vector search, and return enriched response metadata (`sort`, `pagination`, `scoreBreakdown`, `timing`, `cache`, `performanceTargetMs`) while keeping `keywordMatches` and `similarDocuments` for compatibility, and added `score_breakdown` per similar document.
- Updated frontend contract and usage: added fields in `frontend/src/api/types.ts`, extended `frontend/src/api/client.ts` `search()` to accept options (sort/filter/pagination), and updated `frontend/src/components/SearchPanel.tsx` to display returned metadata; added `search_api_contract.md` documenting endpoint params, response schema, call path bottlenecks, P95 targets and cache-key policy.

### Testing
- Compiled Python modules with `python -m py_compile sttEngine/http_api/handler.py sttEngine/vector_search.py sttEngine/search_cache.py` and the step succeeded.
- Built the frontend with `npm run build` (workdir: `frontend`) and the build succeeded.
- Performed a frontend preview + Playwright smoke that rendered the Search panel and produced a screenshot; Vite proxy logs showed connection errors for backend endpoints (backend not running) but the preview and automated screenshot completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eb558e734832e832463e8c2020c84)