### PR TITLE
Use Lucide Trash icon for 전체 초기화 (reset-all) button

### DIFF
--- a/frontend/src/components/HistoryPanel.tsx
+++ b/frontend/src/components/HistoryPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { FileAudio, FileText, Download, Trash2, Calendar, Search, Pencil, Check, X, Play, ChevronDown } from 'lucide-react';
+import { FileAudio, FileText, Download, Trash2, Trash, Calendar, Search, Pencil, Check, X, Play, ChevronDown } from 'lucide-react';
 import { Card } from './ui/card';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
@@ -123,7 +123,7 @@ export function HistoryPanel({ onViewContent, onShowSimilarDocs, onShowResetAll 
           <h2 className={`text-xl font-semibold ${theme === 'dark' ? 'text-white' : 'text-slate-900'}`}>업로드 기록</h2>
           <div className="flex items-center gap-2">
             <Button variant="outline" size="sm" onClick={handleProcessAll}><Play className="size-3 mr-1" /> 전체 진행</Button>
-            <Button variant="outline" size="sm" onClick={onShowResetAll}><Play className="size-3 mr-1" /> 전체 초기화</Button>
+            <Button variant="outline" size="sm" onClick={onShowResetAll}><Trash className="size-3 mr-1" /> 전체 초기화</Button>
             {selectedIds.size > 0 && <Button variant="outline" size="sm" onClick={handleDeleteSelected}><Trash2 className="size-3 mr-1" /> 삭제 ({selectedIds.size})</Button>}
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- The UI should use Lucide's `trash` icon for the global "전체 초기화" (reset-all) action to match iconography and the user's request. 

### Description
- Added `Trash` to the Lucide imports and replaced the `Play` icon with `<Trash />` for the `전체 초기화` button in `frontend/src/components/HistoryPanel.tsx`.

### Testing
- Built the frontend with `cd frontend && npm run build`, which completed successfully (Vite production build produced assets). 
- Launched the dev server with `npm run dev` and captured a Playwright screenshot to validate the updated icon in the History tab (visual smoke test succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f3cee65d4832e9edc4a9dcfe8d429)