### PR TITLE
Graph: use content-based fingerprints for incremental similarity reuse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ GET
   - `/search` 파라미터 정규화: `sort_by(similarity|date, uploaded_at→date)`, `sort_order(asc|desc)`, `status(completed|pending, done/success/incomplete/todo 별칭 지원)`, `status_task(stt|summary|embedding)`
   - `min_score`는 0~1 범위만 유효, 응답은 항상 `contract_version: search-v2` 포함
 - `/api/similarity-graph`, `/api/documents/metadata`
+  - `/api/similarity-graph` 응답 `meta`는 `sampling` + `incremental(reused_pairs/computed_pairs/added_docs/removed_docs/changed_docs)` 진단 정보를 포함
 - `/similar/<uuid_or_path>`, `/models`
 - `/cache/stats`, `/cache/cleanup`
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ venv\Scripts\python.exe -m sttEngine.server
 - `/history`, `/tasks`, `/progress/<task_id>` (진행률 %, ETA, 표준 오류 payload 포함)
 - `/search`, `/models`, `/cache/stats`, `/cache/cleanup`
 - `/api/similarity-graph`, `/api/documents/metadata`
+  - `/api/similarity-graph` 응답 `meta`에는 `sampling`과 `incremental(reused_pairs/computed_pairs/added_docs/removed_docs/changed_docs)` 진단 필드 포함
 
 주요 POST:
 - `/upload`, `/process`, `/cancel`, `/shutdown`

--- a/TODO/Graph.md
+++ b/TODO/Graph.md
@@ -24,7 +24,7 @@
 | 엣지 범례 + 두께 스케일 표준화 | 완료 | - | - |
 | 노드 스타일(문서 타입/중심성 반영) | 완료 | - | - |
 | 필터 UI(threshold + 날짜/타입) | 미착수 | P1 | API 파라미터 정리 |
-| 증분 업데이트 전략(신규 문서 추가 시 부분 갱신) | 미착수 | P2 | 인덱스/캐시 구조 변경 |
+| 증분 업데이트 전략(신규 문서 추가 시 부분 갱신) | 부분완료 | P2 | 인덱스/캐시 구조 변경 |
 | 근사 최근접/샘플링 전략 검토 (대규모 데이터 대응) | 미착수 | P2 | 벤치 기준선/정확도 기준 |
 
 ## 3) 최근 완료 항목
@@ -33,8 +33,9 @@
 |---|---|
 | 성능 계측(문서 100/500/1000 응답시간) 자동화 | `frontend/scripts/benchmark-similarity-graph.mjs`, `docs/perf/similarity-graph-baseline.json`, `docs/perf/similarity-graph-baseline.md` |
 | 엣지 범례/스케일 표준화 + 노드 스타일 개선 | `frontend/src/components/SimilarityGraphPanel.tsx` |
+| 증분 유사도 행렬 재사용(변경 없는 문서 쌍 score 재계산 생략) | `sttEngine/similarity_matrix.py` (`_build_similarity_matrix`, `_INCREMENTAL_STATE`) |
 
 ## 4) 실행 순서
 
 1. **P1** 스타일/범례/필터 고도화
-2. **P2** 증분 계산 고도화
+2. **P2** 증분 계산 고도화 (기본 증분 재사용 구현 완료, 정확도/메모리 최적화 잔여)

--- a/sttEngine/similarity_matrix.py
+++ b/sttEngine/similarity_matrix.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import threading
 import time
 from pathlib import Path
@@ -13,8 +14,9 @@ from .http_api.history import get_active_history
 from .http_api.paths import BASE_DIR, normalize_record_path
 from .http_api.registry import load_file_registry
 
-_CACHE_LOCK = threading.Lock()
+_CACHE_LOCK = threading.RLock()
 _GRAPH_CACHE: dict[tuple[float, int, int, str], dict[str, Any]] = {}
+_INCREMENTAL_STATE: dict[tuple[int, str], dict[str, Any]] = {}
 
 DEFAULT_MIN_SIMILARITY = 0.65
 DEFAULT_MAX_NEIGHBORS = 12
@@ -172,13 +174,12 @@ def _compute_graph(
             },
         }
 
-    matrix = np.zeros((node_count, node_count), dtype=float)
-    for i in range(node_count):
-        matrix[i, i] = 1.0
-        for j in range(i + 1, node_count):
-            score = _cosine_similarity(vectors[i], vectors[j])
-            matrix[i, j] = score
-            matrix[j, i] = score
+    state_key = (max_nodes, sampling_strategy)
+    matrix, incremental_meta = _build_similarity_matrix(
+        state_key=state_key,
+        docs=valid_docs,
+        vectors=vectors,
+    )
 
     nodes = [
         {
@@ -216,14 +217,109 @@ def _compute_graph(
             "max_neighbors": max_neighbors,
             "max_nodes": max_nodes,
             "sampling": sampling_meta,
+            "incremental": incremental_meta,
             "generated_at": time.time(),
         },
+    }
+
+
+def _vector_fingerprint(vector: np.ndarray) -> tuple[str, tuple[int, ...], str]:
+    contiguous = np.ascontiguousarray(vector)
+    digest = hashlib.sha1(contiguous.view(np.uint8).tobytes()).hexdigest()
+    return digest, tuple(contiguous.shape), str(contiguous.dtype)
+
+
+def _build_similarity_matrix(
+    state_key: tuple[int, str],
+    docs: list[dict[str, Any]],
+    vectors: list[np.ndarray],
+) -> tuple[np.ndarray, dict[str, Any]]:
+    node_count = len(docs)
+    matrix = np.zeros((node_count, node_count), dtype=float)
+    if node_count == 0:
+        return matrix, {
+            "reused_pairs": 0,
+            "computed_pairs": 0,
+            "added_docs": 0,
+            "removed_docs": 0,
+            "changed_docs": 0,
+            "strategy": "incremental",
+        }
+
+    current_ids = [str(doc["id"]) for doc in docs]
+    current_fingerprints = {
+        doc_id: _vector_fingerprint(vector)
+        for doc_id, vector in zip(current_ids, vectors)
+    }
+
+    with _CACHE_LOCK:
+        prev_state = _INCREMENTAL_STATE.get(state_key)
+
+    previous_index: dict[str, int] = {}
+    previous_fingerprints: dict[str, tuple[str, tuple[int, ...], str]] = {}
+    previous_matrix: np.ndarray | None = None
+    if prev_state:
+        previous_index = prev_state.get("id_index", {})
+        previous_fingerprints = prev_state.get("fingerprints", {})
+        previous_matrix = prev_state.get("matrix")
+
+    unchanged_ids = {
+        doc_id
+        for doc_id in current_ids
+        if doc_id in previous_index and current_fingerprints.get(doc_id) == previous_fingerprints.get(doc_id)
+    }
+
+    computed_pairs = 0
+    reused_pairs = 0
+
+    for i in range(node_count):
+        matrix[i, i] = 1.0
+        for j in range(i + 1, node_count):
+            source_id = current_ids[i]
+            target_id = current_ids[j]
+            can_reuse = (
+                previous_matrix is not None
+                and source_id in unchanged_ids
+                and target_id in unchanged_ids
+            )
+            if can_reuse:
+                prev_i = previous_index[source_id]
+                prev_j = previous_index[target_id]
+                score = float(previous_matrix[prev_i, prev_j])
+                reused_pairs += 1
+            else:
+                score = _cosine_similarity(vectors[i], vectors[j])
+                computed_pairs += 1
+            matrix[i, j] = score
+            matrix[j, i] = score
+
+    with _CACHE_LOCK:
+        _INCREMENTAL_STATE[state_key] = {
+            "id_index": {doc_id: idx for idx, doc_id in enumerate(current_ids)},
+            "fingerprints": current_fingerprints,
+            "matrix": matrix,
+        }
+
+    previous_ids = set(previous_index.keys())
+    current_ids_set = set(current_ids)
+    added_docs = len(current_ids_set - previous_ids)
+    removed_docs = len(previous_ids - current_ids_set)
+    changed_docs = len(current_ids_set & previous_ids) - len(unchanged_ids)
+
+    return matrix, {
+        "reused_pairs": reused_pairs,
+        "computed_pairs": computed_pairs,
+        "added_docs": max(0, added_docs),
+        "removed_docs": max(0, removed_docs),
+        "changed_docs": max(0, changed_docs),
+        "strategy": "incremental",
     }
 
 
 def invalidate_similarity_cache() -> None:
     with _CACHE_LOCK:
         _GRAPH_CACHE.clear()
+        _INCREMENTAL_STATE.clear()
 
 
 def get_similarity_graph(

--- a/tests/test_similarity_matrix_incremental.py
+++ b/tests/test_similarity_matrix_incremental.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import numpy as np
+
+from sttEngine import similarity_matrix
+
+
+def _doc(doc_id: str, vector_path):
+    return {"id": doc_id, "vector_path": vector_path}
+
+
+def test_incremental_similarity_matrix_reuses_unchanged_pairs(tmp_path):
+    similarity_matrix.invalidate_similarity_cache()
+
+    vec_a = tmp_path / "a.npy"
+    vec_b = tmp_path / "b.npy"
+    vec_c = tmp_path / "c.npy"
+    np.save(vec_a, np.array([1.0, 0.0, 0.0], dtype=float))
+    np.save(vec_b, np.array([0.0, 1.0, 0.0], dtype=float))
+    np.save(vec_c, np.array([0.0, 0.0, 1.0], dtype=float))
+
+    docs = [_doc("a", vec_a), _doc("b", vec_b), _doc("c", vec_c)]
+    vectors = [np.load(vec_a), np.load(vec_b), np.load(vec_c)]
+
+    _, meta_first = similarity_matrix._build_similarity_matrix((150, "hybrid"), docs, vectors)
+    assert meta_first["computed_pairs"] == 3
+    assert meta_first["reused_pairs"] == 0
+
+    _, meta_second = similarity_matrix._build_similarity_matrix((150, "hybrid"), docs, vectors)
+    assert meta_second["computed_pairs"] == 0
+    assert meta_second["reused_pairs"] == 3
+    assert meta_second["added_docs"] == 0
+    assert meta_second["removed_docs"] == 0
+    assert meta_second["changed_docs"] == 0
+
+
+def test_incremental_similarity_matrix_recomputes_changed_docs(tmp_path):
+    similarity_matrix.invalidate_similarity_cache()
+
+    vec_a = tmp_path / "a.npy"
+    vec_b = tmp_path / "b.npy"
+    vec_c = tmp_path / "c.npy"
+    np.save(vec_a, np.array([1.0, 0.0, 0.0], dtype=float))
+    np.save(vec_b, np.array([0.0, 1.0, 0.0], dtype=float))
+    np.save(vec_c, np.array([0.0, 0.0, 1.0], dtype=float))
+
+    docs = [_doc("a", vec_a), _doc("b", vec_b), _doc("c", vec_c)]
+    vectors = [np.load(vec_a), np.load(vec_b), np.load(vec_c)]
+
+    similarity_matrix._build_similarity_matrix((150, "hybrid"), docs, vectors)
+
+    np.save(vec_b, np.array([1.0, 1.0, 0.0], dtype=float))
+    updated_vectors = [np.load(vec_a), np.load(vec_b), np.load(vec_c)]
+
+    _, meta = similarity_matrix._build_similarity_matrix((150, "hybrid"), docs, updated_vectors)
+    assert meta["changed_docs"] == 1
+    assert meta["computed_pairs"] == 2
+    assert meta["reused_pairs"] == 1


### PR DESCRIPTION
### Motivation
- Improve robustness of the Graph incremental reuse by avoiding brittle file `mtime`/`size` heuristics that can fail on some filesystems or CI environments. 
- Ensure that unchanged document vectors are reliably detected so expensive O(n^2) recomputation can be safely reused. 
- Keep diagnostic visibility for incremental computation (reused vs computed pairs, added/removed/changed docs) to aid tuning and monitoring.

### Description
- Replaced filesystem-stat-based detection with a content-based vector fingerprint implemented as `sha1` over the loaded vector bytes plus `shape` and `dtype` in `sttEngine/similarity_matrix.py` via `_vector_fingerprint` and introduced `_build_similarity_matrix` to perform incremental pair reuse. 
- Added `_INCREMENTAL_STATE` to persist previous id/index/fingerprint/matrix and switched the cache lock to `threading.RLock` to simplify safe concurrent updates, and ensured `invalidate_similarity_cache()` clears both `_GRAPH_CACHE` and `_INCREMENTAL_STATE`. 
- Preserved `meta.incremental` diagnostics (`reused_pairs`, `computed_pairs`, `added_docs`, `removed_docs`, `changed_docs`) and integrated incremental results into `get_similarity_graph` responses. 
- Updated tests and docs by adding `tests/test_similarity_matrix_incremental.py` (removed `sleep/utime` reliance) and synchronizing `README.md` and `AGENTS.md` to document the `/api/similarity-graph` incremental diagnostics.

### Testing
- Ran `PYTHONPATH=. pytest tests/test_similarity_matrix_incremental.py tests/http_api/test_file_and_similarity_routes.py tests/http_api/test_search.py tests/server/test_queue.py tests/test_vocab_system.py` and the suite completed successfully (`14 passed`). 
- Ran `PYTHONPATH=. pytest tests/http_api/test_workflow.py` and it completed successfully (`3 passed`). 
- All modified/added tests passed locally and incremental behavior was validated by the new unit tests for unchanged and changed vectors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69948a94b250832e8ea49c96abcfeb40)