### PR TITLE
Refactor HTTP handler by route domain modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
   - `ThreadingHTTPServer` + `UploadHandler`
   - WebSocket 서버는 별도 스레드에서 실행 (`sttEngine/http_api/ws.py`, 포트 `8765`)
 - 런처 래퍼: `sttEngine/server.py` (`python -m sttEngine.server`)
-- 핵심 HTTP 라우팅: `sttEngine/http_api/handler.py`
+- 핵심 HTTP 라우팅: `sttEngine/http_api/handler.py` + 라우트 모듈(`sttEngine/http_api/routes/*`)
 - 워크플로우 실행: `sttEngine/http_api/workflow.py`
 - 프론트엔드: React + Vite (`frontend/src/*`)
 - 레거시 UI: `frontend/legacy/*` (프론트 빌드 실패 시 fallback)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ RecordRoute는 음성/문서 입력을 STT, 교정, 요약, 임베딩 검색으�
 
 ## 현재 아키텍처
 - HTTP 서버 엔트리: `sttEngine/http_api/app.py`
-- 핸들러/라우팅: `sttEngine/http_api/handler.py`
+- 핸들러/라우팅: `sttEngine/http_api/handler.py`, `sttEngine/http_api/routes/*`
 - 워크플로우 실행: `sttEngine/http_api/workflow.py`
 - WebSocket 서버: `sttEngine/http_api/ws.py` (`ws://localhost:8765`)
 - 서버 실행 래퍼: `sttEngine/server.py` (`python -m sttEngine.server`)

--- a/sttEngine/http_api/handler.py
+++ b/sttEngine/http_api/handler.py
@@ -10,18 +10,13 @@ from http.server import BaseHTTPRequestHandler
 from pathlib import Path
 from urllib.parse import unquote
 
-from ..search_cache import cleanup_expired_cache, delete_cache_record, get_cache_stats
+from ..search_cache import delete_cache_record
 from ..vector_search import search as search_vectors
-from ..similarity_matrix import (
-    get_documents_metadata,
-    get_similarity_graph,
-)
 from ..ollama_utils import ensure_ollama_server
 from ..server.routes import history as history_route
 from ..server.routes import process as process_route
 from ..server.routes import progress as progress_route
 
-from .embedding import run_incremental_embedding
 from .history import (
     add_upload_record,
     compute_file_hash,
@@ -29,27 +24,16 @@ from .history import (
     load_upload_history,
 )
 from .paths import BASE_DIR, OUTPUT_DIR, UPLOAD_DIR, normalize_record_path, resolve_record_path, to_record_path
-from .records import (
-    delete_file,
-    delete_records,
-    reset_summary_and_embedding,
-    reset_tasks_for_all_records,
-    reset_upload_record,
-    update_stt_text,
-)
-from .registry import get_file_by_uuid, load_file_registry, update_filename
+from .registry import get_file_by_uuid, load_file_registry
 from .search import (
     build_highlight_snippet,
     collect_keyword_matches,
     collect_searchable_documents,
     get_document_text,
 )
-from .state import cancel_task, get_running_tasks
-from .workflow import (
-    find_existing_stt_file,
-    get_audio_duration,
-    get_file_type,
-)
+from .state import get_running_tasks
+from .workflow import get_audio_duration, get_file_type
+from .routes import admin_routes, management_routes, records_routes, search_routes, similarity_routes
 
 
 class UploadHandler(BaseHTTPRequestHandler):
@@ -196,273 +180,17 @@ class UploadHandler(BaseHTTPRequestHandler):
             self._serve_download(file_identifier)
         elif self.path == "/history":
             history_route.handle(self)
-        elif self.path == "/tasks":
-            self._serve_running_tasks()
         elif self.path.startswith("/progress/"):
             task_id = self.path[len("/progress/") :]
             progress_route.handle(self, task_id)
-        elif self.path.startswith("/file_search"):
-            from urllib.parse import parse_qs, urlparse
-
-            parsed = urlparse(self.path)
-            params = parse_qs(parsed.query)
-            query = params.get("q", [""])[0].lower()
-
-            results = []
-            if query:
-                history = get_active_history()
-                for record in history:
-                    filename = record.get("filename", "")
-                    tags = record.get("tags", [])
-                    if query in filename.lower() or any(query in t.lower() for t in tags):
-                        results.append({"id": record.get("id"), "filename": filename, "tags": tags})
-
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps(results, ensure_ascii=False).encode())
-        elif self.path.startswith("/search"):
-            from urllib.parse import parse_qs, urlparse
-
-            parsed = urlparse(self.path)
-            params = parse_qs(parsed.query)
-
-            def _first(name: str, default=None):
-                return params.get(name, [default])[0]
-
-            def _csv(name: str) -> set[str]:
-                raw = _first(name, "") or ""
-                return {token.strip().lower() for token in raw.split(",") if token.strip()}
-
-            query = (_first("query") or _first("q") or "").strip()
-            limit_raw = _first("limit")
-            start_date = _first("start_date") or _first("start")
-            end_date = _first("end_date") or _first("end")
-            sort_by = (_first("sort_by", "similarity") or "similarity").lower()
-            sort_order = (_first("sort_order", "desc") or "desc").lower()
-            min_score_raw = _first("min_score")
-            page_raw = _first("page", "1")
-            page_size_raw = _first("page_size", "5")
-            include_timing_raw = _first("include_timing", "false")
-            file_types = _csv("file_type")
-            status_filter = (_first("status") or "").strip().lower()
-            status_task = (_first("status_task") or "stt").strip().lower()
-
-            include_timing = str(include_timing_raw).lower() in {"1", "true", "yes", "y", "on"}
-
-            min_score = None
-            if min_score_raw not in (None, ""):
-                try:
-                    min_score = float(min_score_raw)
-                except ValueError:
-                    min_score = None
-
-            try:
-                page = max(1, int(page_raw))
-            except (TypeError, ValueError):
-                page = 1
-
-            try:
-                page_size = max(1, int(page_size_raw))
-            except (TypeError, ValueError):
-                page_size = 5
-
-            try:
-                limit = int(limit_raw) if limit_raw not in (None, "") else max(10, page * page_size)
-                limit = max(1, limit)
-            except (TypeError, ValueError):
-                limit = max(10, page * page_size)
-
-            try:
-                filter_signature = json.dumps({
-                    "file_type": sorted(file_types),
-                    "status": status_filter,
-                    "status_task": status_task,
-                }, ensure_ascii=False, sort_keys=True)
-
-                response_data = {
-                    "query": query,
-                    "limit": limit,
-                    "keywordMatches": [],
-                    "similarDocuments": [],
-                    "sort": {"by": sort_by, "order": sort_order},
-                    "filters": {
-                        "start_date": start_date,
-                        "end_date": end_date,
-                        "min_score": min_score,
-                        "file_type": sorted(file_types),
-                        "status": status_filter or None,
-                        "status_task": status_task or None,
-                    },
-                    "pagination": {"page": page, "pageSize": page_size, "returned": 0, "hasNext": False},
-                    "scoreBreakdown": {"keywordWeight": 0.0, "vectorWeight": 1.0},
-                }
-
-                if query:
-                    documents, path_index = collect_searchable_documents()
-                    history = get_active_history()
-                    history_map = {record.get("id"): record for record in history}
-
-                    def _record_passes(record: dict) -> bool:
-                        if file_types and str(record.get("file_type", "")).lower() not in file_types:
-                            return False
-                        if status_filter:
-                            completed = bool((record.get("completed_tasks") or {}).get(status_task, False))
-                            if status_filter in {"completed", "done", "success"} and not completed:
-                                return False
-                            if status_filter in {"pending", "incomplete", "todo"} and completed:
-                                return False
-                        return True
-
-                    filtered_documents = [
-                        doc for doc in documents
-                        if _record_passes(history_map.get(doc["info"].get("record_id"), {}))
-                    ]
-
-                    keyword_matches = collect_keyword_matches(query, filtered_documents, history_map, limit=limit)
-                    response_data["keywordMatches"] = keyword_matches
-
-                    keyword_paths = {item["file"] for item in keyword_matches}
-                    keyword_uuids = {item["file_uuid"] for item in keyword_matches}
-
-                    search_payload = search_vectors(
-                        query,
-                        BASE_DIR,
-                        top_k=limit,
-                        start_date=start_date,
-                        end_date=end_date,
-                        sort_by=sort_by,
-                        sort_order=sort_order,
-                        min_score=min_score,
-                        page=page,
-                        page_size=page_size,
-                        include_timing=include_timing,
-                        filter_signature=filter_signature,
-                    )
-
-                    if isinstance(search_payload, dict):
-                        hits = search_payload.get("results", [])
-                        if include_timing:
-                            response_data["timing"] = search_payload.get("timing", {})
-                            response_data["cache"] = {"hit": bool(search_payload.get("cache_hit"))}
-                        response_data["pagination"]["hasNext"] = bool(search_payload.get("total_candidates", 0) > page * page_size)
-                    else:
-                        hits = search_payload
-                        response_data["pagination"]["hasNext"] = len(hits) >= page_size
-
-                    similar_documents = []
-                    for hit in hits:
-                        rel_path = hit.get("file")
-                        if not rel_path:
-                            continue
-
-                        doc = path_index.get(rel_path)
-                        if doc and (doc["uuid"] in keyword_uuids or rel_path in keyword_paths):
-                            continue
-                        if not doc and rel_path in keyword_paths:
-                            continue
-
-                        display_name = Path(rel_path).name
-                        link = f"/download/{rel_path}"
-                        uploaded_at = hit.get("uploaded_at")
-                        source_filename = None
-                        file_uuid = None
-                        record_id = None
-                        snippet = ""
-
-                        if doc:
-                            record = history_map.get(doc["info"].get("record_id"), {})
-                            if not _record_passes(record):
-                                continue
-                            record_id = doc["info"].get("record_id")
-                            uploaded_at = record.get("timestamp") or uploaded_at
-                            source_filename = record.get("filename")
-                            display_name = doc["info"].get("original_filename") or display_name
-                            link = f"/download/{doc['uuid']}"
-                            file_uuid = doc["uuid"]
-                            try:
-                                snippet = build_highlight_snippet(get_document_text(doc["full_path"]), query)
-                            except Exception:
-                                snippet = ""
-
-                        similar_documents.append(
-                            {
-                                "file_uuid": file_uuid,
-                                "file": rel_path,
-                                "display_name": display_name,
-                                "score": hit.get("score"),
-                                "snippet": snippet,
-                                "score_breakdown": {
-                                    "vector_similarity": hit.get("score"),
-                                    "keyword_overlap": 0.0,
-                                    "composite": hit.get("score"),
-                                },
-                                "uploaded_at": uploaded_at,
-                                "source_filename": source_filename,
-                                "record_id": record_id,
-                                "link": link,
-                            }
-                        )
-
-                    response_data["similarDocuments"] = similar_documents
-                    response_data["pagination"]["returned"] = len(similar_documents)
-                    response_data["contract_version"] = "search-v2"
-
-                self.send_response(200)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(json.dumps(response_data, ensure_ascii=False).encode())
-
-            except Exception as e:
-                print(f"검색 요청 처리 중 오류: {e}")
-                self.send_response(500)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                error_response = {
-                    "error": "검색 중 오류가 발생했습니다. Ollama 서버가 실행 중인지 확인하고, 임베딩 모델이 설치되어 있는지 확인해주세요.",
-                    "details": str(e),
-                }
-                self.wfile.write(json.dumps(error_response, ensure_ascii=False).encode())
-        elif self.path.startswith("/api/similarity-graph"):
-            from urllib.parse import parse_qs, urlparse
-
-            parsed = urlparse(self.path)
-            params = parse_qs(parsed.query)
-            min_similarity = float(params.get("min_similarity", params.get("threshold", ["0.65"]))[0])
-            max_neighbors = int(params.get("max_neighbors", ["12"])[0])
-            max_nodes = int(params.get("max_nodes", ["150"])[0])
-            sampling_strategy = (params.get("sampling", ["hybrid"])[0] or "hybrid").lower()
-            doc_id = (params.get("doc_id", [""])[0] or "").strip() or None
-            refresh = params.get("refresh", ["false"])[0].lower() == "true"
-
-            payload = get_similarity_graph(
-                min_similarity=min_similarity,
-                max_neighbors=max_neighbors,
-                max_nodes=max_nodes,
-                sampling_strategy=sampling_strategy,
-                doc_id=doc_id,
-                refresh=refresh,
-            )
-
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps(payload, ensure_ascii=False).encode())
-        elif self.path.startswith("/api/documents/metadata"):
-            payload = get_documents_metadata()
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps(payload, ensure_ascii=False).encode())
-        elif self.path.startswith("/similar/"):
-            file_identifier = unquote(self.path[len("/similar/") :])
-            self._serve_similar_documents(file_identifier)
-        elif self.path == "/models":
-            self._serve_available_models()
-        elif self.path == "/cache/stats":
-            self._serve_cache_stats()
-        elif self.path == "/cache/cleanup":
-            self._serve_cache_cleanup()
+        elif management_routes.handle_get(self):
+            return
+        elif search_routes.handle_get(self):
+            return
+        elif similarity_routes.handle_get(self):
+            return
+        elif admin_routes.handle_get(self):
+            return
         else:
             self.send_response(404)
             self.end_headers()
@@ -981,339 +709,18 @@ class UploadHandler(BaseHTTPRequestHandler):
             process_route.handle(self)
             return
 
-        if self.path == "/cancel":
-            length = int(self.headers.get("Content-Length", 0))
-            try:
-                payload = json.loads(self.rfile.read(length)) if length else {}
-            except json.JSONDecodeError:
-                self.send_response(400)
-                self.end_headers()
-                self.wfile.write(b"Invalid JSON payload")
-                return
-            task_id = payload.get("task_id")
-            if not task_id:
-                self.send_response(400)
-                self.end_headers()
-                self.wfile.write(b"Missing task_id")
-                return
-
-            success = cancel_task(task_id)
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps({"success": success}).encode())
+        if management_routes.handle_post(self):
             return
 
-        if self.path == "/shutdown":
-            print("Shutdown request received via /shutdown endpoint")
-            response_data = {
-                "success": True,
-                "message": "서버 종료 요청이 접수되었습니다. 잠시 후 서버가 종료됩니다.",
-            }
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps(response_data, ensure_ascii=False).encode())
-            self._schedule_server_shutdown()
-            self.close_connection = True
+        if records_routes.handle_post(self):
             return
 
-        if self.path == "/reset":
-            length = int(self.headers.get("Content-Length", 0))
-            try:
-                payload = json.loads(self.rfile.read(length)) if length else {}
-            except json.JSONDecodeError:
-                self.send_response(400)
-                self.end_headers()
-                self.wfile.write(b"Invalid JSON payload")
-                return
-            record_id = payload.get("record_id")
-            if not record_id:
-                self.send_response(400)
-                self.end_headers()
-                self.wfile.write(b"Missing record_id")
-                return
-
-            success = reset_upload_record(record_id)
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps({"success": success}).encode())
+        if similarity_routes.handle_post(self):
             return
 
-        if self.path == "/update_filename":
-            length = int(self.headers.get("Content-Length", 0))
-            try:
-                payload = json.loads(self.rfile.read(length)) if length else {}
-            except json.JSONDecodeError:
-                self.send_response(400)
-                self.end_headers()
-                self.wfile.write(b"Invalid JSON payload")
-                return
-            record_id = payload.get("record_id")
-            new_filename = payload.get("filename")
-
-            if not record_id or not new_filename:
-                self.send_response(400)
-                self.end_headers()
-                self.wfile.write(b"Missing record_id or filename")
-                return
-
-            update_filename(record_id, new_filename)
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps({"success": True}).encode())
-            return
-
-        if self.path == "/incremental_embedding":
-            try:
-                processed_count = run_incremental_embedding()
-                self.send_response(200)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(
-                    json.dumps(
-                        {
-                            "success": True,
-                            "processed_count": processed_count,
-                            "message": f"증분 임베딩 완료: {processed_count}개 파일 처리됨",
-                        }
-                    ).encode()
-                )
-            except Exception as e:
-                self.send_response(500)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(json.dumps({"success": False, "error": str(e)}).encode())
-            return
-
-        if self.path == "/check_existing_stt":
-            length = int(self.headers.get("Content-Length", 0))
-            try:
-                payload = json.loads(self.rfile.read(length)) if length else {}
-            except json.JSONDecodeError:
-                self.send_response(400)
-                self.end_headers()
-                self.wfile.write(b"Invalid JSON payload")
-                return
-
-            file_path = payload.get("file_path")
-            if not file_path:
-                self.send_response(400)
-                self.end_headers()
-                self.wfile.write(b"Missing file_path")
-                return
-
-            try:
-                normalized_path = normalize_record_path(file_path)
-                original_file = resolve_record_path(normalized_path)
-                existing_stt = find_existing_stt_file(original_file)
-
-                self.send_response(200)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(
-                    json.dumps(
-                        {
-                            "has_stt": existing_stt is not None,
-                            "stt_file": to_record_path(existing_stt) if existing_stt else None,
-                        }
-                    ).encode()
-                )
-            except Exception as e:
-                self.send_response(500)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(json.dumps({"has_stt": False, "error": str(e)}).encode())
-            return
-
-        if self.path == "/update_stt_text":
-            length = int(self.headers.get("Content-Length", 0))
-            try:
-                payload = json.loads(self.rfile.read(length)) if length else {}
-            except json.JSONDecodeError:
-                self.send_response(400)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(json.dumps({"success": False, "error": "Invalid JSON payload"}).encode())
-                return
-
-            file_identifier = payload.get("file_identifier")
-            content = payload.get("content", "")
-            if not isinstance(content, str):
-                content = str(content)
-
-            success, message, record_id = update_stt_text(file_identifier, content)
-            if success:
-                self.send_response(200)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(json.dumps({"success": True, "record_id": record_id}).encode())
-            else:
-                self.send_response(400)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(
-                    json.dumps({"success": False, "error": message, "record_id": record_id}).encode()
-                )
-            return
-
-        if self.path == "/reset_summary_embedding":
-            length = int(self.headers.get("Content-Length", 0))
-            try:
-                payload = json.loads(self.rfile.read(length)) if length else {}
-            except json.JSONDecodeError:
-                self.send_response(400)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(json.dumps({"success": False, "error": "Invalid JSON payload"}).encode())
-                return
-
-            record_id = payload.get("record_id")
-            success, message = reset_summary_and_embedding(record_id)
-            status_code = 200 if success else 400
-            self.send_response(status_code)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps({"success": success, "message": message}).encode())
-            return
-
-        if self.path == "/reset_all_tasks":
-            length = int(self.headers.get("Content-Length", 0))
-            try:
-                payload = json.loads(self.rfile.read(length)) if length else {}
-            except json.JSONDecodeError:
-                self.send_response(400)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(json.dumps({"success": False, "error": "Invalid JSON payload"}).encode())
-                return
-
-            tasks = payload.get("tasks")
-            if not isinstance(tasks, list):
-                self.send_response(400)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(json.dumps({"success": False, "error": "tasks 필드는 배열이어야 합니다."}).encode())
-                return
-
-            success, counts, message = reset_tasks_for_all_records(set(tasks))
-            status_code = 200 if success else 400
-            self.send_response(status_code)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps({"success": success, "message": message, "counts": counts}).encode())
-            return
-
-        if self.path == "/similar":
-            length = int(self.headers.get("Content-Length", 0))
-            try:
-                payload = json.loads(self.rfile.read(length)) if length else {}
-            except json.JSONDecodeError:
-                self.send_response(400)
-                self.end_headers()
-                self.wfile.write(b"Invalid JSON payload")
-                return
-
-            file_identifier = payload.get("file_identifier")
-            user_filename = payload.get("user_filename")
-            refresh = payload.get("refresh", False)
-
-            if not file_identifier:
-                self.send_response(400)
-                self.end_headers()
-                self.wfile.write(b"Missing file_identifier")
-                return
-
-            self._serve_similar_documents_with_filename(file_identifier, user_filename, refresh)
-            return
-
-        if self.path == "/delete":
-            length = int(self.headers.get("Content-Length", 0))
-            try:
-                payload = json.loads(self.rfile.read(length)) if length else {}
-            except json.JSONDecodeError:
-                self.send_response(400)
-                self.end_headers()
-                self.wfile.write(b"Invalid JSON payload")
-                return
-
-            file_identifier = payload.get("file_identifier")
-            file_type = payload.get("file_type")
-            if not file_identifier or not file_type:
-                self.send_response(400)
-                self.end_headers()
-                self.wfile.write(b"Missing file_identifier or file_type")
-                return
-
-            success, error_msg = delete_file(file_identifier, file_type)
-            if success:
-                self.send_response(200)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(json.dumps({"success": True}).encode())
-            else:
-                self.send_response(400)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(json.dumps({"error": error_msg}).encode())
-            return
-
-        if self.path == "/delete_records":
-            length = int(self.headers.get("Content-Length", 0))
-            try:
-                payload = json.loads(self.rfile.read(length)) if length else {}
-            except json.JSONDecodeError:
-                self.send_response(400)
-                self.end_headers()
-                self.wfile.write(b"Invalid JSON payload")
-                return
-
-            record_ids = payload.get("record_ids")
-            if not isinstance(record_ids, list):
-                self.send_response(400)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(json.dumps({"success": False, "error": "record_ids 필드는 배열이어야 합니다."}).encode())
-                return
-
-            success, results = delete_records([str(r) for r in record_ids])
-            status_code = 200 if success else 207
-            self.send_response(status_code)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps({"success": success, "results": results}, ensure_ascii=False).encode())
+        if admin_routes.handle_post(self):
             return
 
         self.send_response(404)
         self.end_headers()
 
-    def _serve_cache_stats(self):
-        try:
-            stats = get_cache_stats()
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps(stats, ensure_ascii=False).encode())
-        except Exception as e:
-            self.send_response(500)
-            self.end_headers()
-            self.wfile.write(f"Error getting cache stats: {str(e)}".encode())
-
-    def _serve_cache_cleanup(self):
-        try:
-            cleaned_count = cleanup_expired_cache()
-            response = {
-                "success": True,
-                "cleaned_entries": cleaned_count,
-                "message": f"정리된 만료된 캐시 항목: {cleaned_count}개",
-            }
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps(response, ensure_ascii=False).encode())
-        except Exception as e:
-            self.send_response(500)
-            self.end_headers()
-            self.wfile.write(json.dumps({"success": False, "error": f"캐시 정리 중 오류: {str(e)}"}, ensure_ascii=False).encode())

--- a/sttEngine/http_api/routes/__init__.py
+++ b/sttEngine/http_api/routes/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP route modules for UploadHandler."""

--- a/sttEngine/http_api/routes/admin_routes.py
+++ b/sttEngine/http_api/routes/admin_routes.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+
+
+def handle_get(handler) -> bool:
+    if handler.path == '/models':
+        handler._serve_available_models()
+        return True
+    return False
+
+
+def handle_post(handler) -> bool:
+    if handler.path != '/shutdown':
+        return False
+
+    print('Shutdown request received via /shutdown endpoint')
+    response_data = {
+        'success': True,
+        'message': '서버 종료 요청이 접수되었습니다. 잠시 후 서버가 종료됩니다.',
+    }
+    handler.send_response(200)
+    handler.send_header('Content-Type', 'application/json')
+    handler.end_headers()
+    handler.wfile.write(json.dumps(response_data, ensure_ascii=False).encode())
+    handler._schedule_server_shutdown()
+    handler.close_connection = True
+    return True

--- a/sttEngine/http_api/routes/management_routes.py
+++ b/sttEngine/http_api/routes/management_routes.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+
+from ...search_cache import cleanup_expired_cache, get_cache_stats
+from ..embedding import run_incremental_embedding
+from ..records import reset_tasks_for_all_records, reset_upload_record
+from ..state import cancel_task
+
+
+def _read_json_payload(handler):
+    length = int(handler.headers.get('Content-Length', 0))
+    return json.loads(handler.rfile.read(length)) if length else {}
+
+
+def handle_get(handler) -> bool:
+    if handler.path == '/tasks':
+        handler._serve_running_tasks()
+        return True
+
+    if handler.path == '/cache/stats':
+        try:
+            stats = get_cache_stats()
+            handler.send_response(200)
+            handler.send_header('Content-Type', 'application/json')
+            handler.end_headers()
+            handler.wfile.write(json.dumps(stats, ensure_ascii=False).encode())
+        except Exception as e:
+            handler.send_response(500)
+            handler.end_headers()
+            handler.wfile.write(f'Error getting cache stats: {str(e)}'.encode())
+        return True
+
+    if handler.path == '/cache/cleanup':
+        try:
+            cleaned_count = cleanup_expired_cache()
+            response = {
+                'success': True,
+                'cleaned_entries': cleaned_count,
+                'message': f'정리된 만료된 캐시 항목: {cleaned_count}개',
+            }
+            handler.send_response(200)
+            handler.send_header('Content-Type', 'application/json')
+            handler.end_headers()
+            handler.wfile.write(json.dumps(response, ensure_ascii=False).encode())
+        except Exception as e:
+            handler.send_response(500)
+            handler.end_headers()
+            handler.wfile.write(
+                json.dumps({'success': False, 'error': f'캐시 정리 중 오류: {str(e)}'}, ensure_ascii=False).encode()
+            )
+        return True
+
+    return False
+
+
+def handle_post(handler) -> bool:
+    if handler.path == '/cancel':
+        try:
+            payload = _read_json_payload(handler)
+        except json.JSONDecodeError:
+            handler.send_response(400)
+            handler.end_headers()
+            handler.wfile.write(b'Invalid JSON payload')
+            return True
+        task_id = payload.get('task_id')
+        if not task_id:
+            handler.send_response(400)
+            handler.end_headers()
+            handler.wfile.write(b'Missing task_id')
+            return True
+
+        success = cancel_task(task_id)
+        handler.send_response(200)
+        handler.send_header('Content-Type', 'application/json')
+        handler.end_headers()
+        handler.wfile.write(json.dumps({'success': success}).encode())
+        return True
+
+    if handler.path == '/reset':
+        try:
+            payload = _read_json_payload(handler)
+        except json.JSONDecodeError:
+            handler.send_response(400)
+            handler.end_headers()
+            handler.wfile.write(b'Invalid JSON payload')
+            return True
+        record_id = payload.get('record_id')
+        if not record_id:
+            handler.send_response(400)
+            handler.end_headers()
+            handler.wfile.write(b'Missing record_id')
+            return True
+
+        success = reset_upload_record(record_id)
+        handler.send_response(200)
+        handler.send_header('Content-Type', 'application/json')
+        handler.end_headers()
+        handler.wfile.write(json.dumps({'success': success}).encode())
+        return True
+
+    if handler.path == '/incremental_embedding':
+        try:
+            processed_count = run_incremental_embedding()
+            handler.send_response(200)
+            handler.send_header('Content-Type', 'application/json')
+            handler.end_headers()
+            handler.wfile.write(
+                json.dumps(
+                    {
+                        'success': True,
+                        'processed_count': processed_count,
+                        'message': f'증분 임베딩 완료: {processed_count}개 파일 처리됨',
+                    }
+                ).encode()
+            )
+        except Exception as e:
+            handler.send_response(500)
+            handler.send_header('Content-Type', 'application/json')
+            handler.end_headers()
+            handler.wfile.write(json.dumps({'success': False, 'error': str(e)}).encode())
+        return True
+
+    if handler.path == '/reset_all_tasks':
+        try:
+            payload = _read_json_payload(handler)
+        except json.JSONDecodeError:
+            handler.send_response(400)
+            handler.send_header('Content-Type', 'application/json')
+            handler.end_headers()
+            handler.wfile.write(json.dumps({'success': False, 'error': 'Invalid JSON payload'}).encode())
+            return True
+
+        tasks = payload.get('tasks')
+        if not isinstance(tasks, list):
+            handler.send_response(400)
+            handler.send_header('Content-Type', 'application/json')
+            handler.end_headers()
+            handler.wfile.write(json.dumps({'success': False, 'error': 'tasks 필드는 배열이어야 합니다.'}).encode())
+            return True
+
+        success, counts, message = reset_tasks_for_all_records(set(tasks))
+        status_code = 200 if success else 400
+        handler.send_response(status_code)
+        handler.send_header('Content-Type', 'application/json')
+        handler.end_headers()
+        handler.wfile.write(json.dumps({'success': success, 'message': message, 'counts': counts}).encode())
+        return True
+
+    return False

--- a/sttEngine/http_api/routes/records_routes.py
+++ b/sttEngine/http_api/routes/records_routes.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+
+from ..paths import normalize_record_path, resolve_record_path, to_record_path
+from ..records import delete_file, delete_records, reset_summary_and_embedding, update_stt_text
+from ..registry import update_filename
+from ..workflow import find_existing_stt_file
+
+
+def _read_json_payload(handler):
+    length = int(handler.headers.get('Content-Length', 0))
+    return json.loads(handler.rfile.read(length)) if length else {}
+
+
+def handle_post(handler) -> bool:
+    if handler.path == '/update_filename':
+        try:
+            payload = _read_json_payload(handler)
+        except json.JSONDecodeError:
+            handler.send_response(400)
+            handler.end_headers()
+            handler.wfile.write(b'Invalid JSON payload')
+            return True
+
+        record_id = payload.get('record_id')
+        new_filename = payload.get('filename')
+
+        if not record_id or not new_filename:
+            handler.send_response(400)
+            handler.end_headers()
+            handler.wfile.write(b'Missing record_id or filename')
+            return True
+
+        update_filename(record_id, new_filename)
+        handler.send_response(200)
+        handler.send_header('Content-Type', 'application/json')
+        handler.end_headers()
+        handler.wfile.write(json.dumps({'success': True}).encode())
+        return True
+
+    if handler.path == '/check_existing_stt':
+        try:
+            payload = _read_json_payload(handler)
+        except json.JSONDecodeError:
+            handler.send_response(400)
+            handler.end_headers()
+            handler.wfile.write(b'Invalid JSON payload')
+            return True
+
+        file_path = payload.get('file_path')
+        if not file_path:
+            handler.send_response(400)
+            handler.end_headers()
+            handler.wfile.write(b'Missing file_path')
+            return True
+
+        try:
+            normalized_path = normalize_record_path(file_path)
+            original_file = resolve_record_path(normalized_path)
+            existing_stt = find_existing_stt_file(original_file)
+
+            handler.send_response(200)
+            handler.send_header('Content-Type', 'application/json')
+            handler.end_headers()
+            handler.wfile.write(
+                json.dumps(
+                    {
+                        'has_stt': existing_stt is not None,
+                        'stt_file': to_record_path(existing_stt) if existing_stt else None,
+                    }
+                ).encode()
+            )
+        except Exception as e:
+            handler.send_response(500)
+            handler.send_header('Content-Type', 'application/json')
+            handler.end_headers()
+            handler.wfile.write(json.dumps({'has_stt': False, 'error': str(e)}).encode())
+        return True
+
+    if handler.path == '/update_stt_text':
+        try:
+            payload = _read_json_payload(handler)
+        except json.JSONDecodeError:
+            handler.send_response(400)
+            handler.send_header('Content-Type', 'application/json')
+            handler.end_headers()
+            handler.wfile.write(json.dumps({'success': False, 'error': 'Invalid JSON payload'}).encode())
+            return True
+
+        file_identifier = payload.get('file_identifier')
+        content = payload.get('content', '')
+        if not isinstance(content, str):
+            content = str(content)
+
+        success, message, record_id = update_stt_text(file_identifier, content)
+        if success:
+            handler.send_response(200)
+            handler.send_header('Content-Type', 'application/json')
+            handler.end_headers()
+            handler.wfile.write(json.dumps({'success': True, 'record_id': record_id}).encode())
+        else:
+            handler.send_response(400)
+            handler.send_header('Content-Type', 'application/json')
+            handler.end_headers()
+            handler.wfile.write(json.dumps({'success': False, 'error': message, 'record_id': record_id}).encode())
+        return True
+
+    if handler.path == '/reset_summary_embedding':
+        try:
+            payload = _read_json_payload(handler)
+        except json.JSONDecodeError:
+            handler.send_response(400)
+            handler.send_header('Content-Type', 'application/json')
+            handler.end_headers()
+            handler.wfile.write(json.dumps({'success': False, 'error': 'Invalid JSON payload'}).encode())
+            return True
+
+        record_id = payload.get('record_id')
+        success, message = reset_summary_and_embedding(record_id)
+        status_code = 200 if success else 400
+        handler.send_response(status_code)
+        handler.send_header('Content-Type', 'application/json')
+        handler.end_headers()
+        handler.wfile.write(json.dumps({'success': success, 'message': message}).encode())
+        return True
+
+    if handler.path == '/delete':
+        try:
+            payload = _read_json_payload(handler)
+        except json.JSONDecodeError:
+            handler.send_response(400)
+            handler.end_headers()
+            handler.wfile.write(b'Invalid JSON payload')
+            return True
+
+        file_identifier = payload.get('file_identifier')
+        file_type = payload.get('file_type')
+        if not file_identifier or not file_type:
+            handler.send_response(400)
+            handler.end_headers()
+            handler.wfile.write(b'Missing file_identifier or file_type')
+            return True
+
+        success, error_msg = delete_file(file_identifier, file_type)
+        if success:
+            handler.send_response(200)
+            handler.send_header('Content-Type', 'application/json')
+            handler.end_headers()
+            handler.wfile.write(json.dumps({'success': True}).encode())
+        else:
+            handler.send_response(400)
+            handler.send_header('Content-Type', 'application/json')
+            handler.end_headers()
+            handler.wfile.write(json.dumps({'error': error_msg}).encode())
+        return True
+
+    if handler.path == '/delete_records':
+        try:
+            payload = _read_json_payload(handler)
+        except json.JSONDecodeError:
+            handler.send_response(400)
+            handler.end_headers()
+            handler.wfile.write(b'Invalid JSON payload')
+            return True
+
+        record_ids = payload.get('record_ids')
+        if not isinstance(record_ids, list):
+            handler.send_response(400)
+            handler.send_header('Content-Type', 'application/json')
+            handler.end_headers()
+            handler.wfile.write(json.dumps({'success': False, 'error': 'record_ids 필드는 배열이어야 합니다.'}).encode())
+            return True
+
+        success, results = delete_records([str(r) for r in record_ids])
+        status_code = 200 if success else 207
+        handler.send_response(status_code)
+        handler.send_header('Content-Type', 'application/json')
+        handler.end_headers()
+        handler.wfile.write(json.dumps({'success': success, 'results': results}, ensure_ascii=False).encode())
+        return True
+
+    return False

--- a/sttEngine/http_api/routes/search_routes.py
+++ b/sttEngine/http_api/routes/search_routes.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+from ...vector_search import search as search_vectors
+from ..history import get_active_history
+from ..paths import BASE_DIR
+from ..search import (
+    build_highlight_snippet,
+    collect_keyword_matches,
+    collect_searchable_documents,
+    get_document_text,
+)
+
+
+def _resolve(name: str, default):
+    handler_module = importlib.import_module("sttEngine.http_api.handler")
+    return getattr(handler_module, name, default)
+
+
+def handle_get(handler) -> bool:
+    if handler.path.startswith('/file_search'):
+        parsed = urlparse(handler.path)
+        params = parse_qs(parsed.query)
+        query = params.get('q', [''])[0].lower()
+
+        results = []
+        if query:
+            history = _resolve("get_active_history", get_active_history)()
+            for record in history:
+                filename = record.get('filename', '')
+                tags = record.get('tags', [])
+                if query in filename.lower() or any(query in t.lower() for t in tags):
+                    results.append({'id': record.get('id'), 'filename': filename, 'tags': tags})
+
+        handler.send_response(200)
+        handler.send_header('Content-Type', 'application/json')
+        handler.end_headers()
+        handler.wfile.write(json.dumps(results, ensure_ascii=False).encode())
+        return True
+
+    if not handler.path.startswith('/search'):
+        return False
+
+    parsed = urlparse(handler.path)
+    params = parse_qs(parsed.query)
+
+    def _first(name: str, default=None):
+        return params.get(name, [default])[0]
+
+    def _csv(name: str) -> set[str]:
+        raw = _first(name, '') or ''
+        return {token.strip().lower() for token in raw.split(',') if token.strip()}
+
+    query = (_first('query') or _first('q') or '').strip()
+    limit_raw = _first('limit')
+    start_date = _first('start_date') or _first('start')
+    end_date = _first('end_date') or _first('end')
+    sort_by = (_first('sort_by', 'similarity') or 'similarity').lower()
+    sort_order = (_first('sort_order', 'desc') or 'desc').lower()
+    min_score_raw = _first('min_score')
+    page_raw = _first('page', '1')
+    page_size_raw = _first('page_size', '5')
+    include_timing_raw = _first('include_timing', 'false')
+    file_types = _csv('file_type')
+    status_filter = (_first('status') or '').strip().lower()
+    status_task = (_first('status_task') or 'stt').strip().lower()
+
+    include_timing = str(include_timing_raw).lower() in {'1', 'true', 'yes', 'y', 'on'}
+
+    min_score = None
+    if min_score_raw not in (None, ''):
+        try:
+            min_score = float(min_score_raw)
+        except ValueError:
+            min_score = None
+
+    try:
+        page = max(1, int(page_raw))
+    except (TypeError, ValueError):
+        page = 1
+
+    try:
+        page_size = max(1, int(page_size_raw))
+    except (TypeError, ValueError):
+        page_size = 5
+
+    try:
+        limit = int(limit_raw) if limit_raw not in (None, '') else max(10, page * page_size)
+        limit = max(1, limit)
+    except (TypeError, ValueError):
+        limit = max(10, page * page_size)
+
+    try:
+        filter_signature = json.dumps(
+            {'file_type': sorted(file_types), 'status': status_filter, 'status_task': status_task},
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+
+        response_data = {
+            'query': query,
+            'limit': limit,
+            'keywordMatches': [],
+            'similarDocuments': [],
+            'sort': {'by': sort_by, 'order': sort_order},
+            'filters': {
+                'start_date': start_date,
+                'end_date': end_date,
+                'min_score': min_score,
+                'file_type': sorted(file_types),
+                'status': status_filter or None,
+                'status_task': status_task or None,
+            },
+            'pagination': {'page': page, 'pageSize': page_size, 'returned': 0, 'hasNext': False},
+            'scoreBreakdown': {'keywordWeight': 0.0, 'vectorWeight': 1.0},
+        }
+
+        if query:
+            documents, path_index = _resolve("collect_searchable_documents", collect_searchable_documents)()
+            history = _resolve("get_active_history", get_active_history)()
+            history_map = {record.get('id'): record for record in history}
+
+            def _record_passes(record: dict) -> bool:
+                if file_types and str(record.get('file_type', '')).lower() not in file_types:
+                    return False
+                if status_filter:
+                    completed = bool((record.get('completed_tasks') or {}).get(status_task, False))
+                    if status_filter in {'completed', 'done', 'success'} and not completed:
+                        return False
+                    if status_filter in {'pending', 'incomplete', 'todo'} and completed:
+                        return False
+                return True
+
+            filtered_documents = [
+                doc for doc in documents if _record_passes(history_map.get(doc['info'].get('record_id'), {}))
+            ]
+
+            keyword_matches = _resolve("collect_keyword_matches", collect_keyword_matches)(query, filtered_documents, history_map, limit=limit)
+            response_data['keywordMatches'] = keyword_matches
+
+            keyword_paths = {item['file'] for item in keyword_matches}
+            keyword_uuids = {item['file_uuid'] for item in keyword_matches}
+
+            search_payload = _resolve("search_vectors", search_vectors)(
+                query,
+                BASE_DIR,
+                top_k=limit,
+                start_date=start_date,
+                end_date=end_date,
+                sort_by=sort_by,
+                sort_order=sort_order,
+                min_score=min_score,
+                page=page,
+                page_size=page_size,
+                include_timing=include_timing,
+                filter_signature=filter_signature,
+            )
+
+            if isinstance(search_payload, dict):
+                hits = search_payload.get('results', [])
+                if include_timing:
+                    response_data['timing'] = search_payload.get('timing', {})
+                    response_data['cache'] = {'hit': bool(search_payload.get('cache_hit'))}
+                response_data['pagination']['hasNext'] = bool(
+                    search_payload.get('total_candidates', 0) > page * page_size
+                )
+            else:
+                hits = search_payload
+                response_data['pagination']['hasNext'] = len(hits) >= page_size
+
+            similar_documents = []
+            for hit in hits:
+                rel_path = hit.get('file')
+                if not rel_path:
+                    continue
+
+                doc = path_index.get(rel_path)
+                if doc and (doc['uuid'] in keyword_uuids or rel_path in keyword_paths):
+                    continue
+                if not doc and rel_path in keyword_paths:
+                    continue
+
+                display_name = Path(rel_path).name
+                link = f'/download/{rel_path}'
+                uploaded_at = hit.get('uploaded_at')
+                source_filename = None
+                file_uuid = None
+                record_id = None
+                snippet = ''
+
+                if doc:
+                    record = history_map.get(doc['info'].get('record_id'), {})
+                    if not _record_passes(record):
+                        continue
+                    record_id = doc['info'].get('record_id')
+                    uploaded_at = record.get('timestamp') or uploaded_at
+                    source_filename = record.get('filename')
+                    display_name = doc['info'].get('original_filename') or display_name
+                    link = f"/download/{doc['uuid']}"
+                    file_uuid = doc['uuid']
+                    try:
+                        snippet = build_highlight_snippet(get_document_text(doc['full_path']), query)
+                    except Exception:
+                        snippet = ''
+
+                similar_documents.append(
+                    {
+                        'file_uuid': file_uuid,
+                        'file': rel_path,
+                        'display_name': display_name,
+                        'score': hit.get('score'),
+                        'snippet': snippet,
+                        'score_breakdown': {
+                            'vector_similarity': hit.get('score'),
+                            'keyword_overlap': 0.0,
+                            'composite': hit.get('score'),
+                        },
+                        'uploaded_at': uploaded_at,
+                        'source_filename': source_filename,
+                        'record_id': record_id,
+                        'link': link,
+                    }
+                )
+
+            response_data['similarDocuments'] = similar_documents
+            response_data['pagination']['returned'] = len(similar_documents)
+            response_data['contract_version'] = 'search-v2'
+
+        handler.send_response(200)
+        handler.send_header('Content-Type', 'application/json')
+        handler.end_headers()
+        handler.wfile.write(json.dumps(response_data, ensure_ascii=False).encode())
+
+    except Exception as e:
+        print(f'검색 요청 처리 중 오류: {e}')
+        handler.send_response(500)
+        handler.send_header('Content-Type', 'application/json')
+        handler.end_headers()
+        error_response = {
+            'error': '검색 중 오류가 발생했습니다. Ollama 서버가 실행 중인지 확인하고, 임베딩 모델이 설치되어 있는지 확인해주세요.',
+            'details': str(e),
+        }
+        handler.wfile.write(json.dumps(error_response, ensure_ascii=False).encode())
+    return True

--- a/sttEngine/http_api/routes/similarity_routes.py
+++ b/sttEngine/http_api/routes/similarity_routes.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+from urllib.parse import parse_qs, unquote, urlparse
+
+from ...similarity_matrix import get_documents_metadata, get_similarity_graph
+
+
+def _read_json_payload(handler):
+    length = int(handler.headers.get('Content-Length', 0))
+    return json.loads(handler.rfile.read(length)) if length else {}
+
+
+def handle_get(handler) -> bool:
+    if handler.path.startswith('/api/similarity-graph'):
+        parsed = urlparse(handler.path)
+        params = parse_qs(parsed.query)
+        min_similarity = float(params.get('min_similarity', params.get('threshold', ['0.65']))[0])
+        max_neighbors = int(params.get('max_neighbors', ['12'])[0])
+        max_nodes = int(params.get('max_nodes', ['150'])[0])
+        sampling_strategy = (params.get('sampling', ['hybrid'])[0] or 'hybrid').lower()
+        doc_id = (params.get('doc_id', [''])[0] or '').strip() or None
+        refresh = params.get('refresh', ['false'])[0].lower() == 'true'
+
+        payload = get_similarity_graph(
+            min_similarity=min_similarity,
+            max_neighbors=max_neighbors,
+            max_nodes=max_nodes,
+            sampling_strategy=sampling_strategy,
+            doc_id=doc_id,
+            refresh=refresh,
+        )
+
+        handler.send_response(200)
+        handler.send_header('Content-Type', 'application/json')
+        handler.end_headers()
+        handler.wfile.write(json.dumps(payload, ensure_ascii=False).encode())
+        return True
+
+    if handler.path.startswith('/api/documents/metadata'):
+        payload = get_documents_metadata()
+        handler.send_response(200)
+        handler.send_header('Content-Type', 'application/json')
+        handler.end_headers()
+        handler.wfile.write(json.dumps(payload, ensure_ascii=False).encode())
+        return True
+
+    if handler.path.startswith('/similar/'):
+        file_identifier = unquote(handler.path[len('/similar/'):])
+        handler._serve_similar_documents(file_identifier)
+        return True
+
+    return False
+
+
+def handle_post(handler) -> bool:
+    if handler.path != '/similar':
+        return False
+
+    try:
+        payload = _read_json_payload(handler)
+    except json.JSONDecodeError:
+        handler.send_response(400)
+        handler.end_headers()
+        handler.wfile.write(b'Invalid JSON payload')
+        return True
+
+    file_identifier = payload.get('file_identifier')
+    user_filename = payload.get('user_filename')
+    refresh = payload.get('refresh', False)
+
+    if not file_identifier:
+        handler.send_response(400)
+        handler.end_headers()
+        handler.wfile.write(b'Missing file_identifier')
+        return True
+
+    handler._serve_similar_documents_with_filename(file_identifier, user_filename, refresh)
+    return True


### PR DESCRIPTION
### Motivation
- Reduce the large `UploadHandler` switch/branching surface by extracting route-specific logic into focused modules to improve maintainability and testability.
- Keep existing HTTP contracts and response schemas unchanged to avoid breaking clients and frontend integration.
- Make it easier to add/modify API groups (search, similarity, records, management, admin) without inflating `handler.py`.

### Description
- Split route handling into new modules under `sttEngine/http_api/routes/`: `search_routes.py`, `similarity_routes.py`, `records_routes.py`, `management_routes.py`, and `admin_routes.py` and added `routes/__init__.py` as a container.
- Updated `sttEngine/http_api/handler.py` to delegate `do_GET`/`do_POST` dispatch to the new route modules while preserving unchanged endpoints for static assets, download, upload and `process` handling.
- Preserved existing response shape and behavior for search (`keywordMatches`, `similarDocuments`, `pagination`, `contract_version`) and other endpoints; `search_routes.py` uses a runtime resolver to maintain compatibility with test monkeypatches.
- Updated docs to reflect the modular routing structure in `README.md` and `AGENTS.md`.

### Testing
- Ran the core regression suite with `PYTHONPATH=. pytest tests/http_api/test_workflow.py tests/http_api/test_search.py tests/server/test_queue.py tests/test_vocab_system.py` and all tests passed (`9 passed`).
- Verified Python files compile via `py_compile` during the rollout prior to running tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991ce16a1e0832eac696028805811a8)