### PR TITLE
Add automated similarity graph benchmark and baseline report

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,9 @@ POST
 - `pytest tests/http_api/test_search.py`
 - `pytest tests/server/test_queue.py`
 - `pytest tests/test_vocab_system.py`
+- 그래프 성능 기준선 생성: `node frontend/scripts/benchmark-similarity-graph.mjs`
+  - 출력: `docs/perf/similarity-graph-baseline.json`, `docs/perf/similarity-graph-baseline.md`
+  - 실서버 응답 포함: `node frontend/scripts/benchmark-similarity-graph.mjs --api-base-url=http://localhost:8080`
 
 ## 8. 에이전트 작업 규칙
 - 라우트 추가/변경 시 백엔드 + 프론트 API 클라이언트 + 타입 + 테스트를 함께 업데이트

--- a/README.md
+++ b/README.md
@@ -175,6 +175,17 @@ pytest
 pytest tests/http_api/test_workflow.py tests/http_api/test_search.py tests/server/test_queue.py tests/test_vocab_system.py
 ```
 
+그래프 성능 계측(100/500/1000 문서 기준선 자동 생성):
+```bash
+node frontend/scripts/benchmark-similarity-graph.mjs
+```
+결과물: `docs/perf/similarity-graph-baseline.json`, `docs/perf/similarity-graph-baseline.md`
+
+실서버 응답시간까지 함께 계측하려면:
+```bash
+node frontend/scripts/benchmark-similarity-graph.mjs --api-base-url=http://localhost:8080
+```
+
 ## Docker
 기본:
 ```bash

--- a/docs/perf/similarity-graph-baseline.json
+++ b/docs/perf/similarity-graph-baseline.json
@@ -1,0 +1,255 @@
+{
+  "generatedAt": "2026-02-16T02:55:59.014Z",
+  "mode": "mock_api",
+  "apiBaseUrl": null,
+  "mockResponseDelayMs": 8,
+  "iterations": 10,
+  "scenarios": [
+    {
+      "nodeCount": 100,
+      "edges": 294,
+      "samples": [
+        {
+          "iteration": 1,
+          "responseTimeMs": 8,
+          "renderTimeMs": 11.61,
+          "circles": 100,
+          "lines": 294
+        },
+        {
+          "iteration": 2,
+          "responseTimeMs": 8,
+          "renderTimeMs": 3.12,
+          "circles": 100,
+          "lines": 294
+        },
+        {
+          "iteration": 3,
+          "responseTimeMs": 8,
+          "renderTimeMs": 6.5,
+          "circles": 100,
+          "lines": 294
+        },
+        {
+          "iteration": 4,
+          "responseTimeMs": 8,
+          "renderTimeMs": 5.36,
+          "circles": 100,
+          "lines": 294
+        },
+        {
+          "iteration": 5,
+          "responseTimeMs": 8,
+          "renderTimeMs": 3.11,
+          "circles": 100,
+          "lines": 294
+        },
+        {
+          "iteration": 6,
+          "responseTimeMs": 8,
+          "renderTimeMs": 2.85,
+          "circles": 100,
+          "lines": 294
+        },
+        {
+          "iteration": 7,
+          "responseTimeMs": 8,
+          "renderTimeMs": 5.09,
+          "circles": 100,
+          "lines": 294
+        },
+        {
+          "iteration": 8,
+          "responseTimeMs": 8,
+          "renderTimeMs": 1.36,
+          "circles": 100,
+          "lines": 294
+        },
+        {
+          "iteration": 9,
+          "responseTimeMs": 8,
+          "renderTimeMs": 2.85,
+          "circles": 100,
+          "lines": 294
+        },
+        {
+          "iteration": 10,
+          "responseTimeMs": 8,
+          "renderTimeMs": 1.38,
+          "circles": 100,
+          "lines": 294
+        }
+      ],
+      "summary": {
+        "responseAvgMs": 8,
+        "responseP95Ms": 8,
+        "renderAvgMs": 4.32,
+        "renderP95Ms": 11.61
+      }
+    },
+    {
+      "nodeCount": 500,
+      "edges": 1494,
+      "samples": [
+        {
+          "iteration": 1,
+          "responseTimeMs": 8,
+          "renderTimeMs": 35.47,
+          "circles": 500,
+          "lines": 1494
+        },
+        {
+          "iteration": 2,
+          "responseTimeMs": 8,
+          "renderTimeMs": 22.43,
+          "circles": 500,
+          "lines": 1494
+        },
+        {
+          "iteration": 3,
+          "responseTimeMs": 8,
+          "renderTimeMs": 23.47,
+          "circles": 500,
+          "lines": 1494
+        },
+        {
+          "iteration": 4,
+          "responseTimeMs": 8,
+          "renderTimeMs": 42.45,
+          "circles": 500,
+          "lines": 1494
+        },
+        {
+          "iteration": 5,
+          "responseTimeMs": 8,
+          "renderTimeMs": 25.82,
+          "circles": 500,
+          "lines": 1494
+        },
+        {
+          "iteration": 6,
+          "responseTimeMs": 8,
+          "renderTimeMs": 22.76,
+          "circles": 500,
+          "lines": 1494
+        },
+        {
+          "iteration": 7,
+          "responseTimeMs": 8,
+          "renderTimeMs": 22.45,
+          "circles": 500,
+          "lines": 1494
+        },
+        {
+          "iteration": 8,
+          "responseTimeMs": 8,
+          "renderTimeMs": 22.76,
+          "circles": 500,
+          "lines": 1494
+        },
+        {
+          "iteration": 9,
+          "responseTimeMs": 8,
+          "renderTimeMs": 22.8,
+          "circles": 500,
+          "lines": 1494
+        },
+        {
+          "iteration": 10,
+          "responseTimeMs": 8,
+          "renderTimeMs": 22.59,
+          "circles": 500,
+          "lines": 1494
+        }
+      ],
+      "summary": {
+        "responseAvgMs": 8,
+        "responseP95Ms": 8,
+        "renderAvgMs": 26.3,
+        "renderP95Ms": 42.45
+      }
+    },
+    {
+      "nodeCount": 1000,
+      "edges": 2994,
+      "samples": [
+        {
+          "iteration": 1,
+          "responseTimeMs": 8,
+          "renderTimeMs": 129.74,
+          "circles": 1000,
+          "lines": 2994
+        },
+        {
+          "iteration": 2,
+          "responseTimeMs": 8,
+          "renderTimeMs": 80.78,
+          "circles": 1000,
+          "lines": 2994
+        },
+        {
+          "iteration": 3,
+          "responseTimeMs": 8,
+          "renderTimeMs": 78.06,
+          "circles": 1000,
+          "lines": 2994
+        },
+        {
+          "iteration": 4,
+          "responseTimeMs": 8,
+          "renderTimeMs": 77.09,
+          "circles": 1000,
+          "lines": 2994
+        },
+        {
+          "iteration": 5,
+          "responseTimeMs": 8,
+          "renderTimeMs": 79.73,
+          "circles": 1000,
+          "lines": 2994
+        },
+        {
+          "iteration": 6,
+          "responseTimeMs": 8,
+          "renderTimeMs": 82.26,
+          "circles": 1000,
+          "lines": 2994
+        },
+        {
+          "iteration": 7,
+          "responseTimeMs": 8,
+          "renderTimeMs": 79.66,
+          "circles": 1000,
+          "lines": 2994
+        },
+        {
+          "iteration": 8,
+          "responseTimeMs": 8,
+          "renderTimeMs": 81.46,
+          "circles": 1000,
+          "lines": 2994
+        },
+        {
+          "iteration": 9,
+          "responseTimeMs": 8,
+          "renderTimeMs": 81.47,
+          "circles": 1000,
+          "lines": 2994
+        },
+        {
+          "iteration": 10,
+          "responseTimeMs": 8,
+          "renderTimeMs": 79.57,
+          "circles": 1000,
+          "lines": 2994
+        }
+      ],
+      "summary": {
+        "responseAvgMs": 8,
+        "responseP95Ms": 8,
+        "renderAvgMs": 84.98,
+        "renderP95Ms": 129.74
+      }
+    }
+  ]
+}

--- a/docs/perf/similarity-graph-baseline.md
+++ b/docs/perf/similarity-graph-baseline.md
@@ -1,0 +1,20 @@
+# Similarity Graph Benchmark Baseline
+
+- Generated at: 2026-02-16T02:55:59.014Z
+- Response source: mock delay (8 ms)
+- Iterations per scenario: 10
+- Dataset sizes: 100, 500, 1000
+
+## Summary
+
+| Documents | Edges | Response Avg/P95 (ms) | Render Avg/P95 (ms) |
+| --- | --- | --- | --- |
+| 100 | 294 | 8 / 8 | 4.32 / 11.61 |
+| 500 | 1494 | 8 / 8 | 26.3 / 42.45 |
+| 1000 | 2994 | 8 / 8 | 84.98 / 129.74 |
+
+## Measurement definition
+
+- **Response**: `/api/similarity-graph` request/response round trip time.
+- **Render**: SimilarityGraphPanel의 핵심 연산(초기 좌표 시드 + force tick 1회 + SVG element 구성 루프)을 Node 런타임에서 실행한 시간.
+- 현재 렌더 측정은 브라우저 페인트 시간 전체가 아니라, 컴포넌트의 자료구조/루프 비용에 대한 CPU 기준선입니다.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "benchmark:graph": "node ./scripts/benchmark-similarity-graph.mjs"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.1.4",

--- a/frontend/scripts/benchmark-similarity-graph.mjs
+++ b/frontend/scripts/benchmark-similarity-graph.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+
+const DATASET_SIZES = [100, 500, 1000];
+const ITERATIONS = 10;
+const EDGE_LENGTH = 120;
+const REPULSION = 18000;
+const SPRING_K = 0.0018;
+
+function parseArgs(argv) {
+  const options = {
+    outDir: '../docs/perf',
+    apiBaseUrl: null,
+    minSimilarity: 0.65,
+    sampling: 'hybrid',
+    mockResponseDelayMs: 8,
+  };
+
+  for (const arg of argv) {
+    if (arg.startsWith('--out-dir=')) {
+      options.outDir = arg.slice('--out-dir='.length);
+    } else if (arg.startsWith('--api-base-url=')) {
+      options.apiBaseUrl = arg.slice('--api-base-url='.length);
+    } else if (arg.startsWith('--min-similarity=')) {
+      const parsed = Number(arg.slice('--min-similarity='.length));
+      if (!Number.isNaN(parsed)) options.minSimilarity = parsed;
+    } else if (arg.startsWith('--mock-response-delay-ms=')) {
+      const parsed = Number(arg.slice('--mock-response-delay-ms='.length));
+      if (!Number.isNaN(parsed) && parsed >= 0) options.mockResponseDelayMs = parsed;
+    }
+  }
+
+  return options;
+}
+
+function createSyntheticGraph(nodeCount) {
+  const nodes = Array.from({ length: nodeCount }, (_, index) => ({
+    id: `doc-${index + 1}`,
+    label: `Document ${index + 1}`,
+    file: `DB/uploads/doc-${index + 1}.md`,
+    record_id: `record-${index + 1}`,
+    uploaded_at: '2026-01-01T00:00:00Z',
+  }));
+
+  const edges = [];
+  for (let i = 0; i < nodeCount; i += 1) {
+    for (let step = 1; step <= 3; step += 1) {
+      const target = i + step;
+      if (target < nodeCount) {
+        edges.push({
+          source: `doc-${i + 1}`,
+          target: `doc-${target + 1}`,
+          weight: Number((0.65 + (step * 0.08)).toFixed(3)),
+        });
+      }
+    }
+  }
+
+  return { nodes, edges };
+}
+
+function initPositions(graph, width = 980, height = 620) {
+  const cx = width / 2;
+  const cy = height / 2;
+  const radius = Math.max(80, Math.min(width, height) * 0.28);
+
+  return graph.nodes.map((node, idx) => {
+    const angle = (Math.PI * 2 * idx) / Math.max(1, graph.nodes.length);
+    const jitter = ((idx % 7) - 3) * 7;
+    return {
+      ...node,
+      x: cx + (Math.cos(angle) * (radius + jitter)),
+      y: cy + (Math.sin(angle) * (radius + jitter)),
+      vx: 0,
+      vy: 0,
+    };
+  });
+}
+
+function runSinglePhysicsTick(nodes, edges) {
+  const next = nodes.map((node) => ({ ...node }));
+
+  for (let i = 0; i < next.length; i += 1) {
+    for (let j = i + 1; j < next.length; j += 1) {
+      const a = next[i];
+      const b = next[j];
+      const dx = b.x - a.x;
+      const dy = b.y - a.y;
+      const dist2 = Math.max(25, (dx * dx) + (dy * dy));
+      const force = REPULSION / dist2;
+      const fx = (force * dx) / Math.sqrt(dist2);
+      const fy = (force * dy) / Math.sqrt(dist2);
+      a.vx -= fx;
+      a.vy -= fy;
+      b.vx += fx;
+      b.vy += fy;
+    }
+  }
+
+  for (const edge of edges) {
+    const source = next.find((node) => node.id === edge.source);
+    const target = next.find((node) => node.id === edge.target);
+    if (!source || !target) continue;
+    const dx = target.x - source.x;
+    const dy = target.y - source.y;
+    const dist = Math.max(1, Math.sqrt((dx * dx) + (dy * dy)));
+    const displacement = dist - EDGE_LENGTH;
+    const force = SPRING_K * displacement;
+    const fx = (force * dx) / dist;
+    const fy = (force * dy) / dist;
+    source.vx += fx;
+    source.vy += fy;
+    target.vx -= fx;
+    target.vy -= fy;
+  }
+
+  for (const node of next) {
+    node.vx *= 0.86;
+    node.vy *= 0.86;
+    node.x += node.vx;
+    node.y += node.vy;
+  }
+
+  return next;
+}
+
+function estimateSvgRender(nodes, edges) {
+  const nodeMap = new Map(nodes.map((node) => [node.id, node]));
+
+  let lineCount = 0;
+  for (const edge of edges) {
+    const source = nodeMap.get(edge.source);
+    const target = nodeMap.get(edge.target);
+    if (!source || !target) continue;
+    lineCount += 1;
+  }
+
+  let labelBytes = 0;
+  for (const node of nodes) {
+    labelBytes += (node.label || node.id).slice(0, 22).length;
+  }
+
+  return { lineCount, circleCount: nodes.length, labelBytes };
+}
+
+async function measureResponseTimeMs(size, options) {
+  if (!options.apiBaseUrl) {
+    if (options.mockResponseDelayMs > 0) {
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, options.mockResponseDelayMs));
+    }
+    return options.mockResponseDelayMs;
+  }
+
+  const url = new URL('/api/similarity-graph', options.apiBaseUrl);
+  url.searchParams.set('min_similarity', String(options.minSimilarity));
+  url.searchParams.set('max_nodes', String(size));
+  url.searchParams.set('sampling', options.sampling);
+
+  const start = performance.now();
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Graph API failed for size=${size}: ${response.status} ${response.statusText}`);
+  }
+  await response.json();
+  return performance.now() - start;
+}
+
+function mean(values) {
+  return Number((values.reduce((sum, value) => sum + value, 0) / values.length).toFixed(2));
+}
+
+function percentile(values, targetPercentile) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const position = Math.max(0, Math.ceil((targetPercentile / 100) * sorted.length) - 1);
+  return Number(sorted[Math.min(position, sorted.length - 1)].toFixed(2));
+}
+
+async function benchmarkSize(size, options) {
+  const syntheticGraph = createSyntheticGraph(size);
+  const samples = [];
+
+  for (let i = 0; i < ITERATIONS; i += 1) {
+    const responseTimeMs = await measureResponseTimeMs(size, options);
+
+    const renderStart = performance.now();
+    const seededNodes = initPositions(syntheticGraph);
+    const settledNodes = runSinglePhysicsTick(seededNodes, syntheticGraph.edges);
+    const renderMeta = estimateSvgRender(settledNodes, syntheticGraph.edges);
+    const renderTimeMs = performance.now() - renderStart;
+
+    samples.push({
+      iteration: i + 1,
+      responseTimeMs: Number(responseTimeMs.toFixed(2)),
+      renderTimeMs: Number(renderTimeMs.toFixed(2)),
+      circles: renderMeta.circleCount,
+      lines: renderMeta.lineCount,
+    });
+  }
+
+  const responseSeries = samples.map((sample) => sample.responseTimeMs);
+  const renderSeries = samples.map((sample) => sample.renderTimeMs);
+
+  return {
+    nodeCount: size,
+    edges: syntheticGraph.edges.length,
+    samples,
+    summary: {
+      responseAvgMs: mean(responseSeries),
+      responseP95Ms: percentile(responseSeries, 95),
+      renderAvgMs: mean(renderSeries),
+      renderP95Ms: percentile(renderSeries, 95),
+    },
+  };
+}
+
+function makeMarkdownReport(result) {
+  const rows = result.scenarios
+    .map((scenario) => `| ${scenario.nodeCount} | ${scenario.edges} | ${scenario.summary.responseAvgMs} / ${scenario.summary.responseP95Ms} | ${scenario.summary.renderAvgMs} / ${scenario.summary.renderP95Ms} |`)
+    .join('\n');
+
+  return `# Similarity Graph Benchmark Baseline
+
+- Generated at: ${result.generatedAt}
+- Response source: ${result.mode === 'real_api' ? `real API (${result.apiBaseUrl})` : `mock delay (${result.mockResponseDelayMs} ms)`}
+- Iterations per scenario: ${result.iterations}
+- Dataset sizes: ${result.scenarios.map((scenario) => scenario.nodeCount).join(', ')}
+
+## Summary
+
+| Documents | Edges | Response Avg/P95 (ms) | Render Avg/P95 (ms) |
+| --- | --- | --- | --- |
+${rows}
+
+## Measurement definition
+
+- **Response**: \`/api/similarity-graph\` request/response round trip time.
+- **Render**: SimilarityGraphPanel의 핵심 연산(초기 좌표 시드 + force tick 1회 + SVG element 구성 루프)을 Node 런타임에서 실행한 시간.
+- 현재 렌더 측정은 브라우저 페인트 시간 전체가 아니라, 컴포넌트의 자료구조/루프 비용에 대한 CPU 기준선입니다.
+`;
+}
+
+async function run() {
+  const options = parseArgs(process.argv.slice(2));
+  const scenarios = [];
+
+  for (const size of DATASET_SIZES) {
+    // eslint-disable-next-line no-await-in-loop
+    scenarios.push(await benchmarkSize(size, options));
+  }
+
+  const result = {
+    generatedAt: new Date().toISOString(),
+    mode: options.apiBaseUrl ? 'real_api' : 'mock_api',
+    apiBaseUrl: options.apiBaseUrl,
+    mockResponseDelayMs: options.mockResponseDelayMs,
+    iterations: ITERATIONS,
+    scenarios,
+  };
+
+  const outDir = resolve(options.outDir);
+  mkdirSync(outDir, { recursive: true });
+
+  const jsonPath = resolve(outDir, 'similarity-graph-baseline.json');
+  writeFileSync(jsonPath, `${JSON.stringify(result, null, 2)}\n`, 'utf8');
+
+  const mdPath = resolve(outDir, 'similarity-graph-baseline.md');
+  writeFileSync(mdPath, makeMarkdownReport(result), 'utf8');
+
+  console.log(`Generated benchmark baseline:\n- ${jsonPath}\n- ${mdPath}`);
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
### Motivation
- The Similarity Graph React MVP was completed but lacked an automated way to collect performance metrics at scale (100/500/1000 documents) to serve as a repeatable baseline. 

### Description
- Add a Node benchmark script `frontend/scripts/benchmark-similarity-graph.mjs` that measures API response time and a CPU-side render baseline (seed positions + one physics tick + SVG element loop) across dataset sizes. 
- Expose the benchmark via an npm helper script `benchmark:graph` in `frontend/package.json` (runable with `npm --prefix frontend run benchmark:graph`).
- Commit initial baseline artifacts under `docs/perf/` (`similarity-graph-baseline.json` and `similarity-graph-baseline.md`) generated by the script using the default mock-mode configuration.
- Update `README.md` and `AGENTS.md` to document how to run the benchmark and where outputs are written, and document the `--api-base-url` option to include real backend response timing.

### Testing
- Executed `node frontend/scripts/benchmark-similarity-graph.mjs` which completed successfully and produced `docs/perf/similarity-graph-baseline.json` and `docs/perf/similarity-graph-baseline.md` (succeeded). 
- Ran `npm --prefix frontend run benchmark:graph` to validate the npm script wrapper (succeeded). 
- Built the frontend with `cd frontend && npm run build` to ensure the added script and package.json changes do not break the front-end build (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69928610c638832eacb7ed2f01dcf39e)