### PR TITLE
Add similarity graph generation, APIs, caching, and lightweight graph viewer

### DIFF
--- a/frontend/graph-view.html
+++ b/frontend/graph-view.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Similarity Graph View</title>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 0; background: #10131a; color: #e6edf3; }
+      header { padding: 12px 16px; border-bottom: 1px solid #2d3748; display: flex; gap: 8px; align-items: center; }
+      #graph { width: 100%; height: calc(100vh - 180px); background: #0b0f14; }
+      #preview { padding: 12px 16px; border-top: 1px solid #2d3748; min-height: 92px; }
+      .node { fill: #60a5fa; cursor: pointer; }
+      .edge { stroke: #334155; stroke-width: 1.3; }
+      label { font-size: 14px; }
+      input, button { background: #1f2937; color: white; border: 1px solid #374151; border-radius: 6px; padding: 6px; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <label>threshold <input id="threshold" type="number" value="0.65" step="0.05" min="0" max="1"/></label>
+      <button id="reload">Reload Graph</button>
+      <span id="stats"></span>
+    </header>
+    <svg id="graph"></svg>
+    <div id="preview">노드를 클릭하면 문서 미리보기가 표시됩니다.</div>
+
+    <script>
+      const svg = document.getElementById('graph');
+      const preview = document.getElementById('preview');
+      const stats = document.getElementById('stats');
+
+      function randomPos(max) { return 30 + Math.random() * Math.max(30, max - 60); }
+
+      function renderGraph(data) {
+        const width = svg.clientWidth || window.innerWidth;
+        const height = svg.clientHeight || 500;
+        svg.innerHTML = '';
+
+        const positions = {};
+        data.nodes.forEach((node) => {
+          positions[node.id] = { x: randomPos(width), y: randomPos(height) };
+        });
+
+        data.edges.forEach((edge) => {
+          const s = positions[edge.source];
+          const t = positions[edge.target];
+          if (!s || !t) return;
+          const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+          line.setAttribute('class', 'edge');
+          line.setAttribute('x1', s.x);
+          line.setAttribute('y1', s.y);
+          line.setAttribute('x2', t.x);
+          line.setAttribute('y2', t.y);
+          line.setAttribute('opacity', Math.max(0.2, edge.score));
+          svg.appendChild(line);
+        });
+
+        data.nodes.forEach((node) => {
+          const p = positions[node.id];
+          const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+          circle.setAttribute('class', 'node');
+          circle.setAttribute('cx', p.x);
+          circle.setAttribute('cy', p.y);
+          circle.setAttribute('r', 7);
+          circle.addEventListener('click', () => loadPreview(node.id));
+          svg.appendChild(circle);
+        });
+
+        stats.textContent = `nodes: ${data.nodes.length}, edges: ${data.edges.length}`;
+      }
+
+      async function loadPreview(docId) {
+        const threshold = document.getElementById('threshold').value;
+        const resp = await fetch(`/api/similarity-graph/${encodeURIComponent(docId)}?threshold=${threshold}`);
+        const data = await resp.json();
+        if (!data.meta?.found) {
+          preview.textContent = '문서를 찾을 수 없습니다.';
+          return;
+        }
+        const center = data.nodes.find((n) => n.id === docId);
+        preview.innerHTML = `<b>${center?.label || docId}</b><br/>연결 문서 수: ${Math.max(0, data.nodes.length - 1)}<br/>파일: ${center?.file || '-'}`;
+      }
+
+      async function loadGraph() {
+        const threshold = document.getElementById('threshold').value;
+        const resp = await fetch(`/api/similarity-graph?threshold=${threshold}`);
+        const data = await resp.json();
+        renderGraph(data);
+      }
+
+      document.getElementById('reload').addEventListener('click', loadGraph);
+      window.addEventListener('resize', loadGraph);
+      loadGraph();
+    </script>
+  </body>
+</html>

--- a/sttEngine/http_api/embedding.py
+++ b/sttEngine/http_api/embedding.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import numpy as np
 
 from ..embedding_pipeline import embed_text_ollama, load_index, save_index
+from ..vector_search import refresh_similarity_data
 from .paths import OUTPUT_DIR, VECTOR_DIR, to_record_path
 from .registry import update_task_completion
 
@@ -83,6 +84,8 @@ def run_incremental_embedding(base_dir: Path | None = None) -> int:
 
         # Save updated index
         save_index(index)
+        if processed_count > 0:
+            refresh_similarity_data()
         print(f"증분 임베딩 완료: {processed_count}개 파일 처리됨")
         return processed_count
 
@@ -127,6 +130,7 @@ def generate_embedding(file_path: Path, record_id: str | None = None) -> bool:
             "vector_deleted_path": None,
         }
         save_index(index)
+        refresh_similarity_data()
 
         # Update task completion
         if record_id:

--- a/sttEngine/http_api/handler.py
+++ b/sttEngine/http_api/handler.py
@@ -12,6 +12,11 @@ from urllib.parse import unquote
 
 from ..search_cache import cleanup_expired_cache, delete_cache_record, get_cache_stats
 from ..vector_search import search as search_vectors
+from ..similarity_matrix import (
+    get_documents_metadata,
+    get_similarity_graph,
+    get_similarity_subgraph,
+)
 from ..ollama_utils import ensure_ollama_server
 from ..server.routes import history as history_route
 from ..server.routes import process as process_route
@@ -178,6 +183,8 @@ class UploadHandler(BaseHTTPRequestHandler):
         elif self.path in ("/upload.css", "/upload.js"):
             content_type = "text/css" if self.path.endswith(".css") else "application/javascript"
             self._serve_static(self.path.lstrip("/"), content_type)
+        elif self.path in ("/graph-view", "/graph-view.html"):
+            self._serve_static("graph-view.html", "text/html; charset=utf-8")
         elif self.path in ("/favicon.ico", "/vite.svg"):
             self._serve_dist_file(self.path.lstrip("/"))
         elif self.path.startswith("/download/"):
@@ -349,6 +356,41 @@ class UploadHandler(BaseHTTPRequestHandler):
                     "details": str(e),
                 }
                 self.wfile.write(json.dumps(error_response, ensure_ascii=False).encode())
+        elif self.path.startswith("/api/similarity-graph"):
+            from urllib.parse import parse_qs, urlparse
+
+            parsed = urlparse(self.path)
+            params = parse_qs(parsed.query)
+            threshold = float(params.get("threshold", ["0.65"])[0])
+            max_neighbors = int(params.get("max_neighbors", ["12"])[0])
+            refresh = params.get("refresh", ["false"])[0].lower() == "true"
+
+            base_path = parsed.path
+            if base_path == "/api/similarity-graph":
+                payload = get_similarity_graph(
+                    threshold=threshold,
+                    max_neighbors=max_neighbors,
+                    refresh=refresh,
+                )
+            else:
+                doc_id = unquote(base_path[len("/api/similarity-graph/"):])
+                payload = get_similarity_subgraph(
+                    doc_id=doc_id,
+                    threshold=threshold,
+                    max_neighbors=max_neighbors,
+                    refresh=refresh,
+                )
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(payload, ensure_ascii=False).encode())
+        elif self.path.startswith("/api/documents/metadata"):
+            payload = get_documents_metadata()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(payload, ensure_ascii=False).encode())
         elif self.path.startswith("/similar/"):
             file_identifier = unquote(self.path[len("/similar/") :])
             self._serve_similar_documents(file_identifier)

--- a/sttEngine/similarity_matrix.py
+++ b/sttEngine/similarity_matrix.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .embedding_pipeline import VECTOR_DIR, load_index, resolve_index_path
+from .http_api.history import get_active_history
+from .http_api.paths import BASE_DIR, normalize_record_path
+from .http_api.registry import load_file_registry
+
+_CACHE_LOCK = threading.Lock()
+_GRAPH_CACHE: dict[tuple[float, int], dict[str, Any]] = {}
+_SUBGRAPH_CACHE: dict[tuple[str, float, int], dict[str, Any]] = {}
+
+
+def _cosine_similarity(vec_a: np.ndarray, vec_b: np.ndarray) -> float:
+    denom = float(np.linalg.norm(vec_a) * np.linalg.norm(vec_b))
+    if denom == 0.0:
+        return 0.0
+    return float(np.dot(vec_a, vec_b) / denom)
+
+
+def _build_doc_catalog() -> list[dict[str, Any]]:
+    registry = load_file_registry()
+    history = {record.get("id"): record for record in get_active_history()}
+    index = load_index()
+
+    registry_by_path: dict[str, tuple[str, dict[str, Any]]] = {}
+    for file_uuid, info in registry.items():
+        if not isinstance(info, dict) or info.get("deleted"):
+            continue
+        rel_path = normalize_record_path(info.get("file_path", ""))
+        if rel_path:
+            registry_by_path[rel_path] = (file_uuid, info)
+
+    docs: list[dict[str, Any]] = []
+    for path_key, meta in index.items():
+        if not isinstance(meta, dict) or meta.get("deleted"):
+            continue
+
+        vector_name = meta.get("vector")
+        if not vector_name:
+            continue
+
+        vector_path = VECTOR_DIR / vector_name
+        if not vector_path.exists():
+            continue
+
+        try:
+            resolved = resolve_index_path(path_key, meta)
+        except Exception:
+            resolved = Path(path_key).resolve()
+
+        rel_path = normalize_record_path(str(resolved))
+        registry_match = registry_by_path.get(rel_path)
+
+        file_uuid = registry_match[0] if registry_match else rel_path
+        file_info = registry_match[1] if registry_match else {}
+        record = history.get(file_info.get("record_id"), {}) if file_info else {}
+
+        docs.append(
+            {
+                "id": file_uuid,
+                "record_id": file_info.get("record_id") if file_info else None,
+                "file": rel_path,
+                "display_name": file_info.get("original_filename")
+                or resolved.name,
+                "uploaded_at": record.get("timestamp") or meta.get("timestamp"),
+                "vector_path": vector_path,
+            }
+        )
+
+    docs.sort(key=lambda item: item.get("display_name") or item["id"])
+    return docs
+
+
+def _compute_graph(threshold: float = 0.65, max_neighbors: int = 12) -> dict[str, Any]:
+    docs = _build_doc_catalog()
+    if not docs:
+        return {"nodes": [], "edges": [], "meta": {"threshold": threshold, "count": 0, "generated_at": time.time()}}
+
+    vectors: list[np.ndarray] = []
+    valid_docs: list[dict[str, Any]] = []
+    for doc in docs:
+        try:
+            vectors.append(np.load(doc["vector_path"]))
+            valid_docs.append(doc)
+        except Exception:
+            continue
+
+    node_count = len(valid_docs)
+    if node_count == 0:
+        return {"nodes": [], "edges": [], "meta": {"threshold": threshold, "count": 0, "generated_at": time.time()}}
+
+    matrix = np.zeros((node_count, node_count), dtype=float)
+    for i in range(node_count):
+        matrix[i, i] = 1.0
+        for j in range(i + 1, node_count):
+            score = _cosine_similarity(vectors[i], vectors[j])
+            matrix[i, j] = score
+            matrix[j, i] = score
+
+    nodes = [
+        {
+            "id": doc["id"],
+            "label": doc["display_name"],
+            "file": doc["file"],
+            "record_id": doc.get("record_id"),
+            "uploaded_at": doc.get("uploaded_at"),
+        }
+        for doc in valid_docs
+    ]
+
+    edges: list[dict[str, Any]] = []
+    for i in range(node_count):
+        row = matrix[i]
+        candidate_idx = [j for j in np.argsort(row)[::-1] if j != i and row[j] >= threshold][:max_neighbors]
+        for j in candidate_idx:
+            if i < j:
+                edges.append(
+                    {
+                        "source": valid_docs[i]["id"],
+                        "target": valid_docs[j]["id"],
+                        "score": float(row[j]),
+                    }
+                )
+
+    return {
+        "nodes": nodes,
+        "edges": edges,
+        "meta": {
+            "threshold": threshold,
+            "count": node_count,
+            "generated_at": time.time(),
+        },
+    }
+
+
+def invalidate_similarity_cache() -> None:
+    with _CACHE_LOCK:
+        _GRAPH_CACHE.clear()
+        _SUBGRAPH_CACHE.clear()
+
+
+def get_similarity_graph(threshold: float = 0.65, max_neighbors: int = 12, refresh: bool = False) -> dict[str, Any]:
+    key = (round(float(threshold), 4), int(max_neighbors))
+    with _CACHE_LOCK:
+        if not refresh and key in _GRAPH_CACHE:
+            return _GRAPH_CACHE[key]
+
+    graph = _compute_graph(threshold=threshold, max_neighbors=max_neighbors)
+    with _CACHE_LOCK:
+        _GRAPH_CACHE[key] = graph
+    return graph
+
+
+def get_similarity_subgraph(doc_id: str, threshold: float = 0.65, max_neighbors: int = 12, refresh: bool = False) -> dict[str, Any]:
+    cache_key = (doc_id, round(float(threshold), 4), int(max_neighbors))
+    with _CACHE_LOCK:
+        if not refresh and cache_key in _SUBGRAPH_CACHE:
+            return _SUBGRAPH_CACHE[cache_key]
+
+    graph = get_similarity_graph(threshold=threshold, max_neighbors=max_neighbors, refresh=refresh)
+    node_ids = {node["id"] for node in graph["nodes"]}
+    if doc_id not in node_ids:
+        return {"nodes": [], "edges": [], "meta": {"doc_id": doc_id, "found": False}}
+
+    kept_ids = {doc_id}
+    for edge in graph["edges"]:
+        if edge["source"] == doc_id:
+            kept_ids.add(edge["target"])
+        elif edge["target"] == doc_id:
+            kept_ids.add(edge["source"])
+
+    sub_nodes = [node for node in graph["nodes"] if node["id"] in kept_ids]
+    sub_edges = [
+        edge
+        for edge in graph["edges"]
+        if edge["source"] in kept_ids and edge["target"] in kept_ids
+    ]
+
+    payload = {
+        "nodes": sub_nodes,
+        "edges": sub_edges,
+        "meta": {
+            "doc_id": doc_id,
+            "found": True,
+            "threshold": threshold,
+            "count": len(sub_nodes),
+        },
+    }
+    with _CACHE_LOCK:
+        _SUBGRAPH_CACHE[cache_key] = payload
+    return payload
+
+
+def get_documents_metadata() -> dict[str, Any]:
+    docs = _build_doc_catalog()
+    return {
+        "documents": [
+            {
+                "id": doc["id"],
+                "file": doc["file"],
+                "display_name": doc["display_name"],
+                "record_id": doc.get("record_id"),
+                "uploaded_at": doc.get("uploaded_at"),
+            }
+            for doc in docs
+        ],
+        "meta": {
+            "count": len(docs),
+            "base_dir": str(BASE_DIR),
+        },
+    }

--- a/sttEngine/vector_search.py
+++ b/sttEngine/vector_search.py
@@ -17,6 +17,7 @@ from .embedding_pipeline import (
     resolve_index_path,
 )
 from .search_cache import cache_search_result, get_cached_search_result
+from .similarity_matrix import invalidate_similarity_cache
 
 from .config import get_default_model, get_model_for_task, normalize_db_record_path
 
@@ -181,3 +182,9 @@ def search(query: str, base_dir: Path, top_k: int = 10,
             timing["total_ms"] = (time.perf_counter() - overall_start) * 1000
             return {"results": [], "timing": timing, "cache_hit": False, "total_candidates": 0}
         return []
+
+
+def refresh_similarity_data() -> None:
+    """Invalidate similarity graph caches after embedding/index updates."""
+    invalidate_similarity_cache()
+


### PR DESCRIPTION
### Motivation
- Provide document similarity insights by building a cosine-similarity graph from stored embeddings so users can explore related documents. 
- Keep graph generation efficient for large collections by caching full graphs and per-document subgraphs and invalidating caches when embeddings change. 
- Expose server APIs and a minimal frontend to preview graph relationships without coupling layout/cluster logic into the first iteration.

### Description
- Added `sttEngine/similarity_matrix.py` which loads the embedding index/vectors, computes cosine similarity matrix, filters edges by configurable `threshold` and `max_neighbors`, returns full graph (`nodes`, `edges`, `meta`), per-document subgraphs, and document metadata, and implements thread-safe caching and invalidation. 
- Wired cache invalidation into embedding updates by adding `refresh_similarity_data()` to `sttEngine/vector_search.py` and calling it from `sttEngine/http_api/embedding.py` after index/vector writes. 
- Extended HTTP API in `sttEngine/http_api/handler.py` to serve: `GET /api/similarity-graph`, `GET /api/similarity-graph/<doc_id>`, `GET /api/documents/metadata`, and added routes to serve the graph viewer at `/graph-view` and `/graph-view.html`. 
- Added a minimal client-side viewer `frontend/graph-view.html` that renders nodes/edges with SVG, provides a `threshold` control + reload, and uses the subgraph endpoint to show a click preview; layout is randomized for now and advanced layout/clustering deferred.

### Testing
- Compiled changed modules with `python -m compileall sttEngine/similarity_matrix.py sttEngine/vector_search.py sttEngine/http_api/embedding.py sttEngine/http_api/handler.py` and compilation succeeded. 
- Sanity import/return shape checks using `python - <<'PY' ... from sttEngine.similarity_matrix import get_similarity_graph, get_documents_metadata ... PY` returned Python `dict` types as expected. 
- With the server running (`PYTHONPATH=. python sttEngine/server.py`) a smoke test `curl -i --max-time 5 http://127.0.0.1:8080/api/similarity-graph` returned HTTP 200 and a JSON graph payload (empty when no embeddings present). 
- Attempted an automated browser screenshot via Playwright to capture the new front-end, but navigation failed with `ERR_EMPTY_RESPONSE` in the container; API and static HTML serving were still validated via `curl`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ebbad82f8832ea12cde7c76047068)