### PR TITLE
feat: expose queue progress % & ETA and standardize error card

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@
 
 GET
 - `/`, `/assets/*`, `/download/<uuid_or_path>`
-- `/history`, `/tasks`, `/progress/<task_id>`
+- `/history`, `/tasks`, `/progress/<task_id>` (진행률 %, ETA, 표준 오류 payload 포함)
 - `/file_search`, `/search`
 - `/api/similarity-graph`, `/api/documents/metadata`
 - `/similar/<uuid_or_path>`, `/models`
@@ -79,6 +79,7 @@ POST
 - 백엔드 기준 요약 step 키는 `summary`
 - STT 모델 키는 `whisper`
 - 실패 응답 필드: `error`, `error_code`, `retryable`, `failed_step`
+- 진행률 응답(`/progress/<task_id>`, WebSocket)은 `progress_percent`, `eta_seconds`, `error`(표준 오류 카드용 객체) 포함
 
 ## 6. 수정 시 우선 확인할 파일
 - 라우트/핸들러: `sttEngine/http_api/handler.py`

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ venv\Scripts\python.exe -m sttEngine.server
 
 주요 GET:
 - `/`, `/assets/*`, `/download/<uuid_or_path>`
-- `/history`, `/tasks`, `/progress/<task_id>`
+- `/history`, `/tasks`, `/progress/<task_id>` (진행률 %, ETA, 표준 오류 payload 포함)
 - `/search`, `/models`, `/cache/stats`, `/cache/cleanup`
 - `/api/similarity-graph`, `/api/documents/metadata`
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -162,13 +162,23 @@ export interface RunningTask {
   [key: string]: unknown;
 }
 
+export interface StandardErrorPayload {
+  message: string;
+  code?: string | null;
+  retryable?: boolean | null;
+  failed_step?: string | null;
+}
+
 export interface TaskProgress {
   task_id: string;
   message: string;
   stage?: TaskStage;
+  progress_percent?: number;
+  eta_seconds?: number | null;
   error_code?: string;
   retryable?: boolean;
   failed_step?: string;
+  error?: StandardErrorPayload | null;
 }
 
 export interface QueueTask {
@@ -189,6 +199,9 @@ export interface QueueTask {
   retryable?: boolean;
   failedStep?: string;
   stage?: TaskStage;
+  progressPercent?: number;
+  etaSeconds?: number | null;
+  error?: StandardErrorPayload | null;
 }
 
 export interface ModelSettings {

--- a/frontend/src/components/JobQueue.tsx
+++ b/frontend/src/components/JobQueue.tsx
@@ -1,4 +1,4 @@
-import { Clock, Loader2, CheckCircle2, XCircle, FileAudio, FileText, X } from 'lucide-react';
+import { Clock, Loader2, CheckCircle2, XCircle, FileAudio, FileText, X, AlertTriangle } from 'lucide-react';
 import { Card } from './ui/card';
 import { Badge } from './ui/badge';
 import { Progress } from './ui/progress';
@@ -56,6 +56,16 @@ export function JobQueue() {
 
   const stepLabels: Record<string, string> = { stt: '변환', correct: '교정', embedding: '변환', summary: '요약', summarize: '요약' };
 
+
+
+  const formatEta = (seconds?: number | null) => {
+    if (seconds === undefined || seconds === null || Number.isNaN(seconds)) return null;
+    if (seconds <= 0) return '곧 완료';
+    const min = Math.floor(seconds / 60);
+    const sec = seconds % 60;
+    return min > 0 ? `약 ${min}분 ${sec}초` : `약 ${sec}초`;
+  };
+
   const getCurrentStage = (task: QueueTask): (typeof STAGE_ORDER)[number] => {
     if (task.stage) return task.stage;
     if (task.status === QueueTaskStatus.Pending || task.status === QueueTaskStatus.Queued) return 'upload';
@@ -109,12 +119,19 @@ export function JobQueue() {
                         <div className="flex items-center gap-2 text-sm">
                           {getStatusIcon(task.status)}
                           <span className={theme === 'dark' ? 'text-slate-400' : 'text-slate-600'}>{task.progress || '대기 중...'}</span>
+                          {(task.status === QueueTaskStatus.Processing || task.status === QueueTaskStatus.Queued) && (task.progressPercent !== undefined || task.etaSeconds !== undefined) && (
+                            <span className={theme === 'dark' ? 'text-xs text-slate-500' : 'text-xs text-slate-500'}>{task.progressPercent !== undefined ? `${task.progressPercent}%` : ''}{task.etaSeconds !== undefined && formatEta(task.etaSeconds) ? ` · ETA ${formatEta(task.etaSeconds)}` : ''}</span>
+                          )}
                         </div>
-                        {task.status === QueueTaskStatus.Error && (task.failedStep || task.errorCode) && (
-                          <div className={`text-xs ${theme === 'dark' ? 'text-red-300' : 'text-red-600'}`}>
-                            실패 단계: {task.failedStep ? (stepLabels[task.failedStep] || task.failedStep) : '-'}
-                            {task.errorCode ? ` · 코드: ${task.errorCode}` : ''}
-                            {task.retryable === false ? ' · 재시도 불가' : ''}
+                        {task.status === QueueTaskStatus.Error && (
+                          <div className={`rounded-lg border p-2 text-xs space-y-1 ${theme === 'dark' ? 'border-red-500/40 bg-red-950/30 text-red-200' : 'border-red-300 bg-red-50 text-red-700'}`}>
+                            <div className="flex items-center gap-1 font-medium"><AlertTriangle className="size-3.5" />오류 정보</div>
+                            <div>{task.error?.message || task.progress || '오류 발생'}</div>
+                            <div>
+                              실패 단계: {task.error?.failed_step ? (stepLabels[task.error.failed_step] || task.error.failed_step) : (task.failedStep ? (stepLabels[task.failedStep] || task.failedStep) : '-')}
+                              {(task.error?.code || task.errorCode) ? ` · 코드: ${task.error?.code || task.errorCode}` : ''}
+                              {task.retryable === false || task.error?.retryable === false ? ' · 재시도 불가' : ''}
+                            </div>
                           </div>
                         )}
 
@@ -133,7 +150,7 @@ export function JobQueue() {
                               );
                             })}
                           </div>
-                          {task.status === QueueTaskStatus.Processing && <Progress value={Math.max(20, (STAGE_ORDER.indexOf(getCurrentStage(task)) + 1) * 25)} className="h-1.5" />}
+                          {task.status === QueueTaskStatus.Processing && <Progress value={task.progressPercent ?? Math.max(20, (STAGE_ORDER.indexOf(getCurrentStage(task)) + 1) * 25)} className="h-1.5" />}
                         </div>
                         <TaskActionControls
                           compact

--- a/frontend/src/hooks/useTaskQueue.ts
+++ b/frontend/src/hooks/useTaskQueue.ts
@@ -53,13 +53,13 @@ export function useTaskQueue(modelSettings: ModelSettings, onTaskComplete?: () =
     setQueue(prev => [...prev, task]);
   }, []);
 
-  const applyProgressUpdate = useCallback((taskId: string, message: string, meta?: { stage?: TaskStage; error_code?: string; retryable?: boolean; failed_step?: string }) => {
+  const applyProgressUpdate = useCallback((taskId: string, message: string, meta?: { stage?: TaskStage; error_code?: string; retryable?: boolean; failed_step?: string; progress_percent?: number; eta_seconds?: number | null; error?: { message: string; code?: string | null; retryable?: boolean | null; failed_step?: string | null } | null }) => {
     const previousMessage = progressDedupRef.current.get(taskId);
     if (previousMessage === message) return;
     progressDedupRef.current.set(taskId, message);
 
-    setQueue(prev => prev.map(t => t.taskId === taskId ? { ...t, progress: message, stage: meta?.stage, errorCode: meta?.error_code, retryable: meta?.retryable, failedStep: meta?.failed_step } : t));
-    setCurrentTask(prev => prev && prev.taskId === taskId ? { ...prev, progress: message, stage: meta?.stage, errorCode: meta?.error_code, retryable: meta?.retryable, failedStep: meta?.failed_step } : prev);
+    setQueue(prev => prev.map(t => t.taskId === taskId ? { ...t, progress: message, stage: meta?.stage, errorCode: meta?.error_code, retryable: meta?.retryable, failedStep: meta?.failed_step, progressPercent: meta?.progress_percent, etaSeconds: meta?.eta_seconds, error: meta?.error } : t));
+    setCurrentTask(prev => prev && prev.taskId === taskId ? { ...prev, progress: message, stage: meta?.stage, errorCode: meta?.error_code, retryable: meta?.retryable, failedStep: meta?.failed_step, progressPercent: meta?.progress_percent, etaSeconds: meta?.eta_seconds, error: meta?.error } : prev);
   }, []);
 
   const removeTask = useCallback((taskId: string) => {
@@ -158,7 +158,7 @@ export function useTaskQueue(modelSettings: ModelSettings, onTaskComplete?: () =
       );
 
       if (result.error) {
-        setCurrentTask(prev => prev ? { ...prev, status: QueueTaskStatus.Error, progress: result.error || "오류 발생", stage: result.failed_step === 'correct' ? 'correct' : result.failed_step === 'summary' ? 'summary' : 'transform', errorCode: result.error_code, retryable: result.retryable, failedStep: result.failed_step } : null);
+        setCurrentTask(prev => prev ? { ...prev, status: QueueTaskStatus.Error, progress: result.error || "오류 발생", stage: result.failed_step === 'correct' ? 'correct' : result.failed_step === 'summary' ? 'summary' : 'transform', errorCode: result.error_code, retryable: result.retryable, failedStep: result.failed_step, error: { message: result.error || '오류 발생', code: result.error_code, retryable: result.retryable, failed_step: result.failed_step } } : null);
       } else {
         setCurrentTask(prev => prev ? { ...prev, status: QueueTaskStatus.Completed } : null);
       }
@@ -186,7 +186,7 @@ export function useTaskQueue(modelSettings: ModelSettings, onTaskComplete?: () =
       try {
         const progress: TaskProgress = await api.getProgress(currentTask.taskId);
         if (cancelled || !progress.message) return;
-        applyProgressUpdate(progress.task_id, progress.message, { stage: progress.stage, error_code: progress.error_code, retryable: progress.retryable, failed_step: progress.failed_step });
+        applyProgressUpdate(progress.task_id, progress.message, { stage: progress.stage, error_code: progress.error_code, retryable: progress.retryable, failed_step: progress.failed_step, progress_percent: progress.progress_percent, eta_seconds: progress.eta_seconds, error: progress.error });
       } catch {
         // WebSocket is primary; polling explicitly prevents stale UI when websocket events are dropped.
       }

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef, useCallback } from 'react';
 type MessageHandler = (
   taskId: string,
   message: string,
-  meta?: { stage?: 'upload' | 'transform' | 'correct' | 'summary'; error_code?: string; retryable?: boolean; failed_step?: string }
+  meta?: { stage?: 'upload' | 'transform' | 'correct' | 'summary'; error_code?: string; retryable?: boolean; failed_step?: string; progress_percent?: number; eta_seconds?: number | null; error?: { message: string; code?: string | null; retryable?: boolean | null; failed_step?: string | null } | null }
 ) => void;
 
 export function useWebSocket(onMessage: MessageHandler) {
@@ -31,6 +31,9 @@ export function useWebSocket(onMessage: MessageHandler) {
               error_code: data.error_code,
               retryable: data.retryable,
               failed_step: data.failed_step,
+              progress_percent: data.progress_percent,
+              eta_seconds: data.eta_seconds,
+              error: data.error,
             });
           }
         } catch (e) {

--- a/sttEngine/http_api/state.py
+++ b/sttEngine/http_api/state.py
@@ -25,6 +25,26 @@ process_lock = threading.Lock()
 task_progress: dict[str, dict] = {}
 progress_lock = threading.Lock()
 
+_STAGE_PROGRESS_BASE: dict[str, int] = {
+    "upload": 10,
+    "transform": 45,
+    "correct": 70,
+    "summary": 90,
+}
+
+
+def _infer_progress_percent(stage: TaskStage | str | None, message: str, previous: int | None) -> int:
+    lower_message = message.lower()
+    if "완료" in message or "complete" in lower_message or "success" in lower_message:
+        return 100
+    if "실패" in message or "error" in lower_message or "취소" in message:
+        return min(99, previous or 0)
+
+    inferred = _STAGE_PROGRESS_BASE.get(str(stage), 25)
+    if "시작" in message or "중" in message:
+        inferred = max(15, inferred - 5)
+    return max(previous or 0, min(99, inferred))
+
 
 def register_process(task_id: str, process) -> None:
     """Register a running process for a task."""
@@ -93,18 +113,55 @@ def update_task_progress(
     failed_step: str | None = None,
 ) -> None:
     """Update progress message for a task."""
+    now = time.time()
     with progress_lock:
+        current = task_progress.get(task_id, {})
+        started_at = current.get("started_at")
+        if not started_at:
+            with process_lock:
+                process_info = running_processes.get(task_id) or {}
+            started_at = process_info.get("start_time", now)
+
+        progress_percent = _infer_progress_percent(stage, message, current.get("progress_percent"))
+        elapsed = max(0.0, now - float(started_at))
+        eta_seconds = None
+        if 0 < progress_percent < 100:
+            eta_seconds = int((elapsed * (100 - progress_percent)) / progress_percent)
+
+        error_payload = None
+        if error_code or failed_step or retryable is not None:
+            error_payload = {
+                "message": message,
+                "code": error_code,
+                "retryable": retryable,
+                "failed_step": failed_step,
+            }
+
         task_progress[task_id] = {
             "task_id": task_id,
             "message": message,
             "stage": str(stage) if stage else None,
-            "timestamp": time.time(),
+            "timestamp": now,
+            "started_at": started_at,
+            "progress_percent": progress_percent,
+            "eta_seconds": eta_seconds,
             "error_code": error_code,
             "retryable": retryable,
             "failed_step": failed_step,
+            "error": error_payload,
         }
         print(f"Task {task_id}: {message}")
-    broadcast_progress(task_id, message, str(stage) if stage else None, error_code, retryable, failed_step)
+    broadcast_progress(
+        task_id,
+        message,
+        str(stage) if stage else None,
+        error_code,
+        retryable,
+        failed_step,
+        progress_percent=progress_percent,
+        eta_seconds=eta_seconds,
+        error=error_payload,
+    )
 
 
 def get_task_progress(task_id: str) -> dict:

--- a/sttEngine/http_api/ws.py
+++ b/sttEngine/http_api/ws.py
@@ -18,6 +18,9 @@ async def _send_progress(
     error_code: str | None = None,
     retryable: bool | None = None,
     failed_step: str | None = None,
+    progress_percent: int | None = None,
+    eta_seconds: int | None = None,
+    error: dict | None = None,
 ) -> None:
     data = json.dumps({
         "task_id": task_id,
@@ -26,6 +29,9 @@ async def _send_progress(
         "error_code": error_code,
         "retryable": retryable,
         "failed_step": failed_step,
+        "progress_percent": progress_percent,
+        "eta_seconds": eta_seconds,
+        "error": error,
     })
     if connected_clients:
         await asyncio.gather(
@@ -40,10 +46,13 @@ def broadcast_progress(
     error_code: str | None = None,
     retryable: bool | None = None,
     failed_step: str | None = None,
+    progress_percent: int | None = None,
+    eta_seconds: int | None = None,
+    error: dict | None = None,
 ) -> None:
     if websocket_loop.is_running():
         asyncio.run_coroutine_threadsafe(
-            _send_progress(task_id, message, stage, error_code, retryable, failed_step), websocket_loop
+            _send_progress(task_id, message, stage, error_code, retryable, failed_step, progress_percent, eta_seconds, error), websocket_loop
         )
 
 


### PR DESCRIPTION
### Motivation
- Improve queue UX by surfacing numeric progress and ETA and provide a consistent error card payload so frontend can render richer, uniform error UI. 
- Provide a single backend DTO (HTTP progress + WebSocket) so both polling and WS use identical fields for progress and error presentation.

### Description
- Backend: `sttEngine/http_api/state.py` — add `progress_percent`, `eta_seconds`, and a standardized `error` object; infer progress (%) from stage/message and compute ETA; include these fields in stored progress state and broadcast.
- WebSocket: `sttEngine/http_api/ws.py` — extend WS payload to include `progress_percent`, `eta_seconds`, and `error` so clients receive the expanded DTO in real-time.
- Frontend types: `frontend/src/api/types.ts` — add `StandardErrorPayload`, extend `TaskProgress` and `QueueTask` with progress/ETA/error fields.
- Frontend hooks: `frontend/src/hooks/useWebSocket.ts`, `frontend/src/hooks/useTaskQueue.ts` — accept the extended meta from WS and polling responses and merge into queue state (progressPercent, etaSeconds, error).
- Frontend UI: `frontend/src/components/JobQueue.tsx` — display numeric progress (%) and ETA on task cards; use a standardized error card (message / failed step / code / retryable) and prefer actual `progressPercent` for the progress bar when available.
- Docs: update `README.md` and `AGENTS.md` to document the expanded progress payload (`progress_percent`, `eta_seconds`, `error`).

### Testing
- Ran backend unit tests: `PYTHONPATH=. pytest tests/server/test_queue.py tests/http_api/test_workflow.py` — all tests passed (`4 passed`).
- Built frontend: `cd frontend && npm run build` — build succeeded.
- Manual UI smoke: launched dev server and captured a UI screenshot to verify progress/ETA and error card rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991d3283b60832e924c6d802e52f456)