### PR TITLE
docs: prune completed TODO items and refresh status docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,10 @@
    - 워크플로우: `sttEngine/http_api/workflow.py`
    - 프론트 API 연동: `frontend/src/api/client.ts`, `frontend/src/api/types.ts`
 
+## 문서 점검
+
+- 백로그는 `TODO/TODO.md`(실행 항목만 유지), 최신 점검 결과는 `TODO/STATUS_REVIEW.md`를 우선 참고합니다.
+
 ## 최소 검증
 
 - `pytest tests/http_api/test_workflow.py tests/http_api/test_search.py tests/server/test_queue.py tests/test_vocab_system.py`

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,6 +8,10 @@
 - 백엔드 핵심: `sttEngine/http_api/handler.py`, `sttEngine/http_api/workflow.py`
 - 프론트 핵심: `frontend/src/*`
 
+## 문서 점검
+
+- 백로그는 `TODO/TODO.md`(실행 항목만 유지), 최신 점검 결과는 `TODO/STATUS_REVIEW.md`를 우선 참고합니다.
+
 ## 작업 체크리스트
 
 1. 백엔드 라우트/스키마 변경 시 `frontend/src/api/client.ts`와 `frontend/src/api/types.ts` 동기화

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ RecordRoute/
 │   ├── embedding_pipeline.py
 │   ├── vector_search.py
 │   └── server.py
-├── db/
+├── DB/
 └── tests/
 ```
 
@@ -211,4 +211,5 @@ docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --build
 - 프론트 문제: `cd frontend && npm install && npm run build` 재실행
 
 ## 참고
-- 구현 예정 사항: `TODO/TODO.md`
+- 진행 중 백로그(완료 항목 제외): `TODO/TODO.md`
+- 최신 점검 요약: `TODO/STATUS_REVIEW.md`

--- a/TODO/STATUS_REVIEW.md
+++ b/TODO/STATUS_REVIEW.md
@@ -1,24 +1,24 @@
-# 코드베이스 상태 점검 (2026-02-16, 문서 정합성 갱신)
+# 코드베이스 상태 점검 (2026-02-16, 문서 정합성 재갱신)
 
 ## 1) 이번 점검 범위
 
 다음 기준 문서와 실제 구현 파일을 대조해 상태를 갱신했다.
-- 기준 문서: `TODO/TODO.md`, `TODO/GUI.md`, `TODO/Graph.md`, `README.md`, `AGENTS.md`
-- 구현 근거: `sttEngine/http_api/handler.py`, `sttEngine/http_api/state.py`, `sttEngine/http_api/ws.py`, `sttEngine/http_api/routes/*`, `frontend/src/*`, `sttEngine/similarity_matrix.py`
+- 기준 문서: `TODO/TODO.md`, `README.md`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- 구현 근거: `sttEngine/http_api/handler.py`, `sttEngine/http_api/destructive_guard.py`, `sttEngine/http_api/routes/*`, `frontend/scripts/benchmark-similarity-graph.mjs`, `frontend/src/*`
 
 ## 2) 핵심 결론
 
-1. **기존 P0 중 일부는 완료 상태**다. 그래프 React 탭 통합/줌·팬·드래그, 큐 진행률(%)·ETA·오류 카드는 코드에 반영되어 있다.
-2. **미완료 P0는 2개**다. `handler.py` 책임 분리와 파괴적 API 보호 정책은 여전히 필요하다.
-3. **Graph/GUI 문서는 “미착수” 과대표기를 제거**하고 완료·부분완료·미착수로 재분류했다.
-4. TODO 문서는 원칙대로 **완료 항목을 백로그에서 제거**하고 실행 항목만 유지하도록 정리했다.
+1. **기존 P0 중 2개는 완료 상태**다.
+   - 파괴적 API 보호(기본 안전 모드 + 토큰/세션 검증)는 라우트 레벨에서 적용되어 있다.
+   - 그래프 성능 계측 자동화(100/500/1000 문서 기준선 생성 스크립트)는 제공된다.
+2. **현재 미완료 P0는 1개**다.
+   - `handler.py` 내부 업로드 처리 책임 분리가 남아 있다.
+3. TODO 원칙에 맞춰 **완료 항목은 `TODO/TODO.md`에서 제거**했고, 실행이 필요한 작업만 유지했다.
 
 ## 3) 현재 유효 백로그 요약
 
 ### P0
 1. `handler.py` 책임 분리(라우트 단위 모듈화 마무리)
-2. 파괴적 API 보호(`/shutdown`, `/delete*`, `/reset*`)
-3. Graph 대용량 성능 계측 자동화(100/500/1000 문서 기준)
 
 ### P1
 1. 검색 고급필터 UI + 하이라이트
@@ -39,11 +39,10 @@
 ## 4) 의존관계 맵 (실행 전 체크)
 
 - 검색 고급화(P1) ← 검색 API 계약 명세/OpenAPI 초안
-- 그래프 고도화(P1) ← 성능 계측/기준선(P0)
 - 운영 지표(P2) ← 로깅/메트릭 스키마 정리
 
 ## 5) 상태값 정리 결과
 
-- 완료된 작업(그래프 상호작용 MVP, 큐 진행률/ETA/오류 UX)은 TODO 체크리스트에서 삭제했다.
+- 완료된 작업(파괴적 API 보호, 그래프 성능 계측 자동화)은 TODO 체크리스트에서 삭제했다.
 - TODO 문서는 실행 관점(P0/P1/P2) 기준으로 재배치했다.
-- README/AGENTS와 충돌하지 않도록 현재 아키텍처/용어 기준을 유지했다.
+- README/AGENTS/CLAUDE/GEMINI와 충돌하지 않도록 현재 아키텍처/용어 기준을 유지했다.

--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -1,24 +1,16 @@
 # TODO Master (신규 백로그)
 
 - 마지막 점검일: 2026-02-16
-- 점검 기준: `README.md`, `CLAUDE.md`, `GEMINI.md`, `TODO/STATUS_REVIEW.md`, 주요 구현 파일(`sttEngine/http_api/handler.py`, `sttEngine/http_api/routes/*`, `frontend/src/*`)
+- 점검 기준: `README.md`, `CLAUDE.md`, `GEMINI.md`, `TODO/STATUS_REVIEW.md`, 주요 구현 파일(`sttEngine/http_api/handler.py`, `sttEngine/http_api/destructive_guard.py`, `frontend/scripts/benchmark-similarity-graph.mjs`, `frontend/src/*`)
 - 원칙: **완료 항목은 TODO에서 제거**하고, 실행이 필요한 항목만 유지
 
 ---
 
 ## 1) P0 (즉시 착수)
 
-- [ ] `handler.py` 책임 분리 (라우트 단위 모듈화)
-  - 점검 결과: `sttEngine/http_api/routes/*`로 분리됐지만 `UploadHandler`에 다운로드/정적 파일 서빙/유사문서 처리 등 대형 로직이 잔존
-  - 잔여 작업: 파일 서빙/도메인별 응답 조합 책임 추가 분리 + 회귀 테스트 고정
-
-- [ ] 파괴적 API 보호
-  - 범위: `/shutdown`, `/delete`, `/delete_records`, `/reset`, `/reset_all_tasks`, `/reset_summary_embedding`
-  - 목표: 토큰/세션 기반 보호 정책 도입 + 기본값 안전 모드
-
-- [ ] Graph 대용량 성능 계측 자동화
-  - 점검 결과: React 그래프 MVP(줌/팬/드래그/탭 통합)는 완료되었으나 100/500/1000 문서 기준 성능 지표 자동 수집 부재
-  - 목표: 응답시간/렌더시간 벤치 스크립트 및 기준선 리포트 추가
+- [ ] `handler.py` 책임 분리 (라우트 단위 모듈화 마무리)
+  - 점검 결과: `sttEngine/http_api/routes/*` 분리는 진행됐지만, `UploadHandler` 내부에 업로드 파싱/저장/응답 조합 로직이 크게 남아 있음
+  - 잔여 작업: 업로드 처리 책임 분리 + 회귀 테스트 고정
 
 ## 2) P1 (다음 스프린트)
 
@@ -54,7 +46,6 @@
 ## 4) 의존관계 체크포인트
 
 - 검색 고급화(P1) ← 검색 API 계약(파라미터/응답) 명세
-- 그래프 고도화(P1) ← 성능 계측/기준선(P0)
 - 운영 지표(P2) ← 로깅/메트릭 스키마 정리
 
 ## 5) 메모


### PR DESCRIPTION
### Motivation

- Remove completed backlog items from the master TODO and make the remaining actionable items explicit. 
- Keep repository docs and agent guidance aligned with the current implementation and operational expectations.

### Description

- Pruned `TODO/TODO.md` to remove completed P0 items and left the remaining immediate task as `handler.py` responsibility separation. 
- Updated `TODO/STATUS_REVIEW.md` to reflect the current code-state summary and the reorganized backlog. 
- Synchronized documentation references by updating `README.md` (normalize `DB/` path and add links to the updated TODO/status files) and by adding a short "document check" note to `CLAUDE.md` and `GEMINI.md`. 
- Adjusted referenced implementation files in the TODO metadata to match the actual modules used for checks (e.g. `sttEngine/http_api/destructive_guard.py` and the benchmark script). 

### Testing

- Ran `pytest tests/http_api/test_search.py` which initially failed due to `PYTHONPATH` not being set. 
- Re-ran with `PYTHONPATH=. pytest tests/http_api/test_search.py` and all tests passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992884c40d8832e93a1b4f64238c5b0)