### PR TITLE
Add TaskStage enum, staged progress UI, and retry contract for workflow tasks

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -8,6 +8,7 @@ import type {
   RunningTask,
   ModelSettings,
   ProcessResult,
+  RetryMode,
   TaskProgress,
   ViewerFileType,
 } from './types';
@@ -39,7 +40,9 @@ export async function processTask(
   recordId?: string,
   taskId?: string,
   modelSettings?: Partial<ModelSettings>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  retryMode: RetryMode = 'new_task',
+  retryOfTaskId?: string,
 ): Promise<ProcessResult> {
   return apiRequest<ProcessResult>('/process', {
     method: 'POST',
@@ -50,6 +53,8 @@ export async function processTask(
       record_id: recordId,
       task_id: taskId,
       model_settings: modelSettings,
+      retry_mode: retryMode,
+      retry_of_task_id: retryOfTaskId,
     }),
     signal,
   });

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -12,6 +12,8 @@ export enum QueueTaskStatus {
 
 export type QueueSortMode = 'category' | 'order';
 export type TaskType = 'stt' | 'embedding' | 'summary';
+export type TaskStage = 'upload' | 'transform' | 'correct' | 'summary';
+export type RetryMode = 'new_task' | 'resume_existing';
 
 export interface AsyncState<T> {
   data: T;
@@ -45,6 +47,8 @@ export interface HistoryRecord {
 export interface ProcessResult {
   accepted?: boolean;
   task_id?: string;
+  retry_mode?: RetryMode;
+  retry_of_task_id?: string;
   stt?: string;
   summary?: string;
   correct?: string;
@@ -132,6 +136,7 @@ export interface RunningTask {
 export interface TaskProgress {
   task_id: string;
   message: string;
+  stage?: TaskStage;
   error_code?: string;
   retryable?: boolean;
   failed_step?: string;
@@ -149,10 +154,12 @@ export interface QueueTask {
   abortController?: AbortController;
   lastRetryTime?: number;
   retryCount?: number;
+  retryOfTaskId?: string;
   modelInfo?: string;
   errorCode?: string;
   retryable?: boolean;
   failedStep?: string;
+  stage?: TaskStage;
 }
 
 export interface ModelSettings {

--- a/frontend/src/components/JobQueue.tsx
+++ b/frontend/src/components/JobQueue.tsx
@@ -9,6 +9,14 @@ import { useApp } from '../contexts/AppContext';
 import type { QueueTask } from '../api/types';
 import { QueueTaskStatus } from '../api/types';
 
+const STAGE_ORDER: Array<'upload' | 'transform' | 'correct' | 'summary'> = ['upload', 'transform', 'correct', 'summary'];
+const STAGE_LABEL: Record<(typeof STAGE_ORDER)[number], string> = {
+  upload: '업로드',
+  transform: '변환',
+  correct: '교정',
+  summary: '요약',
+};
+
 export function JobQueue() {
   const { theme } = useTheme();
   const { queue, currentTask, sortMode, setSortMode, removeTask, retryTask, cancelAll, categoryLabels } = useApp();
@@ -46,7 +54,15 @@ export function JobQueue() {
 
   const isAudioTask = (task: QueueTask) => ['.mp3', '.wav', '.m4a', '.flac', '.ogg', '.webm', '.mp4'].some(ext => task.filePath.toLowerCase().endsWith(ext));
 
-  const stepLabels: Record<string, string> = { stt: 'STT', correct: '교정', embedding: '임베딩', summary: '요약', summarize: '요약' };
+  const stepLabels: Record<string, string> = { stt: '변환', correct: '교정', embedding: '변환', summary: '요약', summarize: '요약' };
+
+  const getCurrentStage = (task: QueueTask): (typeof STAGE_ORDER)[number] => {
+    if (task.stage) return task.stage;
+    if (task.status === QueueTaskStatus.Pending || task.status === QueueTaskStatus.Queued) return 'upload';
+    if (task.failedStep === 'correct') return 'correct';
+    if (task.failedStep === 'summary') return 'summary';
+    return 'transform';
+  };
 
   return (
     <div className="space-y-6">
@@ -102,11 +118,27 @@ export function JobQueue() {
                           </div>
                         )}
 
-                        {task.status === QueueTaskStatus.Processing && <Progress value={50} className="h-1.5" />}
+                        <div className="space-y-2">
+                          <div className="grid grid-cols-4 gap-2">
+                            {STAGE_ORDER.map((stage, idx) => {
+                              const current = getCurrentStage(task);
+                              const currentIndex = STAGE_ORDER.indexOf(current);
+                              const complete = task.status === QueueTaskStatus.Completed || idx < currentIndex;
+                              const active = idx === currentIndex && task.status !== QueueTaskStatus.Completed;
+                              return (
+                                <div key={stage} className="space-y-1">
+                                  <div className={`h-1.5 rounded ${complete ? 'bg-violet-500' : active ? 'bg-violet-300/80' : 'bg-slate-600/40'}`} />
+                                  <div className={`text-[11px] ${active ? (theme === 'dark' ? 'text-violet-300' : 'text-violet-700') : (theme === 'dark' ? 'text-slate-500' : 'text-slate-500')}`}>{STAGE_LABEL[stage]}</div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                          {task.status === QueueTaskStatus.Processing && <Progress value={Math.max(20, (STAGE_ORDER.indexOf(getCurrentStage(task)) + 1) * 25)} className="h-1.5" />}
+                        </div>
                         <TaskActionControls
                           compact
                           canCancel={task.status === QueueTaskStatus.Processing || task.status === QueueTaskStatus.Pending || task.status === QueueTaskStatus.Queued}
-                          canRetry={(task.status === QueueTaskStatus.Error && task.retryable !== false) || task.status === QueueTaskStatus.Cancelled}
+                          canRetry={task.status === QueueTaskStatus.Error && task.retryable !== false}
                           retryLabel={task.failedStep ? `${stepLabels[task.failedStep] || task.failedStep} 단계만 재시도` : "재시도"}
                           onCancel={() => removeTask(task.id)}
                           onRetry={() => retryTask(task)}

--- a/frontend/src/hooks/useTaskQueue.ts
+++ b/frontend/src/hooks/useTaskQueue.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import * as api from '../api/client';
-import type { QueueTask, TaskType, ModelSettings, QueueSortMode, TaskProgress } from '../api/types';
+import type { QueueTask, TaskType, ModelSettings, QueueSortMode, TaskProgress, TaskStage } from '../api/types';
 import { QueueTaskStatus } from '../api/types';
 
 const CATEGORY_ORDER: TaskType[] = ['stt', 'embedding', 'summary'];
@@ -53,13 +53,13 @@ export function useTaskQueue(modelSettings: ModelSettings, onTaskComplete?: () =
     setQueue(prev => [...prev, task]);
   }, []);
 
-  const applyProgressUpdate = useCallback((taskId: string, message: string, meta?: { error_code?: string; retryable?: boolean; failed_step?: string }) => {
+  const applyProgressUpdate = useCallback((taskId: string, message: string, meta?: { stage?: TaskStage; error_code?: string; retryable?: boolean; failed_step?: string }) => {
     const previousMessage = progressDedupRef.current.get(taskId);
     if (previousMessage === message) return;
     progressDedupRef.current.set(taskId, message);
 
-    setQueue(prev => prev.map(t => t.taskId === taskId ? { ...t, progress: message, errorCode: meta?.error_code, retryable: meta?.retryable, failedStep: meta?.failed_step } : t));
-    setCurrentTask(prev => prev && prev.taskId === taskId ? { ...prev, progress: message, errorCode: meta?.error_code, retryable: meta?.retryable, failedStep: meta?.failed_step } : prev);
+    setQueue(prev => prev.map(t => t.taskId === taskId ? { ...t, progress: message, stage: meta?.stage, errorCode: meta?.error_code, retryable: meta?.retryable, failedStep: meta?.failed_step } : t));
+    setCurrentTask(prev => prev && prev.taskId === taskId ? { ...prev, progress: message, stage: meta?.stage, errorCode: meta?.error_code, retryable: meta?.retryable, failedStep: meta?.failed_step } : prev);
   }, []);
 
   const removeTask = useCallback((taskId: string) => {
@@ -84,6 +84,7 @@ export function useTaskQueue(modelSettings: ModelSettings, onTaskComplete?: () =
       status: QueueTaskStatus.Pending,
       progress: '',
       retryCount: (task.retryCount || 0) + 1,
+      retryOfTaskId: task.retryOfTaskId || task.taskId,
       abortController: undefined,
       lastRetryTime: Date.now(),
     };
@@ -152,10 +153,12 @@ export function useTaskQueue(modelSettings: ModelSettings, onTaskComplete?: () =
           language: ms.language,
         },
         abortController.signal,
+        'new_task',
+        task.retryOfTaskId,
       );
 
       if (result.error) {
-        setCurrentTask(prev => prev ? { ...prev, status: QueueTaskStatus.Error, progress: result.error || "오류 발생", errorCode: result.error_code, retryable: result.retryable, failedStep: result.failed_step } : null);
+        setCurrentTask(prev => prev ? { ...prev, status: QueueTaskStatus.Error, progress: result.error || "오류 발생", stage: result.failed_step === 'correct' ? 'correct' : result.failed_step === 'summary' ? 'summary' : 'transform', errorCode: result.error_code, retryable: result.retryable, failedStep: result.failed_step } : null);
       } else {
         setCurrentTask(prev => prev ? { ...prev, status: QueueTaskStatus.Completed } : null);
       }
@@ -183,9 +186,9 @@ export function useTaskQueue(modelSettings: ModelSettings, onTaskComplete?: () =
       try {
         const progress: TaskProgress = await api.getProgress(currentTask.taskId);
         if (cancelled || !progress.message) return;
-        applyProgressUpdate(progress.task_id, progress.message, { error_code: progress.error_code, retryable: progress.retryable, failed_step: progress.failed_step });
+        applyProgressUpdate(progress.task_id, progress.message, { stage: progress.stage, error_code: progress.error_code, retryable: progress.retryable, failed_step: progress.failed_step });
       } catch {
-        // WebSocket path remains primary; polling is best-effort fallback.
+        // WebSocket is primary; polling explicitly prevents stale UI when websocket events are dropped.
       }
     };
 

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,6 +1,10 @@
 import { useEffect, useRef, useCallback } from 'react';
 
-type MessageHandler = (taskId: string, message: string, meta?: { error_code?: string; retryable?: boolean; failed_step?: string }) => void;
+type MessageHandler = (
+  taskId: string,
+  message: string,
+  meta?: { stage?: 'upload' | 'transform' | 'correct' | 'summary'; error_code?: string; retryable?: boolean; failed_step?: string }
+) => void;
 
 export function useWebSocket(onMessage: MessageHandler) {
   const wsRef = useRef<WebSocket | null>(null);
@@ -22,7 +26,12 @@ export function useWebSocket(onMessage: MessageHandler) {
         try {
           const data = JSON.parse(event.data);
           if (data.task_id && data.message) {
-            onMessageRef.current(data.task_id, data.message, { error_code: data.error_code, retryable: data.retryable, failed_step: data.failed_step });
+            onMessageRef.current(data.task_id, data.message, {
+              stage: data.stage,
+              error_code: data.error_code,
+              retryable: data.retryable,
+              failed_step: data.failed_step,
+            });
           }
         } catch (e) {
           console.error('WebSocket message parse error:', e);

--- a/sttEngine/http_api/state.py
+++ b/sttEngine/http_api/state.py
@@ -3,11 +3,19 @@ from __future__ import annotations
 import subprocess
 import threading
 import time
+from enum import StrEnum
 
 from .ws import broadcast_progress
 
 
 TASK_TYPES = ("stt", "embedding", "summary")
+
+
+class TaskStage(StrEnum):
+    UPLOAD = "upload"
+    TRANSFORM = "transform"
+    CORRECT = "correct"
+    SUMMARY = "summary"
 
 # Global dictionary to track running processes
 running_processes: dict[str, dict] = {}
@@ -79,6 +87,7 @@ def is_task_cancelled(task_id: str) -> bool:
 def update_task_progress(
     task_id: str,
     message: str,
+    stage: TaskStage | str | None = None,
     error_code: str | None = None,
     retryable: bool | None = None,
     failed_step: str | None = None,
@@ -88,13 +97,14 @@ def update_task_progress(
         task_progress[task_id] = {
             "task_id": task_id,
             "message": message,
+            "stage": str(stage) if stage else None,
             "timestamp": time.time(),
             "error_code": error_code,
             "retryable": retryable,
             "failed_step": failed_step,
         }
         print(f"Task {task_id}: {message}")
-    broadcast_progress(task_id, message, error_code, retryable, failed_step)
+    broadcast_progress(task_id, message, str(stage) if stage else None, error_code, retryable, failed_step)
 
 
 def get_task_progress(task_id: str) -> dict:

--- a/sttEngine/http_api/workflow.py
+++ b/sttEngine/http_api/workflow.py
@@ -25,6 +25,7 @@ from .state import (
     is_task_cancelled,
     unregister_process,
     update_task_progress,
+    TaskStage,
 )
 
 
@@ -36,6 +37,7 @@ def _workflow_error_result(task_id: str | None, exc: Exception, failed_step: str
         update_task_progress(
             task_id,
             f"{failed_step} 실패: {mapped.message}",
+            stage=TaskStage.CORRECT if (mapped.failed_step or failed_step)=="correct" else (TaskStage.SUMMARY if (mapped.failed_step or failed_step)=="summary" else TaskStage.TRANSFORM),
             error_code=mapped.code,
             retryable=mapped.retryable,
             failed_step=mapped.failed_step or failed_step,
@@ -202,7 +204,7 @@ def run_workflow(
 
             def progress_callback(message):
                 if task_id:
-                    update_task_progress(task_id, message)
+                    update_task_progress(task_id, message, stage=TaskStage.TRANSFORM)
 
             whisper_model = "large-v3-turbo"
             if model_settings and model_settings.get("whisper"):
@@ -238,7 +240,7 @@ def run_workflow(
             except Exception as e:
                 print(f"STT process failed: {e}")
                 if task_id:
-                    update_task_progress(task_id, f"STT 실패: {e}")
+                    update_task_progress(task_id, f"STT 실패: {e}", stage=TaskStage.TRANSFORM)
                 return _workflow_error_result(task_id, e, "stt")
 
             stt_file = individual_output_dir / f"{file_path.stem}.md"
@@ -259,7 +261,7 @@ def run_workflow(
 
                 if existing_stt:
                     if task_id:
-                        update_task_progress(task_id, f"기존 STT 결과 발견: {existing_stt.name}")
+                        update_task_progress(task_id, f"기존 STT 결과 발견: {existing_stt.name}", stage=TaskStage.TRANSFORM)
                     current_file = existing_stt
                     download_url = f"/download/{upload_folder_name}/{existing_stt.name}"
                     results["stt"] = download_url
@@ -269,12 +271,12 @@ def run_workflow(
                         update_task_completion(record_id, "stt", file_path_str)
                 else:
                     if task_id:
-                        update_task_progress(task_id, "STT 자동 실행 시작")
+                        update_task_progress(task_id, "STT 자동 실행 시작", stage=TaskStage.TRANSFORM)
                     try:
 
                         def progress_callback(message):
                             if task_id:
-                                update_task_progress(task_id, message)
+                                update_task_progress(task_id, message, stage=TaskStage.TRANSFORM)
 
                         whisper_model = "large-v3-turbo"
                         if model_settings and model_settings.get("whisper"):
@@ -309,7 +311,7 @@ def run_workflow(
                     except Exception as e:
                         print(f"STT process failed: {e}")
                         if task_id:
-                            update_task_progress(task_id, f"STT 실패: {e}")
+                            update_task_progress(task_id, f"STT 실패: {e}", stage=TaskStage.TRANSFORM)
                         return _workflow_error_result(task_id, e, "stt")
 
                     stt_file = individual_output_dir / f"{file_path.stem}.md"
@@ -322,21 +324,21 @@ def run_workflow(
                         update_task_completion(record_id, "stt", file_path_str)
 
             if task_id:
-                update_task_progress(task_id, "임베딩 생성 시작")
+                update_task_progress(task_id, "임베딩 생성 시작", stage=TaskStage.TRANSFORM)
 
             if generate_embedding(current_file, record_id):
                 if task_id:
-                    update_task_progress(task_id, "임베딩 생성 완료")
+                    update_task_progress(task_id, "임베딩 생성 완료", stage=TaskStage.TRANSFORM)
             else:
                 if task_id:
-                    update_task_progress(task_id, "임베딩 생성 실패")
+                    update_task_progress(task_id, "임베딩 생성 실패", stage=TaskStage.TRANSFORM)
 
         if "correct" in steps and current_file:
             if task_id and is_task_cancelled(task_id):
                 return {"error": "Task was cancelled"}
 
             if task_id:
-                update_task_progress(task_id, "교정 시작")
+                update_task_progress(task_id, "교정 시작", stage=TaskStage.CORRECT)
 
             corrected_file = Path(current_file).with_name(f"{Path(current_file).stem}.corrected.md")
             try:
@@ -363,7 +365,7 @@ def run_workflow(
 
                 if existing_stt:
                     if task_id:
-                        update_task_progress(task_id, f"기존 STT 결과 발견: {existing_stt.name}")
+                        update_task_progress(task_id, f"기존 STT 결과 발견: {existing_stt.name}", stage=TaskStage.TRANSFORM)
                     current_file = existing_stt
                     download_url = f"/download/{upload_folder_name}/{existing_stt.name}"
                     results["stt"] = download_url
@@ -373,12 +375,12 @@ def run_workflow(
                         update_task_completion(record_id, "stt", file_path_str)
                 else:
                     if task_id:
-                        update_task_progress(task_id, "STT 자동 실행 시작")
+                        update_task_progress(task_id, "STT 자동 실행 시작", stage=TaskStage.TRANSFORM)
                     try:
 
                         def progress_callback(message):
                             if task_id:
-                                update_task_progress(task_id, message)
+                                update_task_progress(task_id, message, stage=TaskStage.TRANSFORM)
 
                         whisper_model = "large-v3-turbo"
                         if model_settings and model_settings.get("whisper"):
@@ -413,7 +415,7 @@ def run_workflow(
                     except Exception as e:
                         print(f"STT process failed: {e}")
                         if task_id:
-                            update_task_progress(task_id, f"STT 실패: {e}")
+                            update_task_progress(task_id, f"STT 실패: {e}", stage=TaskStage.TRANSFORM)
                         return _workflow_error_result(task_id, e, "stt")
 
                     stt_file = individual_output_dir / f"{file_path.stem}.md"
@@ -429,7 +431,7 @@ def run_workflow(
 
             print(f"Starting summary for task {task_id}")
             if task_id:
-                update_task_progress(task_id, "요약 생성 시작")
+                update_task_progress(task_id, "요약 생성 시작", stage=TaskStage.SUMMARY)
 
             summarize_model = DEFAULT_MODEL
             if model_settings and model_settings.get("summarize"):
@@ -438,11 +440,11 @@ def run_workflow(
             try:
                 text = read_text_with_fallback(Path(current_file))
                 if task_id:
-                    update_task_progress(task_id, "텍스트 분석 중...")
+                    update_task_progress(task_id, "텍스트 분석 중...", stage=TaskStage.SUMMARY)
 
                 def summary_progress_callback(message):
                     if task_id:
-                        update_task_progress(task_id, message)
+                        update_task_progress(task_id, message, stage=TaskStage.SUMMARY)
 
                 summary = summarize_text_mapreduce(
                     text=text,
@@ -454,7 +456,7 @@ def run_workflow(
                 )
 
                 if task_id:
-                    update_task_progress(task_id, "요약 파일 저장 중...")
+                    update_task_progress(task_id, "요약 파일 저장 중...", stage=TaskStage.SUMMARY)
 
                 output_file = Path(current_file).with_name(f"{Path(current_file).stem}.summary.md")
                 save_output(summary, output_file, as_json=False)
@@ -477,7 +479,7 @@ def run_workflow(
                     created_at = datetime.now()
 
                     if task_id:
-                        update_task_progress(task_id, "Obsidian 전송 중...")
+                        update_task_progress(task_id, "Obsidian 전송 중...", stage=TaskStage.SUMMARY)
 
                     mcp_result = send_summary_to_obsidian_sync(
                         uuid=file_uuid,
@@ -489,7 +491,7 @@ def run_workflow(
                     if mcp_result["success"]:
                         print(f"Obsidian MCP 전송 성공: {mcp_result['message']}")
                         if task_id:
-                            update_task_progress(task_id, "Obsidian 전송 완료")
+                            update_task_progress(task_id, "Obsidian 전송 완료", stage=TaskStage.SUMMARY)
                     else:
                         print(f"Obsidian MCP 전송 실패 (처리는 계속): {mcp_result['message']}")
 
@@ -497,11 +499,11 @@ def run_workflow(
                     print(f"Obsidian MCP 전송 중 오류 (처리는 계속): {e}")
 
                 if task_id:
-                    update_task_progress(task_id, "요약 생성 완료")
+                    update_task_progress(task_id, "요약 생성 완료", stage=TaskStage.SUMMARY)
             except Exception as e:
                 print(f"Summary process failed: {e}")
                 if task_id:
-                    update_task_progress(task_id, f"요약 생성 실패: {e}")
+                    update_task_progress(task_id, f"요약 생성 실패: {e}", stage=TaskStage.SUMMARY)
                 return _workflow_error_result(task_id, e, "summary")
 
             summary_file = current_file.with_name(f"{current_file.stem}.summary.md")
@@ -518,7 +520,7 @@ def run_workflow(
     except Exception as exc:  # pragma: no cover
         if task_id:
             unregister_process(task_id)
-            update_task_progress(task_id, f"작업 실패: {exc}")
+            update_task_progress(task_id, f"작업 실패: {exc}", stage=TaskStage.TRANSFORM)
         return _workflow_error_result(task_id, exc, "workflow")
 
     finally:

--- a/sttEngine/http_api/ws.py
+++ b/sttEngine/http_api/ws.py
@@ -11,17 +11,40 @@ connected_clients: set[Any] = set()
 websocket_loop = asyncio.new_event_loop()
 
 
-async def _send_progress(task_id: str, message: str, error_code: str | None = None, retryable: bool | None = None, failed_step: str | None = None) -> None:
-    data = json.dumps({"task_id": task_id, "message": message, "error_code": error_code, "retryable": retryable, "failed_step": failed_step})
+async def _send_progress(
+    task_id: str,
+    message: str,
+    stage: str | None = None,
+    error_code: str | None = None,
+    retryable: bool | None = None,
+    failed_step: str | None = None,
+) -> None:
+    data = json.dumps({
+        "task_id": task_id,
+        "message": message,
+        "stage": stage,
+        "error_code": error_code,
+        "retryable": retryable,
+        "failed_step": failed_step,
+    })
     if connected_clients:
         await asyncio.gather(
             *[client.send(data) for client in list(connected_clients) if not client.closed]
         )
 
 
-def broadcast_progress(task_id: str, message: str, error_code: str | None = None, retryable: bool | None = None, failed_step: str | None = None) -> None:
+def broadcast_progress(
+    task_id: str,
+    message: str,
+    stage: str | None = None,
+    error_code: str | None = None,
+    retryable: bool | None = None,
+    failed_step: str | None = None,
+) -> None:
     if websocket_loop.is_running():
-        asyncio.run_coroutine_threadsafe(_send_progress(task_id, message, error_code, retryable, failed_step), websocket_loop)
+        asyncio.run_coroutine_threadsafe(
+            _send_progress(task_id, message, stage, error_code, retryable, failed_step), websocket_loop
+        )
 
 
 async def websocket_handler(websocket):

--- a/sttEngine/server/services/file_service.py
+++ b/sttEngine/server/services/file_service.py
@@ -27,4 +27,6 @@ def parse_process_payload(handler) -> dict:
         "record_id": payload.get("record_id"),
         "task_id": payload.get("task_id") or str(uuid.uuid4()),
         "model_settings": payload.get("model_settings", {}),
+        "retry_mode": payload.get("retry_mode") or "new_task",
+        "retry_of_task_id": payload.get("retry_of_task_id"),
     }

--- a/sttEngine/server/tasks/queue.py
+++ b/sttEngine/server/tasks/queue.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from ...http_api.workflow import run_workflow
+from ...http_api.state import update_task_progress, TaskStage
 from ..services.errors import map_workflow_exception
 
 
 def run_process_task(task_request: dict) -> dict:
     try:
+        update_task_progress(task_request["task_id"], "작업 접수 완료", stage=TaskStage.UPLOAD)
         result = run_workflow(
             task_request["absolute_path"],
             task_request["steps"],
@@ -13,6 +15,10 @@ def run_process_task(task_request: dict) -> dict:
             task_request["task_id"],
             task_request["model_settings"],
         )
+        result["task_id"] = task_request["task_id"]
+        result["retry_mode"] = task_request.get("retry_mode", "new_task")
+        if task_request.get("retry_of_task_id"):
+            result["retry_of_task_id"] = task_request.get("retry_of_task_id")
         return result
     except Exception as exc:
         mapped = map_workflow_exception(exc, "workflow")


### PR DESCRIPTION
### Motivation
- Provide a consistent, stage-aware progress model across backend payloads and WebSocket events so the frontend can render deterministic step progress (upload/transform/correct/summary). 
- Make retry behavior explicit in the API and preserve lineage when users retry failed work without mutating the original task id. 
- Avoid UI state stalls when WS events are dropped by keeping a clear polling fallback and deduplicated progress updates.

### Description
- Added a `TaskStage` enum (`upload | transform | correct | summary`) and included `stage` in in-memory progress and broadcast payloads (`sttEngine/http_api/state.py`, `sttEngine/http_api/ws.py`).
- Mapped workflow steps to stages in `run_workflow` so STT/embedding use `transform`, correction uses `correct`, and summary uses `summary`; errors set the same stage mapping (changes in `sttEngine/http_api/workflow.py`).
- Emit an initial `upload` stage update when a process request is accepted and return `task_id` and retry metadata in the process response (changes in `sttEngine/server/tasks/queue.py` and `sttEngine/server/services/file_service.py`).
- Added explicit retry API fields: request fields `retry_mode` and `retry_of_task_id`, and response inclusion of `retry_mode`/`retry_of_task_id` (front/back contract in `frontend/src/api/client.ts`, `frontend/src/api/types.ts`, `sttEngine/server/services/file_service.py`).
- Frontend changes: added `TaskStage`/`RetryMode` types, consumed `stage` from WS/progress polling, create retry as a new task while setting `retryOfTaskId` to preserve lineage, and added a 4-step visual progress bar to job cards with retry buttons shown only for failed tasks (files under `frontend/src/hooks/*` and `frontend/src/components/JobQueue.tsx`).
- Kept polling fallback in `useTaskQueue` to call `GET /progress/{task_id}` periodically to prevent stale UI when websocket events are missed.

### Testing
- Built the frontend: ran `npm run build` in `frontend` and the build completed successfully.
- Verified Python modules compile: ran `python -m compileall sttEngine/http_api sttEngine/server` and compilation succeeded.
- Attempted an end-to-end UI screenshot via Playwright, but Chromium crashed (SIGSEGV) in this environment so no browser artifact could be captured; backend and frontend servers did start during local validation steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f263a9650832eab53a77d09790647)