### PR TITLE
교정 모델을 요약 모델 설정과 일치시킴

### DIFF
--- a/sttEngine/workflow/correct.py
+++ b/sttEngine/workflow/correct.py
@@ -21,15 +21,15 @@ from sttEngine.workflow.cli_utils import (
 )
 
 
-# 플랫폼별 기본 모델 설정 (.env 파일에서 로드)
+# 교정 모델은 요약 모델 설정과 동일한 값을 사용
 try:
-    DEFAULT_MODEL = get_model_for_task("CORRECT", get_default_model("CORRECT"))
+    DEFAULT_MODEL = get_model_for_task("SUMMARY", get_default_model("SUMMARY"))
 except:
-    # 환경변수 설정이 없을 때 기존 로직 사용
+    # 환경변수 설정이 없을 때 요약 모델 기본값 사용
     if platform.system() == "Windows":
         DEFAULT_MODEL = "gemma3:4b"
     else:
-        DEFAULT_MODEL = "gemma3:12b-it-qat"
+        DEFAULT_MODEL = "gpt-oss:20b"
 
 SYSTEM_PROMPT = (
     "당신은 한국어 텍스트를 전문적으로 교정하는 편집자입니다. "


### PR DESCRIPTION
### Motivation
- 교정 단계가 특정 모델로 하드코딩되어 요약에서 선택한 모델과 불일치해 발생하던 모델 통신 오류를 방지하기 위해 교정도 요약 모델 설정을 재사용하도록 변경했습니다.

### Description
- `sttEngine/workflow/correct.py`에서 기본 모델을 `get_model_for_task("SUMMARY", get_default_model("SUMMARY"))`로 가져오도록 변경했고, 환경변수 미설정 시의 fallback도 요약 기본값(`Windows: gemma3:4b`, `Unix: gpt-oss:20b`)을 사용하도록 수정했습니다.

### Testing
- `python -m py_compile sttEngine/workflow/correct.py sttEngine/workflow/summarize.py sttEngine/http_api/workflow.py`를 실행하여 파이썬 문법 검사를 통과했음을 확인했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f3fd799c0832eb26f9b121b00a482)