### PR TITLE
Add unified /api/similarity-graph endpoint with sampling, node cap, and basic graph view wiring

### DIFF
--- a/frontend/graph-view.html
+++ b/frontend/graph-view.html
@@ -11,23 +11,25 @@
       #preview { padding: 12px 16px; border-top: 1px solid #2d3748; min-height: 92px; }
       .node { fill: #60a5fa; cursor: pointer; }
       .edge { stroke: #334155; stroke-width: 1.3; }
+      .hint { color: #94a3b8; font-size: 13px; }
       label { font-size: 14px; }
       input, button { background: #1f2937; color: white; border: 1px solid #374151; border-radius: 6px; padding: 6px; }
     </style>
   </head>
   <body>
     <header>
-      <label>threshold <input id="threshold" type="number" value="0.65" step="0.05" min="0" max="1"/></label>
+      <label>min similarity <input id="minSimilarity" type="number" value="0.65" step="0.05" min="0" max="1"/></label>
       <button id="reload">Reload Graph</button>
-      <span id="stats"></span>
+      <span id="stats" class="hint"></span>
     </header>
     <svg id="graph"></svg>
-    <div id="preview">노드를 클릭하면 문서 미리보기가 표시됩니다.</div>
+    <div id="preview">노드를 클릭하면 해당 문서 다운로드로 이동합니다.</div>
 
     <script>
       const svg = document.getElementById('graph');
       const preview = document.getElementById('preview');
       const stats = document.getElementById('stats');
+      const minSimilarityInput = document.getElementById('minSimilarity');
 
       function randomPos(max) { return 30 + Math.random() * Math.max(30, max - 60); }
 
@@ -51,7 +53,7 @@
           line.setAttribute('y1', s.y);
           line.setAttribute('x2', t.x);
           line.setAttribute('y2', t.y);
-          line.setAttribute('opacity', Math.max(0.2, edge.score));
+          line.setAttribute('opacity', Math.max(0.2, edge.weight || 0));
           svg.appendChild(line);
         });
 
@@ -62,28 +64,21 @@
           circle.setAttribute('cx', p.x);
           circle.setAttribute('cy', p.y);
           circle.setAttribute('r', 7);
-          circle.addEventListener('click', () => loadPreview(node.id));
+          circle.addEventListener('click', () => openDocument(node));
           svg.appendChild(circle);
         });
 
         stats.textContent = `nodes: ${data.nodes.length}, edges: ${data.edges.length}`;
       }
 
-      async function loadPreview(docId) {
-        const threshold = document.getElementById('threshold').value;
-        const resp = await fetch(`/api/similarity-graph/${encodeURIComponent(docId)}?threshold=${threshold}`);
-        const data = await resp.json();
-        if (!data.meta?.found) {
-          preview.textContent = '문서를 찾을 수 없습니다.';
-          return;
-        }
-        const center = data.nodes.find((n) => n.id === docId);
-        preview.innerHTML = `<b>${center?.label || docId}</b><br/>연결 문서 수: ${Math.max(0, data.nodes.length - 1)}<br/>파일: ${center?.file || '-'}`;
+      function openDocument(node) {
+        preview.innerHTML = `<b>${node.label || node.id}</b><br/>문서로 이동합니다...`;
+        window.location.href = `/download/${encodeURIComponent(node.id)}`;
       }
 
       async function loadGraph() {
-        const threshold = document.getElementById('threshold').value;
-        const resp = await fetch(`/api/similarity-graph?threshold=${threshold}`);
+        const minSimilarity = minSimilarityInput.value || '0.65';
+        const resp = await fetch(`/api/similarity-graph?min_similarity=${minSimilarity}&max_nodes=150&sampling=hybrid`);
         const data = await resp.json();
         renderGraph(data);
       }

--- a/sttEngine/http_api/handler.py
+++ b/sttEngine/http_api/handler.py
@@ -15,7 +15,6 @@ from ..vector_search import search as search_vectors
 from ..similarity_matrix import (
     get_documents_metadata,
     get_similarity_graph,
-    get_similarity_subgraph,
 )
 from ..ollama_utils import ensure_ollama_server
 from ..server.routes import history as history_route
@@ -429,25 +428,21 @@ class UploadHandler(BaseHTTPRequestHandler):
 
             parsed = urlparse(self.path)
             params = parse_qs(parsed.query)
-            threshold = float(params.get("threshold", ["0.65"])[0])
+            min_similarity = float(params.get("min_similarity", params.get("threshold", ["0.65"]))[0])
             max_neighbors = int(params.get("max_neighbors", ["12"])[0])
+            max_nodes = int(params.get("max_nodes", ["150"])[0])
+            sampling_strategy = (params.get("sampling", ["hybrid"])[0] or "hybrid").lower()
+            doc_id = (params.get("doc_id", [""])[0] or "").strip() or None
             refresh = params.get("refresh", ["false"])[0].lower() == "true"
 
-            base_path = parsed.path
-            if base_path == "/api/similarity-graph":
-                payload = get_similarity_graph(
-                    threshold=threshold,
-                    max_neighbors=max_neighbors,
-                    refresh=refresh,
-                )
-            else:
-                doc_id = unquote(base_path[len("/api/similarity-graph/"):])
-                payload = get_similarity_subgraph(
-                    doc_id=doc_id,
-                    threshold=threshold,
-                    max_neighbors=max_neighbors,
-                    refresh=refresh,
-                )
+            payload = get_similarity_graph(
+                min_similarity=min_similarity,
+                max_neighbors=max_neighbors,
+                max_nodes=max_nodes,
+                sampling_strategy=sampling_strategy,
+                doc_id=doc_id,
+                refresh=refresh,
+            )
 
             self.send_response(200)
             self.send_header("Content-Type", "application/json")

--- a/sttEngine/similarity_matrix.py
+++ b/sttEngine/similarity_matrix.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import threading
 import time
 from pathlib import Path
+import random
 from typing import Any
 
 import numpy as np
@@ -13,8 +14,13 @@ from .http_api.paths import BASE_DIR, normalize_record_path
 from .http_api.registry import load_file_registry
 
 _CACHE_LOCK = threading.Lock()
-_GRAPH_CACHE: dict[tuple[float, int], dict[str, Any]] = {}
-_SUBGRAPH_CACHE: dict[tuple[str, float, int], dict[str, Any]] = {}
+_GRAPH_CACHE: dict[tuple[float, int, int, str], dict[str, Any]] = {}
+
+DEFAULT_MIN_SIMILARITY = 0.65
+DEFAULT_MAX_NEIGHBORS = 12
+DEFAULT_MAX_NODES = 150
+DEFAULT_SAMPLING_STRATEGY = "hybrid"
+ALLOWED_SAMPLING_STRATEGIES = {"hybrid", "recent", "random"}
 
 
 def _cosine_similarity(vec_a: np.ndarray, vec_b: np.ndarray) -> float:
@@ -78,10 +84,71 @@ def _build_doc_catalog() -> list[dict[str, Any]]:
     return docs
 
 
-def _compute_graph(threshold: float = 0.65, max_neighbors: int = 12) -> dict[str, Any]:
+def _safe_timestamp(value: Any) -> float:
+    try:
+        if value is None:
+            return 0.0
+        return float(value)
+    except Exception:
+        return 0.0
+
+
+def _sample_docs(docs: list[dict[str, Any]], max_nodes: int, strategy: str) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    total_docs = len(docs)
+    if max_nodes <= 0 or total_docs <= max_nodes:
+        return docs, {
+            "strategy": strategy,
+            "total_before_sampling": total_docs,
+            "sampled": False,
+            "max_nodes": max_nodes,
+        }
+
+    if strategy == "recent":
+        sampled = sorted(docs, key=lambda item: _safe_timestamp(item.get("uploaded_at")), reverse=True)[:max_nodes]
+    elif strategy == "random":
+        rng = random.Random(42)
+        sampled = rng.sample(docs, max_nodes)
+    else:
+        recent_count = max(1, int(max_nodes * 0.7))
+        random_count = max_nodes - recent_count
+        sorted_recent = sorted(docs, key=lambda item: _safe_timestamp(item.get("uploaded_at")), reverse=True)
+        sampled = sorted_recent[:recent_count]
+        if random_count > 0:
+            remaining = sorted_recent[recent_count:]
+            if remaining:
+                rng = random.Random(42)
+                sampled.extend(rng.sample(remaining, min(random_count, len(remaining))))
+
+    sampled.sort(key=lambda item: item.get("display_name") or item["id"])
+    return sampled, {
+        "strategy": strategy,
+        "total_before_sampling": total_docs,
+        "sampled": True,
+        "max_nodes": max_nodes,
+        "total_after_sampling": len(sampled),
+    }
+
+
+def _compute_graph(
+    min_similarity: float = DEFAULT_MIN_SIMILARITY,
+    max_neighbors: int = DEFAULT_MAX_NEIGHBORS,
+    max_nodes: int = DEFAULT_MAX_NODES,
+    sampling_strategy: str = DEFAULT_SAMPLING_STRATEGY,
+) -> dict[str, Any]:
     docs = _build_doc_catalog()
+    docs, sampling_meta = _sample_docs(docs, max_nodes=max_nodes, strategy=sampling_strategy)
+
     if not docs:
-        return {"nodes": [], "edges": [], "meta": {"threshold": threshold, "count": 0, "generated_at": time.time()}}
+        return {
+            "nodes": [],
+            "edges": [],
+            "meta": {
+                "min_similarity": min_similarity,
+                "count": 0,
+                "generated_at": time.time(),
+                "sampling": sampling_meta,
+            },
+        }
 
     vectors: list[np.ndarray] = []
     valid_docs: list[dict[str, Any]] = []
@@ -94,7 +161,16 @@ def _compute_graph(threshold: float = 0.65, max_neighbors: int = 12) -> dict[str
 
     node_count = len(valid_docs)
     if node_count == 0:
-        return {"nodes": [], "edges": [], "meta": {"threshold": threshold, "count": 0, "generated_at": time.time()}}
+        return {
+            "nodes": [],
+            "edges": [],
+            "meta": {
+                "min_similarity": min_similarity,
+                "count": 0,
+                "generated_at": time.time(),
+                "sampling": sampling_meta,
+            },
+        }
 
     matrix = np.zeros((node_count, node_count), dtype=float)
     for i in range(node_count):
@@ -118,14 +194,14 @@ def _compute_graph(threshold: float = 0.65, max_neighbors: int = 12) -> dict[str
     edges: list[dict[str, Any]] = []
     for i in range(node_count):
         row = matrix[i]
-        candidate_idx = [j for j in np.argsort(row)[::-1] if j != i and row[j] >= threshold][:max_neighbors]
+        candidate_idx = [j for j in np.argsort(row)[::-1] if j != i and row[j] >= min_similarity][:max_neighbors]
         for j in candidate_idx:
             if i < j:
                 edges.append(
                     {
                         "source": valid_docs[i]["id"],
                         "target": valid_docs[j]["id"],
-                        "score": float(row[j]),
+                        "weight": float(row[j]),
                     }
                 )
 
@@ -133,8 +209,13 @@ def _compute_graph(threshold: float = 0.65, max_neighbors: int = 12) -> dict[str
         "nodes": nodes,
         "edges": edges,
         "meta": {
-            "threshold": threshold,
+            "node_schema": {"id": "string", "label": "string", "record_id": "string|null", "file": "string"},
+            "edge_schema": {"source": "string", "target": "string", "weight": "number"},
+            "min_similarity": min_similarity,
             "count": node_count,
+            "max_neighbors": max_neighbors,
+            "max_nodes": max_nodes,
+            "sampling": sampling_meta,
             "generated_at": time.time(),
         },
     }
@@ -143,31 +224,36 @@ def _compute_graph(threshold: float = 0.65, max_neighbors: int = 12) -> dict[str
 def invalidate_similarity_cache() -> None:
     with _CACHE_LOCK:
         _GRAPH_CACHE.clear()
-        _SUBGRAPH_CACHE.clear()
 
 
-def get_similarity_graph(threshold: float = 0.65, max_neighbors: int = 12, refresh: bool = False) -> dict[str, Any]:
-    key = (round(float(threshold), 4), int(max_neighbors))
+def get_similarity_graph(
+    min_similarity: float = DEFAULT_MIN_SIMILARITY,
+    max_neighbors: int = DEFAULT_MAX_NEIGHBORS,
+    max_nodes: int = DEFAULT_MAX_NODES,
+    sampling_strategy: str = DEFAULT_SAMPLING_STRATEGY,
+    doc_id: str | None = None,
+    refresh: bool = False,
+) -> dict[str, Any]:
+    strategy = sampling_strategy if sampling_strategy in ALLOWED_SAMPLING_STRATEGIES else DEFAULT_SAMPLING_STRATEGY
+    key = (round(float(min_similarity), 4), int(max_neighbors), int(max_nodes), strategy)
     with _CACHE_LOCK:
         if not refresh and key in _GRAPH_CACHE:
-            return _GRAPH_CACHE[key]
+            graph = _GRAPH_CACHE[key]
+        else:
+            graph = _compute_graph(
+                min_similarity=min_similarity,
+                max_neighbors=max_neighbors,
+                max_nodes=max_nodes,
+                sampling_strategy=strategy,
+            )
+            _GRAPH_CACHE[key] = graph
 
-    graph = _compute_graph(threshold=threshold, max_neighbors=max_neighbors)
-    with _CACHE_LOCK:
-        _GRAPH_CACHE[key] = graph
-    return graph
+    if not doc_id:
+        return graph
 
-
-def get_similarity_subgraph(doc_id: str, threshold: float = 0.65, max_neighbors: int = 12, refresh: bool = False) -> dict[str, Any]:
-    cache_key = (doc_id, round(float(threshold), 4), int(max_neighbors))
-    with _CACHE_LOCK:
-        if not refresh and cache_key in _SUBGRAPH_CACHE:
-            return _SUBGRAPH_CACHE[cache_key]
-
-    graph = get_similarity_graph(threshold=threshold, max_neighbors=max_neighbors, refresh=refresh)
     node_ids = {node["id"] for node in graph["nodes"]}
     if doc_id not in node_ids:
-        return {"nodes": [], "edges": [], "meta": {"doc_id": doc_id, "found": False}}
+        return {"nodes": [], "edges": [], "meta": {"doc_id": doc_id, "found": False, "min_similarity": min_similarity}}
 
     kept_ids = {doc_id}
     for edge in graph["edges"]:
@@ -189,12 +275,12 @@ def get_similarity_subgraph(doc_id: str, threshold: float = 0.65, max_neighbors:
         "meta": {
             "doc_id": doc_id,
             "found": True,
-            "threshold": threshold,
+            "min_similarity": min_similarity,
             "count": len(sub_nodes),
+            "node_schema": graph["meta"].get("node_schema"),
+            "edge_schema": graph["meta"].get("edge_schema"),
         },
     }
-    with _CACHE_LOCK:
-        _SUBGRAPH_CACHE[cache_key] = payload
     return payload
 
 


### PR DESCRIPTION
### Motivation
- Provide a single `/api/similarity-graph` endpoint that returns a document similarity graph (or per-doc subgraph) while preventing expensive full-graph generation on large datasets. 
- Standardize node/edge schema and surface a simple frontend integration so users can inspect and navigate to documents from the graph.

### Description
- Added query-driven single endpoint handling in `sttEngine/http_api/handler.py` that accepts `min_similarity` (falls back to legacy `threshold`), `max_neighbors`, `max_nodes`, `sampling` (`hybrid|recent|random`), optional `doc_id`, and `refresh` and forwards them into the graph generator via `get_similarity_graph`.
- Refactored `sttEngine/similarity_matrix.py` to: expose `get_similarity_graph(...)` supporting `min_similarity`, `max_neighbors`, `max_nodes`, and `sampling_strategy`; add deterministic sampling to limit node count (`DEFAULT_MAX_NODES = 150`) with `hybrid/recent/random` strategies; include sampling metadata in the response; and make cache keys include similarity/sampling options.
- Standardized graph payload schema: node objects contain `id`, `label`, `file`, `record_id`, `uploaded_at`, and edges use `weight` for similarity; `meta` includes `node_schema` and `edge_schema` plus sampling and generation metadata.
- Wired basic UI in `frontend/graph-view.html` to call the unified endpoint (`/api/similarity-graph?min_similarity=...&max_nodes=...&sampling=...`), render edges using `edge.weight`, and navigate to the document download URL on node click (`/download/<id>`).

### Testing
- Compiled modified modules with `python -m py_compile sttEngine/similarity_matrix.py sttEngine/http_api/handler.py` and the compilation succeeded.
- Executed `get_similarity_graph(min_similarity=0.7, max_nodes=10, sampling_strategy='random', refresh=True)` to validate runtime behavior and response shape, which returned a dict with `nodes`, `edges`, and `meta` keys.
- Launched a temporary static server (`python -m http.server 9000`) and used a Playwright script to load `frontend/graph-view.html` and capture a screenshot to verify UI wiring; the screenshot run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f281182c0832e95f13cdf4c6b2c34)