### PR TITLE
Fix `python -m sttEngine.server` startup failure

### DIFF
--- a/sttEngine/server/__main__.py
+++ b/sttEngine/server/__main__.py
@@ -1,0 +1,15 @@
+"""Module entrypoint for ``python -m sttEngine.server``."""
+
+from sttEngine.logger import setup_logging
+from sttEngine.http_api.app import main as run_app
+
+
+setup_logging()
+
+
+def main() -> None:
+    run_app()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Running `python -m sttEngine.server` failed because the `sttEngine/server/` package shadowed the historical `sttEngine/server.py` wrapper and there was no `sttEngine/server/__main__.py` entrypoint.

### Description
- Add `sttEngine/server/__main__.py` which initializes logging via `sttEngine.logger.setup_logging()` and delegates to the HTTP app entry `sttEngine.http_api.app.main` so `python -m sttEngine.server` works as expected.

### Testing
- Verified with `python -c "import sttEngine.server.__main__ as m; print(m.main.__name__)"` which printed `main` successfully. 
- Verified by running `timeout 5s python -m sttEngine.server` which started without the previous import error (terminated by timeout); both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69927ca423b4832e8e059dbb6236b150)