### PR TITLE
Refactor upload processing out of UploadHandler

### DIFF
--- a/sttEngine/http_api/handler.py
+++ b/sttEngine/http_api/handler.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
 import json
-import os
-import re
 import threading
 import time
-import uuid
 from http.server import BaseHTTPRequestHandler
 
 from ..ollama_utils import ensure_ollama_server
@@ -14,13 +11,7 @@ from ..server.routes import history as history_route
 from ..server.routes import process as process_route
 from ..server.routes import progress as progress_route
 
-from .history import (
-    add_upload_record,
-    compute_file_hash,
-    get_active_history,
-    load_upload_history,
-)
-from .paths import UPLOAD_DIR, to_record_path
+from .history import get_active_history
 from .search import (
     build_highlight_snippet,
     collect_keyword_matches,
@@ -28,8 +19,7 @@ from .search import (
     get_document_text,
 )
 from .state import get_running_tasks
-from .workflow import get_audio_duration, get_file_type
-from .routes import admin_routes, file_routes, management_routes, records_routes, search_routes, similarity_routes
+from .routes import admin_routes, file_routes, management_routes, records_routes, search_routes, similarity_routes, upload_routes
 
 
 class UploadHandler(BaseHTTPRequestHandler):
@@ -132,127 +122,9 @@ class UploadHandler(BaseHTTPRequestHandler):
 
         threading.Thread(target=shutdown_server, daemon=True).start()
 
-    def _parse_multipart(self, data, boundary):
-        parts = data.split(f"--{boundary}".encode())
-        files = {}
-
-        for part in parts[1:-1]:
-            if b"Content-Disposition" not in part:
-                continue
-
-            headers, body = part.split(b"\r\n\r\n", 1)
-            headers = headers.decode("utf-8")
-            body = body.rstrip(b"\r\n")
-
-            if "filename=" in headers:
-                filename_match = re.search(r'filename="([^"]*)"', headers)
-                name_match = re.search(r'name="([^"]*)"', headers)
-
-                if filename_match and name_match:
-                    filename = filename_match.group(1)
-                    name = name_match.group(1)
-                    files.setdefault(name, []).append({"filename": filename, "data": body})
-
-        return files
-
     def do_POST(self):
-        if self.path == "/upload":
-            try:
-                print(f"Upload request received - Content-Length: {self.headers.get('Content-Length')}")
-                print(f"Content-Type: {self.headers.get('Content-Type')}")
-
-                content_type = self.headers.get("Content-Type", "")
-                if not content_type.startswith("multipart/form-data"):
-                    print("Upload failed: Not multipart/form-data")
-                    self.send_response(400)
-                    self.end_headers()
-                    self.wfile.write(b"Invalid content type")
-                    return
-
-                boundary_match = re.search(r"boundary=([^;]+)", content_type)
-                if not boundary_match:
-                    print("Upload failed: No boundary found")
-                    self.send_response(400)
-                    self.end_headers()
-                    self.wfile.write(b"No boundary found")
-                    return
-
-                boundary = boundary_match.group(1).strip()
-                content_length = int(self.headers.get("Content-Length", 0))
-                data = self.rfile.read(content_length)
-
-                files = self._parse_multipart(data, boundary)
-                print(f"Parsed fields: {list(files.keys())}")
-
-                file_entries = files.get("files") or files.get("file")
-                if not file_entries:
-                    print("Upload failed: No files provided")
-                    self.send_response(400)
-                    self.end_headers()
-                    self.wfile.write(b"No file uploaded")
-                    return
-
-                history = load_upload_history()
-                uploaded_files = []
-                for file_info in file_entries:
-                    if not file_info.get("filename"):
-                        continue
-
-                    file_hash = compute_file_hash(file_info["data"])
-                    existing = next((r for r in history if r.get("file_hash") == file_hash), None)
-                    if existing:
-                        uploaded_files.append(
-                            {
-                                "duplicate": True,
-                                "original_record_id": existing["id"],
-                                "filename": file_info["filename"],
-                            }
-                        )
-                        continue
-
-                    uid = uuid.uuid4().hex
-                    save_dir = UPLOAD_DIR / uid
-                    save_dir.mkdir(parents=True, exist_ok=True)
-                    file_path = save_dir / os.path.basename(file_info["filename"])
-
-                    with open(file_path, "wb") as output_file:
-                        output_file.write(file_info["data"])
-
-                    print(f"File saved successfully: {file_path}")
-
-                    file_type = get_file_type(file_path)
-
-                    duration = None
-                    if file_type == "audio":
-                        duration = get_audio_duration(file_path)
-
-                    record = add_upload_record(file_path, file_type, duration, file_hash)
-                    history.insert(0, record)
-
-                    uploaded_files.append(
-                        {
-                            "file_path": to_record_path(file_path),
-                            "file_type": file_type,
-                            "record_id": record["id"],
-                        }
-                    )
-
-                self.send_response(200)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(json.dumps(uploaded_files).encode())
-                return
-
-            except Exception as e:
-                print(f"Upload error: {str(e)}")
-                print(f"Exception type: {type(e).__name__}")
-                import traceback
-
-                traceback.print_exc()
-                self.send_response(500)
-                self.end_headers()
-                self.wfile.write(f"Upload error: {str(e)}".encode())
-                return
+        if upload_routes.handle_post(self):
+            return
 
         if self.path == "/process":
             process_route.handle(self)

--- a/sttEngine/http_api/routes/upload_routes.py
+++ b/sttEngine/http_api/routes/upload_routes.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import traceback
+import uuid
+
+from ..history import add_upload_record, compute_file_hash, load_upload_history
+from ..paths import UPLOAD_DIR, to_record_path
+from ..workflow import get_audio_duration, get_file_type
+
+
+def _parse_multipart(data: bytes, boundary: str) -> dict[str, list[dict[str, bytes | str]]]:
+    parts = data.split(f'--{boundary}'.encode())
+    files: dict[str, list[dict[str, bytes | str]]] = {}
+
+    for part in parts[1:-1]:
+        if b'Content-Disposition' not in part:
+            continue
+
+        headers, body = part.split(b'\r\n\r\n', 1)
+        headers_text = headers.decode('utf-8')
+        body = body.rstrip(b'\r\n')
+
+        if 'filename=' not in headers_text:
+            continue
+
+        filename_match = re.search(r'filename="([^"]*)"', headers_text)
+        name_match = re.search(r'name="([^"]*)"', headers_text)
+        if not filename_match or not name_match:
+            continue
+
+        files.setdefault(name_match.group(1), []).append({'filename': filename_match.group(1), 'data': body})
+
+    return files
+
+
+def _save_upload(file_info: dict[str, bytes | str], history: list[dict]) -> dict:
+    filename = str(file_info['filename'])
+    data = file_info['data']
+    if not isinstance(data, bytes):
+        raise ValueError('Invalid multipart payload')
+
+    file_hash = compute_file_hash(data)
+    existing = next((record for record in history if record.get('file_hash') == file_hash), None)
+    if existing:
+        return {
+            'duplicate': True,
+            'original_record_id': existing['id'],
+            'filename': filename,
+        }
+
+    uid = uuid.uuid4().hex
+    save_dir = UPLOAD_DIR / uid
+    save_dir.mkdir(parents=True, exist_ok=True)
+    file_path = save_dir / os.path.basename(filename)
+
+    with open(file_path, 'wb') as output_file:
+        output_file.write(data)
+
+    print(f'File saved successfully: {file_path}')
+
+    file_type = get_file_type(file_path)
+    duration = get_audio_duration(file_path) if file_type == 'audio' else None
+    record = add_upload_record(file_path, file_type, duration, file_hash)
+    history.insert(0, record)
+
+    return {
+        'file_path': to_record_path(file_path),
+        'file_type': file_type,
+        'record_id': record['id'],
+    }
+
+
+def handle_post(handler) -> bool:
+    if handler.path != '/upload':
+        return False
+
+    try:
+        print(f"Upload request received - Content-Length: {handler.headers.get('Content-Length')}")
+        print(f"Content-Type: {handler.headers.get('Content-Type')}")
+
+        content_type = handler.headers.get('Content-Type', '')
+        if not content_type.startswith('multipart/form-data'):
+            print('Upload failed: Not multipart/form-data')
+            handler.send_response(400)
+            handler.end_headers()
+            handler.wfile.write(b'Invalid content type')
+            return True
+
+        boundary_match = re.search(r'boundary=([^;]+)', content_type)
+        if not boundary_match:
+            print('Upload failed: No boundary found')
+            handler.send_response(400)
+            handler.end_headers()
+            handler.wfile.write(b'No boundary found')
+            return True
+
+        boundary = boundary_match.group(1).strip()
+        content_length = int(handler.headers.get('Content-Length', 0))
+        data = handler.rfile.read(content_length)
+
+        files = _parse_multipart(data, boundary)
+        print(f"Parsed fields: {list(files.keys())}")
+
+        file_entries = files.get('files') or files.get('file')
+        if not file_entries:
+            print('Upload failed: No files provided')
+            handler.send_response(400)
+            handler.end_headers()
+            handler.wfile.write(b'No file uploaded')
+            return True
+
+        history = load_upload_history()
+        uploaded_files = []
+        for file_info in file_entries:
+            if not file_info.get('filename'):
+                continue
+            uploaded_files.append(_save_upload(file_info, history))
+
+        handler.send_response(200)
+        handler.send_header('Content-Type', 'application/json')
+        handler.end_headers()
+        handler.wfile.write(json.dumps(uploaded_files).encode())
+        return True
+    except Exception as e:
+        print(f'Upload error: {str(e)}')
+        print(f'Exception type: {type(e).__name__}')
+        traceback.print_exc()
+        handler.send_response(500)
+        handler.end_headers()
+        handler.wfile.write(f'Upload error: {str(e)}'.encode())
+        return True

--- a/tests/http_api/test_upload_routes.py
+++ b/tests/http_api/test_upload_routes.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from sttEngine.http_api.routes import upload_routes
+
+
+class DummyUploadHandler:
+    def __init__(self, body: bytes, content_type: str):
+        self.path = '/upload'
+        self.headers = {
+            'Content-Type': content_type,
+            'Content-Length': str(len(body)),
+        }
+        self.rfile = io.BytesIO(body)
+        self.wfile = io.BytesIO()
+        self.status = None
+        self.response_headers = {}
+
+    def send_response(self, code):
+        self.status = code
+
+    def send_header(self, key, value):
+        self.response_headers[key] = value
+
+    def end_headers(self):
+        return None
+
+
+def _multipart_body(boundary: str, filename: str, content: bytes, field_name: str = 'files') -> bytes:
+    lines = [
+        f'--{boundary}',
+        f'Content-Disposition: form-data; name="{field_name}"; filename="{filename}"',
+        'Content-Type: application/octet-stream',
+        '',
+    ]
+    head = '\r\n'.join(lines).encode('utf-8') + b'\r\n'
+    tail = f'\r\n--{boundary}--\r\n'.encode('utf-8')
+    return head + content + tail
+
+
+def test_upload_rejects_invalid_content_type():
+    handler = DummyUploadHandler(body=b'{}', content_type='application/json')
+
+    assert upload_routes.handle_post(handler) is True
+    assert handler.status == 400
+    assert handler.wfile.getvalue() == b'Invalid content type'
+
+
+def test_upload_saves_file_and_returns_record(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    uploads_dir = tmp_path / 'uploads'
+    monkeypatch.setattr(upload_routes, 'UPLOAD_DIR', uploads_dir)
+    monkeypatch.setattr(upload_routes, 'load_upload_history', lambda: [])
+    monkeypatch.setattr(upload_routes, 'get_file_type', lambda _path: 'audio')
+    monkeypatch.setattr(upload_routes, 'get_audio_duration', lambda _path: '00:05')
+
+    captured = {}
+
+    def fake_add_upload_record(file_path, file_type, duration, file_hash):
+        captured['file_path'] = file_path
+        captured['file_type'] = file_type
+        captured['duration'] = duration
+        captured['file_hash'] = file_hash
+        return {'id': 'rec-1', 'file_hash': file_hash}
+
+    monkeypatch.setattr(upload_routes, 'add_upload_record', fake_add_upload_record)
+
+    boundary = '----recordroute-boundary'
+    body = _multipart_body(boundary, 'hello.wav', b'abc123')
+    handler = DummyUploadHandler(body=body, content_type=f'multipart/form-data; boundary={boundary}')
+
+    assert upload_routes.handle_post(handler) is True
+    assert handler.status == 200
+
+    payload = json.loads(handler.wfile.getvalue().decode('utf-8'))
+    assert payload[0]['record_id'] == 'rec-1'
+    assert payload[0]['file_type'] == 'audio'
+    assert payload[0]['file_path'].endswith('/hello.wav')
+    assert captured['file_type'] == 'audio'
+    assert captured['duration'] == '00:05'
+    assert captured['file_path'].exists()
+
+
+def test_upload_returns_duplicate_for_existing_hash(monkeypatch: pytest.MonkeyPatch):
+    file_bytes = b'duplicate-content'
+    existing_hash = upload_routes.compute_file_hash(file_bytes)
+    monkeypatch.setattr(upload_routes, 'load_upload_history', lambda: [{'id': 'rec-existing', 'file_hash': existing_hash}])
+
+    boundary = '----recordroute-boundary'
+    body = _multipart_body(boundary, 'dup.txt', file_bytes)
+    handler = DummyUploadHandler(body=body, content_type=f'multipart/form-data; boundary={boundary}')
+
+    assert upload_routes.handle_post(handler) is True
+    assert handler.status == 200
+    payload = json.loads(handler.wfile.getvalue().decode('utf-8'))
+    assert payload == [{'duplicate': True, 'original_record_id': 'rec-existing', 'filename': 'dup.txt'}]


### PR DESCRIPTION
### Motivation
- Finish route-level modularization by removing heavy upload parsing/storage logic from `UploadHandler` and isolating upload responsibilities. 
- Improve maintainability and testability by extracting multipart parsing, deduplication, file persistence, and response assembly into a focused module. 

### Description
- Added a dedicated upload route module `sttEngine/http_api/routes/upload_routes.py` which implements multipart parsing, hash-based duplicate detection, file save logic, upload record creation, and the `handle_post(handler)` entrypoint. 
- Simplified `sttEngine/http_api/handler.py` so `do_POST()` delegates `/upload` handling to `upload_routes.handle_post(self)` and no longer contains upload parsing/storage logic. 
- Introduced unit tests `tests/http_api/test_upload_routes.py` covering invalid content-type rejection, successful upload persistence/response, and duplicate-file detection. 
- Kept API behavior/contract unchanged; upload response shape and other routes remain compatible with existing handlers. 

### Testing
- Ran targeted regression tests with `PYTHONPATH=. pytest tests/http_api/test_upload_routes.py tests/http_api/test_search.py tests/http_api/test_file_and_similarity_routes.py` and all tests passed (`11 passed`).
- Verified the new upload unit tests exercise multipart parsing, file save, record creation, and duplicate-detection scenarios successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69928cdecbcc832eb68a7e87830b14d2)