### PR TITLE
Fix startup scripts to avoid `sttEngine.server.__main__` error

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -234,7 +234,7 @@ echo ^(웹브라우저에서 http://localhost:8080 에 접속하세요^)
 echo.
 
 cd /d "%SCRIPT_DIR%"
-"%VENV_PYTHON%" -m sttEngine.server
+"%VENV_PYTHON%" "%WEB_SERVER%"
 set EXIT_CODE=!ERRORLEVEL!
 
 echo.

--- a/run.sh
+++ b/run.sh
@@ -193,7 +193,7 @@ echo "(웹브라우저에서 http://localhost:8080 에 접속하세요)"
 echo
 
 cd "$SCRIPT_DIR"
-"$VENV_PYTHON" -m sttEngine.server
+"$VENV_PYTHON" "$WEB_SERVER"
 EXIT_CODE=$?
 
 echo

--- a/sttEngine/run.bat
+++ b/sttEngine/run.bat
@@ -75,7 +75,7 @@ echo "서버 URL: http://localhost:8080"
 echo "(웹브라우저에서 http://localhost:8080 에 접속하세요)"
 echo.
 
-"%VENV_PYTHON%" -m sttEngine.server
+"%VENV_PYTHON%" "%WEB_SERVER%"
 
 echo.
 echo "서버가 종료되었습니다."


### PR DESCRIPTION
### Motivation
- Running `python -m sttEngine.server` collided with the `sttEngine/server/` package and produced `No module named sttEngine.server.__main__`, so the startup scripts need to invoke the actual `server.py` file directly.

### Description
- Changed root `run.sh`, root `run.bat`, and `sttEngine/run.bat` to run the `sttEngine/server.py` script directly via the virtualenv Python interpreter by invoking the `WEB_SERVER` path (use `"$VENV_PYTHON" "$WEB_SERVER"` / `"%VENV_PYTHON%" "%WEB_SERVER%"`).

### Testing
- Verified shell syntax with `bash -n run.sh` which returned OK.
- Confirmed the scripts now reference `WEB_SERVER` using `rg -n -- "WEB_SERVER" run.sh run.bat sttEngine/run.bat` and checks passed.
- Committed the changes and ensured the repository shows the three modified files in the commit (commit created successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f2f500854832e8c3ba569c64a302b)