### PR TITLE
fix(graph): avoid per-frame degree recomputation

### DIFF
--- a/TODO/Graph.md
+++ b/TODO/Graph.md
@@ -13,7 +13,7 @@
 | 인터랙션(드래그/줌/팬) | 완료 | - | - | 패널에서 휠 줌/배경 팬/노드 드래그 지원 |
 | 기본 필터(min_similarity/max_nodes) | 완료 | - | - | 패널 제어값이 API 요청 파라미터로 연결 |
 | 성능 계측 자동화(100/500/1000 문서) | 완료 | - | - | `frontend/scripts/benchmark-similarity-graph.mjs` + `docs/perf/*` 산출물 |
-| 엣지 가중치 시각화 | 부분완료 | P1 | 범례/스케일 표준화 | opacity/두께 반영, 범례 미구현 |
+| 엣지 가중치 시각화 | 완료 | - | - | opacity/두께 스케일 표준화 + 범례 UI 반영 |
 | 필터(문서타입/기간/키워드) | 미착수 | P1 | metadata 확장 + UI 컨트롤 | 현재 similarity/max_nodes 중심 |
 | 대용량 성능 전략(O(n²) 대응) | 부분완료 | P0 | 샘플링/근사 최근접/증분 계산 설계 | `max_nodes` 샘플링(`recent/random/hybrid`) + 벤치 기준선은 존재하나, 근사 최근접/증분 계산은 미구현 |
 
@@ -21,8 +21,8 @@
 
 | 항목 | 상태 | 우선순위 | 의존관계 |
 |---|---|---|---|
-| 엣지 범례 + 두께 스케일 표준화 | 미착수 | P1 | 스코어 스케일 규칙 |
-| 노드 스타일(문서 타입/중심성 반영) | 미착수 | P1 | metadata 확장 |
+| 엣지 범례 + 두께 스케일 표준화 | 완료 | - | - |
+| 노드 스타일(문서 타입/중심성 반영) | 완료 | - | - |
 | 필터 UI(threshold + 날짜/타입) | 미착수 | P1 | API 파라미터 정리 |
 | 증분 업데이트 전략(신규 문서 추가 시 부분 갱신) | 미착수 | P2 | 인덱스/캐시 구조 변경 |
 | 근사 최근접/샘플링 전략 검토 (대규모 데이터 대응) | 미착수 | P2 | 벤치 기준선/정확도 기준 |
@@ -32,6 +32,7 @@
 | 항목 | 완료 근거 |
 |---|---|
 | 성능 계측(문서 100/500/1000 응답시간) 자동화 | `frontend/scripts/benchmark-similarity-graph.mjs`, `docs/perf/similarity-graph-baseline.json`, `docs/perf/similarity-graph-baseline.md` |
+| 엣지 범례/스케일 표준화 + 노드 스타일 개선 | `frontend/src/components/SimilarityGraphPanel.tsx` |
 
 ## 4) 실행 순서
 

--- a/frontend/src/components/SimilarityGraphPanel.tsx
+++ b/frontend/src/components/SimilarityGraphPanel.tsx
@@ -26,6 +26,20 @@ const EDGE_LENGTH = 120;
 const REPULSION = 18000;
 const SPRING_K = 0.0018;
 
+type DocType = 'audio' | 'document' | 'other';
+
+const AUDIO_EXTENSIONS = new Set(['.mp3', '.wav', '.m4a', '.aac', '.ogg', '.flac', '.wma', '.opus']);
+const DOCUMENT_EXTENSIONS = new Set(['.txt', '.md', '.pdf', '.doc', '.docx', '.ppt', '.pptx', '.xls', '.xlsx', '.hwp']);
+
+const resolveDocType = (filePath?: string): DocType => {
+  if (!filePath) return 'other';
+  const idx = filePath.lastIndexOf('.');
+  const ext = idx >= 0 ? filePath.slice(idx).toLowerCase() : '';
+  if (AUDIO_EXTENSIONS.has(ext)) return 'audio';
+  if (DOCUMENT_EXTENSIONS.has(ext)) return 'document';
+  return 'other';
+};
+
 export function SimilarityGraphPanel() {
   const { theme } = useTheme();
   const svgRef = useRef<SVGSVGElement | null>(null);
@@ -52,6 +66,30 @@ export function SimilarityGraphPanel() {
   const nodeMap = useMemo(() => {
     return new Map(nodes.map((node) => [node.id, node]));
   }, [nodes]);
+
+  const edgeStats = useMemo(() => {
+    const weights = graph?.edges?.map((edge) => edge.weight) ?? [];
+    const min = weights.length ? Math.min(...weights) : minSimilarity;
+    const max = weights.length ? Math.max(...weights) : minSimilarity;
+    return { min, max };
+  }, [graph?.edges, minSimilarity]);
+
+  const degreeMap = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const node of graph?.nodes ?? []) {
+      map.set(node.id, 0);
+    }
+    for (const edge of graph?.edges ?? []) {
+      map.set(edge.source, (map.get(edge.source) ?? 0) + 1);
+      map.set(edge.target, (map.get(edge.target) ?? 0) + 1);
+    }
+    return map;
+  }, [graph?.nodes, graph?.edges]);
+
+  const maxDegree = useMemo(() => {
+    if (degreeMap.size === 0) return 1;
+    return Math.max(...degreeMap.values(), 1);
+  }, [degreeMap]);
 
   const worldFromClient = useCallback((clientX: number, clientY: number) => {
     const rect = svgRef.current?.getBoundingClientRect();
@@ -189,7 +227,28 @@ export function SimilarityGraphPanel() {
     return () => window.cancelAnimationFrame(rafId);
   }, [graph, nodes.length, size.height, size.width]);
 
-  const edgeWidth = (edge: SimilarityEdge) => 1 + Math.max(0, (edge.weight - minSimilarity) * 7);
+  const edgeWidth = (edge: SimilarityEdge) => {
+    const range = Math.max(0.0001, edgeStats.max - edgeStats.min);
+    const normalized = Math.max(0, Math.min(1, (edge.weight - edgeStats.min) / range));
+    return 1.2 + normalized * 3.2;
+  };
+
+  const edgeOpacity = (edge: SimilarityEdge) => {
+    const range = Math.max(0.0001, edgeStats.max - edgeStats.min);
+    const normalized = Math.max(0, Math.min(1, (edge.weight - edgeStats.min) / range));
+    return 0.2 + normalized * 0.7;
+  };
+
+  const getNodeStyle = (node: SimNode) => {
+    const docType = resolveDocType(node.file);
+    const degree = degreeMap.get(node.id) ?? 0;
+    const centrality = degree / Math.max(1, maxDegree);
+    const radius = 7 + centrality * 6;
+
+    if (docType === 'audio') return { radius, fill: '#38bdf8', stroke: '#bae6fd' };
+    if (docType === 'document') return { radius, fill: '#34d399', stroke: '#a7f3d0' };
+    return { radius, fill: '#a78bfa', stroke: '#ddd6fe' };
+  };
 
   const handlePointerMove = (event: ReactPointerEvent<SVGSVGElement>) => {
     const drag = dragStateRef.current;
@@ -275,8 +334,25 @@ export function SimilarityGraphPanel() {
           </div>
         </div>
 
-        <div className={`text-xs ${theme === 'dark' ? 'text-slate-400' : 'text-slate-600'}`}>
-          마우스 휠 줌, 배경 드래그 팬, 노드 드래그 이동, 노드 클릭 선택.
+        <div className={`grid gap-2 text-xs ${theme === 'dark' ? 'text-slate-400' : 'text-slate-600'} lg:grid-cols-[1fr_auto]`}>
+          <div>마우스 휠 줌, 배경 드래그 팬, 노드 드래그 이동, 노드 클릭 선택.</div>
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2">
+              <span className="font-medium">노드 타입</span>
+              <span className="inline-flex items-center gap-1"><span className="size-2 rounded-full bg-sky-400" />audio</span>
+              <span className="inline-flex items-center gap-1"><span className="size-2 rounded-full bg-emerald-400" />document</span>
+              <span className="inline-flex items-center gap-1"><span className="size-2 rounded-full bg-violet-400" />other</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="font-medium">edge weight</span>
+              <svg width="90" height="18" viewBox="0 0 90 18" aria-label="edge weight legend">
+                <line x1="4" y1="9" x2="28" y2="9" stroke={theme === 'dark' ? '#64748b' : '#94a3b8'} strokeWidth={1.4} strokeOpacity={0.25} />
+                <line x1="33" y1="9" x2="57" y2="9" stroke={theme === 'dark' ? '#64748b' : '#94a3b8'} strokeWidth={2.8} strokeOpacity={0.55} />
+                <line x1="62" y1="9" x2="86" y2="9" stroke={theme === 'dark' ? '#64748b' : '#94a3b8'} strokeWidth={4.2} strokeOpacity={0.9} />
+              </svg>
+              <span>{edgeStats.min.toFixed(2)}~{edgeStats.max.toFixed(2)}</span>
+            </div>
+          </div>
         </div>
 
         {error && <div className="text-sm text-red-500">{error}</div>}
@@ -304,21 +380,22 @@ export function SimilarityGraphPanel() {
                     x2={target.x}
                     y2={target.y}
                     stroke={theme === 'dark' ? '#334155' : '#94a3b8'}
-                    strokeOpacity={Math.max(0.18, Math.min(0.95, edge.weight))}
+                    strokeOpacity={edgeOpacity(edge)}
                     strokeWidth={edgeWidth(edge)}
                   />
                 );
               })}
               {nodes.map((node) => {
                 const selected = node.id === selectedNodeId;
+                const style = getNodeStyle(node);
                 return (
                   <g key={node.id}>
                     <circle
                       cx={node.x}
                       cy={node.y}
-                      r={selected ? 11 : 8}
-                      fill={selected ? '#c084fc' : '#60a5fa'}
-                      stroke={selected ? '#f5d0fe' : '#bfdbfe'}
+                      r={selected ? style.radius + 2 : style.radius}
+                      fill={selected ? '#f59e0b' : style.fill}
+                      stroke={selected ? '#fde68a' : style.stroke}
                       strokeWidth={selected ? 2 : 1}
                       onPointerDown={(event) => startNodeDrag(event, node.id)}
                       onClick={(event) => {


### PR DESCRIPTION
### Motivation
- Prevent unnecessary per-frame recomputation of node degree caused by tying topology-derived memoization to animated `nodes` state.
- Keep the visual improvements (edge legend, normalized edge rendering, node styling) from the prior graph work while removing the performance regression.
- Ensure the graph panel computes topology-only values from stable graph payload fields to reduce render churn.

### Description
- Changed `degreeMap` in `frontend/src/components/SimilarityGraphPanel.tsx` to derive from `graph.nodes`/`graph.edges` instead of the animated `nodes` array, and updated the `useMemo` dependencies accordingly. 
- Added stable edge stats (`edgeStats`) and normalized edge helpers (`edgeWidth`, `edgeOpacity`) to scale stroke width/opacity by actual min/max weights. 
- Introduced simple file-type inference (`resolveDocType`) and `getNodeStyle` to compute node radius, fill and stroke by document type and degree-based centrality, and applied these styles to node rendering. 
- Enhanced the panel UI with an inline edge weight legend and updated `TODO/Graph.md` to mark the edge-legend and node-style P1 items as completed.

### Testing
- Built the frontend with `cd frontend && npm run build` and the build completed successfully. 
- Launched the frontend dev server with `cd frontend && npm run dev -- --host 0.0.0.0 --port 4173` and the server started successfully. 
- Captured a Playwright screenshot of the Graph tab to visually validate the panel render, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699480105820832eb9a020603a61b6a5)