### PR TITLE
fix(graph): normalize similarity-graph params and stabilize date filtering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,8 @@ GET
   - `/search` 파라미터 정규화: `sort_by(similarity|date, uploaded_at→date)`, `sort_order(asc|desc)`, `status(completed|pending, done/success/incomplete/todo 별칭 지원)`, `status_task(stt|summary|embedding)`
   - `min_score`는 0~1 범위만 유효, 응답은 항상 `contract_version: search-v2` 포함
 - `/api/similarity-graph`, `/api/documents/metadata`
-  - `/api/similarity-graph` 응답 `meta`는 `sampling` + `incremental(reused_pairs/computed_pairs/added_docs/removed_docs/changed_docs)` 진단 정보를 포함
+  - `/api/similarity-graph`는 `min_similarity/max_neighbors/max_nodes/sampling` + 필터(`doc_types`, `start_date`, `end_date`, `keyword`)를 지원
+  - 응답 `meta`는 `sampling`, `filters`, `incremental(reused_pairs/computed_pairs/added_docs/removed_docs/changed_docs)` 진단 정보를 포함
 - `/similar/<uuid_or_path>`, `/models`
 - `/cache/stats`, `/cache/cleanup`
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ venv\Scripts\python.exe -m sttEngine.server
 - `/history`, `/tasks`, `/progress/<task_id>` (진행률 %, ETA, 표준 오류 payload 포함)
 - `/search`, `/models`, `/cache/stats`, `/cache/cleanup`
 - `/api/similarity-graph`, `/api/documents/metadata`
-  - `/api/similarity-graph` 응답 `meta`에는 `sampling`과 `incremental(reused_pairs/computed_pairs/added_docs/removed_docs/changed_docs)` 진단 필드 포함
+  - `/api/similarity-graph`는 `min_similarity/max_neighbors/max_nodes/sampling` + 필터(`doc_types`, `start_date`, `end_date`, `keyword`)를 지원
+  - 응답 `meta`에는 `sampling`, `filters`, `incremental(reused_pairs/computed_pairs/added_docs/removed_docs/changed_docs)` 진단 필드 포함
 
 주요 POST:
 - `/upload`, `/process`, `/cancel`, `/shutdown`

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -183,6 +183,10 @@ export async function getSimilarityGraph(request: SimilarityGraphRequest = {}): 
   if (request.max_nodes !== undefined) params.set('max_nodes', String(request.max_nodes));
   if (request.sampling) params.set('sampling', request.sampling);
   if (request.doc_id) params.set('doc_id', request.doc_id);
+  if (request.doc_types?.length) params.set('doc_types', request.doc_types.join(','));
+  if (request.start_date) params.set('start_date', request.start_date);
+  if (request.end_date) params.set('end_date', request.end_date);
+  if (request.keyword) params.set('keyword', request.keyword);
   if (request.refresh !== undefined) params.set('refresh', String(request.refresh));
   const query = params.toString();
   return apiRequest<SimilarityGraphResponse>(`/api/similarity-graph${query ? `?${query}` : ''}`);

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -128,6 +128,7 @@ export interface SimilarityGraphNode {
   id: string;
   label: string;
   file?: string;
+  file_type?: 'audio' | 'document' | 'other';
   record_id?: string | null;
   uploaded_at?: string | null;
 }
@@ -150,6 +151,10 @@ export interface SimilarityGraphRequest {
   max_nodes?: number;
   sampling?: 'recent' | 'random' | 'hybrid';
   doc_id?: string;
+  doc_types?: Array<'audio' | 'document' | 'other'>;
+  start_date?: string;
+  end_date?: string;
+  keyword?: string;
   refresh?: boolean;
 }
 

--- a/frontend/src/components/SimilarityGraphPanel.tsx
+++ b/frontend/src/components/SimilarityGraphPanel.tsx
@@ -31,7 +31,8 @@ type DocType = 'audio' | 'document' | 'other';
 const AUDIO_EXTENSIONS = new Set(['.mp3', '.wav', '.m4a', '.aac', '.ogg', '.flac', '.wma', '.opus']);
 const DOCUMENT_EXTENSIONS = new Set(['.txt', '.md', '.pdf', '.doc', '.docx', '.ppt', '.pptx', '.xls', '.xlsx', '.hwp']);
 
-const resolveDocType = (filePath?: string): DocType => {
+const resolveDocType = (filePath?: string, fileType?: string): DocType => {
+  if (fileType === 'audio' || fileType === 'document' || fileType === 'other') return fileType;
   if (!filePath) return 'other';
   const idx = filePath.lastIndexOf('.');
   const ext = idx >= 0 ? filePath.slice(idx).toLowerCase() : '';
@@ -47,6 +48,13 @@ export function SimilarityGraphPanel() {
 
   const [minSimilarity, setMinSimilarity] = useState(0.65);
   const [maxNodes, setMaxNodes] = useState(120);
+  const [sampling, setSampling] = useState<'hybrid' | 'recent' | 'random'>('hybrid');
+  const [keyword, setKeyword] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [docTypeAudio, setDocTypeAudio] = useState(true);
+  const [docTypeDocument, setDocTypeDocument] = useState(true);
+  const [docTypeOther, setDocTypeOther] = useState(true);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [graph, setGraph] = useState<SimilarityGraphResponse | null>(null);
@@ -126,10 +134,19 @@ export function SimilarityGraphPanel() {
     setLoading(true);
     setError(null);
     try {
+      const docTypes: Array<'audio' | 'document' | 'other'> = [];
+      if (docTypeAudio) docTypes.push('audio');
+      if (docTypeDocument) docTypes.push('document');
+      if (docTypeOther) docTypes.push('other');
+
       const payload = await api.getSimilarityGraph({
         min_similarity: minSimilarity,
         max_nodes: maxNodes,
-        sampling: 'hybrid',
+        sampling,
+        doc_types: docTypes.length ? docTypes : ['audio', 'document', 'other'],
+        start_date: startDate || undefined,
+        end_date: endDate || undefined,
+        keyword: keyword.trim() || undefined,
       });
       setGraph(payload);
       initPositions(payload);
@@ -141,7 +158,7 @@ export function SimilarityGraphPanel() {
     } finally {
       setLoading(false);
     }
-  }, [initPositions, maxNodes, minSimilarity]);
+  }, [docTypeAudio, docTypeDocument, docTypeOther, endDate, initPositions, keyword, maxNodes, minSimilarity, sampling, startDate]);
 
   useEffect(() => {
     loadGraph();
@@ -240,7 +257,7 @@ export function SimilarityGraphPanel() {
   };
 
   const getNodeStyle = (node: SimNode) => {
-    const docType = resolveDocType(node.file);
+    const docType = resolveDocType(node.file, node.file_type);
     const degree = degreeMap.get(node.id) ?? 0;
     const centrality = degree / Math.max(1, maxDegree);
     const radius = 7 + centrality * 6;
@@ -322,6 +339,35 @@ export function SimilarityGraphPanel() {
             <label className="text-xs font-medium">max nodes</label>
             <Input type="number" min={20} max={180} step={10} value={maxNodes}
               onChange={(e) => setMaxNodes(Number(e.target.value || 120))} className="w-28" />
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-medium">sampling</label>
+            <select
+              value={sampling}
+              onChange={(e) => setSampling(e.target.value as 'hybrid' | 'recent' | 'random')}
+              className={`h-10 rounded-md border px-3 text-sm ${theme === 'dark' ? 'border-slate-700 bg-slate-900' : 'border-slate-300 bg-white'}`}
+            >
+              <option value="hybrid">hybrid</option>
+              <option value="recent">recent</option>
+              <option value="random">random</option>
+            </select>
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-medium">keyword</label>
+            <Input type="text" value={keyword} onChange={(e) => setKeyword(e.target.value)} className="w-40" placeholder="파일명/경로" />
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-medium">start</label>
+            <Input type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} className="w-40" />
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-medium">end</label>
+            <Input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} className="w-40" />
+          </div>
+          <div className="flex items-end gap-3 pb-1 text-xs">
+            <label className="inline-flex items-center gap-1"><input type="checkbox" checked={docTypeAudio} onChange={(e) => setDocTypeAudio(e.target.checked)} /> audio</label>
+            <label className="inline-flex items-center gap-1"><input type="checkbox" checked={docTypeDocument} onChange={(e) => setDocTypeDocument(e.target.checked)} /> document</label>
+            <label className="inline-flex items-center gap-1"><input type="checkbox" checked={docTypeOther} onChange={(e) => setDocTypeOther(e.target.checked)} /> other</label>
           </div>
           <Button onClick={() => void loadGraph()} disabled={loading} className="gap-2">
             <RefreshCw className={`size-4 ${loading ? 'animate-spin' : ''}`} /> Reload

--- a/sttEngine/http_api/routes/similarity_routes.py
+++ b/sttEngine/http_api/routes/similarity_routes.py
@@ -12,16 +12,60 @@ def _read_json_payload(handler):
     return json.loads(handler.rfile.read(length)) if length else {}
 
 
+
+
+def _first(params, *names: str, default: str = "") -> str:
+    for name in names:
+        values = params.get(name)
+        if values:
+            return values[0]
+    return default
+
+
+def _parse_int(value: str, default: int, *, minimum: int | None = None, maximum: int | None = None) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    if minimum is not None:
+        parsed = max(minimum, parsed)
+    if maximum is not None:
+        parsed = min(maximum, parsed)
+    return parsed
+
+
+def _parse_float(value: str, default: float, *, minimum: float | None = None, maximum: float | None = None) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        parsed = default
+    if minimum is not None:
+        parsed = max(minimum, parsed)
+    if maximum is not None:
+        parsed = min(maximum, parsed)
+    return parsed
+
+
+def _parse_bool(value: str) -> bool:
+    return (value or '').strip().lower() in {'1', 'true', 't', 'yes', 'y', 'on'}
+
 def handle_get(handler) -> bool:
     if handler.path.startswith('/api/similarity-graph'):
         parsed = urlparse(handler.path)
         params = parse_qs(parsed.query)
-        min_similarity = float(params.get('min_similarity', params.get('threshold', ['0.65']))[0])
-        max_neighbors = int(params.get('max_neighbors', ['12'])[0])
-        max_nodes = int(params.get('max_nodes', ['150'])[0])
-        sampling_strategy = (params.get('sampling', ['hybrid'])[0] or 'hybrid').lower()
-        doc_id = (params.get('doc_id', [''])[0] or '').strip() or None
-        refresh = params.get('refresh', ['false'])[0].lower() == 'true'
+        min_similarity = _parse_float(_first(params, 'min_similarity', 'threshold', default='0.65'), 0.65, minimum=0.0, maximum=1.0)
+        max_neighbors = _parse_int(_first(params, 'max_neighbors', default='12'), 12, minimum=1)
+        max_nodes = _parse_int(_first(params, 'max_nodes', default='150'), 150, minimum=1)
+        sampling_strategy = (_first(params, 'sampling', default='hybrid') or 'hybrid').strip().lower()
+        doc_id = (_first(params, 'doc_id', default='') or '').strip() or None
+        refresh = _parse_bool(_first(params, 'refresh', default='false'))
+        raw_doc_types = params.get('doc_types', params.get('file_type', []))
+        doc_types: list[str] = []
+        for item in raw_doc_types:
+            doc_types.extend([part.strip().lower() for part in item.split(',') if part.strip()])
+        start_date = (_first(params, 'start_date', 'start', default='') or '').strip() or None
+        end_date = (_first(params, 'end_date', 'end', default='') or '').strip() or None
+        keyword = (params.get('keyword', [''])[0] or '').strip() or None
 
         payload = get_similarity_graph(
             min_similarity=min_similarity,
@@ -29,6 +73,10 @@ def handle_get(handler) -> bool:
             max_nodes=max_nodes,
             sampling_strategy=sampling_strategy,
             doc_id=doc_id,
+            doc_types=doc_types,
+            start_date=start_date,
+            end_date=end_date,
+            keyword=keyword,
             refresh=refresh,
         )
 

--- a/sttEngine/similarity_matrix.py
+++ b/sttEngine/similarity_matrix.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import threading
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 import random
 from typing import Any
@@ -15,7 +16,7 @@ from .http_api.paths import BASE_DIR, normalize_record_path
 from .http_api.registry import load_file_registry
 
 _CACHE_LOCK = threading.RLock()
-_GRAPH_CACHE: dict[tuple[float, int, int, str], dict[str, Any]] = {}
+_GRAPH_CACHE: dict[tuple[Any, ...], dict[str, Any]] = {}
 _INCREMENTAL_STATE: dict[tuple[int, str], dict[str, Any]] = {}
 
 DEFAULT_MIN_SIMILARITY = 0.65
@@ -23,6 +24,9 @@ DEFAULT_MAX_NEIGHBORS = 12
 DEFAULT_MAX_NODES = 150
 DEFAULT_SAMPLING_STRATEGY = "hybrid"
 ALLOWED_SAMPLING_STRATEGIES = {"hybrid", "recent", "random"}
+ALLOWED_DOC_TYPES = {"audio", "document", "other"}
+AUDIO_EXTENSIONS = {".mp3", ".wav", ".m4a", ".aac", ".ogg", ".flac", ".wma", ".opus"}
+DOCUMENT_EXTENSIONS = {".txt", ".md", ".pdf", ".doc", ".docx", ".ppt", ".pptx", ".xls", ".xlsx", ".hwp"}
 
 
 def _cosine_similarity(vec_a: np.ndarray, vec_b: np.ndarray) -> float:
@@ -87,12 +91,103 @@ def _build_doc_catalog() -> list[dict[str, Any]]:
 
 
 def _safe_timestamp(value: Any) -> float:
-    try:
-        if value is None:
-            return 0.0
-        return float(value)
-    except Exception:
+    if value is None:
         return 0.0
+
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return 0.0
+        try:
+            return float(raw)
+        except ValueError:
+            parsed = _parse_datetime(raw)
+            return parsed if parsed is not None else 0.0
+
+    return 0.0
+
+
+def _resolve_doc_type(file_path: str | None) -> str:
+    if not file_path:
+        return "other"
+    suffix = Path(file_path).suffix.lower()
+    if suffix in AUDIO_EXTENSIONS:
+        return "audio"
+    if suffix in DOCUMENT_EXTENSIONS:
+        return "document"
+    return "other"
+
+
+def _parse_datetime(value: str | None) -> float | None:
+    if not value:
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+
+    try:
+        return float(raw)
+    except ValueError:
+        pass
+
+    normalized = raw.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+
+    return parsed.timestamp()
+
+
+def _filter_docs(
+    docs: list[dict[str, Any]],
+    *,
+    doc_types: set[str] | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    keyword: str | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    normalized_types = {item.lower() for item in (doc_types or set()) if item.lower() in ALLOWED_DOC_TYPES}
+    keyword_norm = (keyword or "").strip().lower()
+    start_ts = _parse_datetime(start_date)
+    end_ts = _parse_datetime(end_date)
+
+    filtered: list[dict[str, Any]] = []
+    for doc in docs:
+        current_type = _resolve_doc_type(doc.get("file"))
+        if normalized_types and current_type not in normalized_types:
+            continue
+
+        uploaded_ts = _safe_timestamp(doc.get("uploaded_at"))
+        if start_ts is not None and uploaded_ts < start_ts:
+            continue
+        if end_ts is not None and uploaded_ts > end_ts:
+            continue
+
+        if keyword_norm:
+            haystack = " ".join(
+                str(part or "")
+                for part in (doc.get("display_name"), doc.get("file"), doc.get("id"))
+            ).lower()
+            if keyword_norm not in haystack:
+                continue
+
+        filtered.append(doc)
+
+    return filtered, {
+        "doc_types": sorted(normalized_types),
+        "start_date": start_date,
+        "end_date": end_date,
+        "keyword": keyword_norm or None,
+        "total_before_filtering": len(docs),
+        "total_after_filtering": len(filtered),
+    }
 
 
 def _sample_docs(docs: list[dict[str, Any]], max_nodes: int, strategy: str) -> tuple[list[dict[str, Any]], dict[str, Any]]:
@@ -136,8 +231,19 @@ def _compute_graph(
     max_neighbors: int = DEFAULT_MAX_NEIGHBORS,
     max_nodes: int = DEFAULT_MAX_NODES,
     sampling_strategy: str = DEFAULT_SAMPLING_STRATEGY,
+    doc_types: set[str] | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    keyword: str | None = None,
 ) -> dict[str, Any]:
     docs = _build_doc_catalog()
+    docs, filter_meta = _filter_docs(
+        docs,
+        doc_types=doc_types,
+        start_date=start_date,
+        end_date=end_date,
+        keyword=keyword,
+    )
     docs, sampling_meta = _sample_docs(docs, max_nodes=max_nodes, strategy=sampling_strategy)
 
     if not docs:
@@ -148,6 +254,7 @@ def _compute_graph(
                 "min_similarity": min_similarity,
                 "count": 0,
                 "generated_at": time.time(),
+                "filters": filter_meta,
                 "sampling": sampling_meta,
             },
         }
@@ -170,6 +277,7 @@ def _compute_graph(
                 "min_similarity": min_similarity,
                 "count": 0,
                 "generated_at": time.time(),
+                "filters": filter_meta,
                 "sampling": sampling_meta,
             },
         }
@@ -186,6 +294,7 @@ def _compute_graph(
             "id": doc["id"],
             "label": doc["display_name"],
             "file": doc["file"],
+            "file_type": _resolve_doc_type(doc.get("file")),
             "record_id": doc.get("record_id"),
             "uploaded_at": doc.get("uploaded_at"),
         }
@@ -210,12 +319,13 @@ def _compute_graph(
         "nodes": nodes,
         "edges": edges,
         "meta": {
-            "node_schema": {"id": "string", "label": "string", "record_id": "string|null", "file": "string"},
+            "node_schema": {"id": "string", "label": "string", "record_id": "string|null", "file": "string", "file_type": "audio|document|other"},
             "edge_schema": {"source": "string", "target": "string", "weight": "number"},
             "min_similarity": min_similarity,
             "count": node_count,
             "max_neighbors": max_neighbors,
             "max_nodes": max_nodes,
+            "filters": filter_meta,
             "sampling": sampling_meta,
             "incremental": incremental_meta,
             "generated_at": time.time(),
@@ -328,10 +438,25 @@ def get_similarity_graph(
     max_nodes: int = DEFAULT_MAX_NODES,
     sampling_strategy: str = DEFAULT_SAMPLING_STRATEGY,
     doc_id: str | None = None,
+    doc_types: list[str] | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    keyword: str | None = None,
     refresh: bool = False,
 ) -> dict[str, Any]:
     strategy = sampling_strategy if sampling_strategy in ALLOWED_SAMPLING_STRATEGIES else DEFAULT_SAMPLING_STRATEGY
-    key = (round(float(min_similarity), 4), int(max_neighbors), int(max_nodes), strategy)
+    normalized_doc_types = tuple(sorted({item.lower() for item in (doc_types or []) if item.lower() in ALLOWED_DOC_TYPES}))
+    normalized_keyword = (keyword or "").strip().lower()
+    key = (
+        round(float(min_similarity), 4),
+        int(max_neighbors),
+        int(max_nodes),
+        strategy,
+        normalized_doc_types,
+        (start_date or "").strip(),
+        (end_date or "").strip(),
+        normalized_keyword,
+    )
     with _CACHE_LOCK:
         if not refresh and key in _GRAPH_CACHE:
             graph = _GRAPH_CACHE[key]
@@ -341,6 +466,10 @@ def get_similarity_graph(
                 max_neighbors=max_neighbors,
                 max_nodes=max_nodes,
                 sampling_strategy=strategy,
+                doc_types=set(normalized_doc_types),
+                start_date=start_date,
+                end_date=end_date,
+                keyword=normalized_keyword or None,
             )
             _GRAPH_CACHE[key] = graph
 
@@ -388,6 +517,7 @@ def get_documents_metadata() -> dict[str, Any]:
                 "id": doc["id"],
                 "file": doc["file"],
                 "display_name": doc["display_name"],
+                "file_type": _resolve_doc_type(doc.get("file")),
                 "record_id": doc.get("record_id"),
                 "uploaded_at": doc.get("uploaded_at"),
             }

--- a/tests/http_api/test_similarity_graph.py
+++ b/tests/http_api/test_similarity_graph.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import threading
+from http.server import ThreadingHTTPServer
+from urllib.parse import quote
+from urllib.request import urlopen
+
+import pytest
+
+from sttEngine.http_api.handler import UploadHandler
+
+
+@pytest.fixture
+def server(monkeypatch: pytest.MonkeyPatch):
+    from sttEngine.http_api.routes import similarity_routes
+
+    captured: dict[str, object] = {}
+
+    def fake_graph(**kwargs):
+        captured.update(kwargs)
+        return {"nodes": [], "edges": [], "meta": {"ok": True}}
+
+    monkeypatch.setattr(similarity_routes, "get_similarity_graph", fake_graph)
+
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), UploadHandler)
+    worker = threading.Thread(target=httpd.serve_forever, daemon=True)
+    worker.start()
+
+    base_url = f"http://127.0.0.1:{httpd.server_port}"
+    try:
+        yield base_url, captured
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        worker.join(timeout=2)
+
+
+def test_similarity_graph_accepts_filter_and_sampling_query(server):
+    base_url, captured = server
+    with urlopen(
+        (
+            f"{base_url}/api/similarity-graph?min_similarity=0.7&max_neighbors=8&max_nodes=90"
+            "&sampling=recent&doc_types=audio,document&start_date=2025-01-01"
+            f"&end_date=2025-12-31&keyword={quote('회의')}"
+        )
+    ) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+
+    assert payload["meta"]["ok"] is True
+    assert captured["min_similarity"] == 0.7
+    assert captured["max_neighbors"] == 8
+    assert captured["max_nodes"] == 90
+    assert captured["sampling_strategy"] == "recent"
+    assert captured["doc_types"] == ["audio", "document"]
+    assert captured["start_date"] == "2025-01-01"
+    assert captured["end_date"] == "2025-12-31"
+    assert captured["keyword"] == "회의"
+
+
+def test_similarity_graph_normalizes_invalid_params(server):
+    base_url, captured = server
+    with urlopen(
+        f"{base_url}/api/similarity-graph?min_similarity=bad&max_neighbors=0&max_nodes=-2&refresh=YES"
+    ) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+
+    assert payload["meta"]["ok"] is True
+    assert captured["min_similarity"] == 0.65
+    assert captured["max_neighbors"] == 1
+    assert captured["max_nodes"] == 1
+    assert captured["refresh"] is True
+
+
+def test_similarity_graph_accepts_start_end_alias(server):
+    base_url, captured = server
+    with urlopen(f"{base_url}/api/similarity-graph?start=2025-01-01&end=2025-12-31") as response:
+        payload = json.loads(response.read().decode("utf-8"))
+
+    assert payload["meta"]["ok"] is True
+    assert captured["start_date"] == "2025-01-01"
+    assert captured["end_date"] == "2025-12-31"

--- a/tests/test_similarity_matrix_filters.py
+++ b/tests/test_similarity_matrix_filters.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from sttEngine import similarity_matrix
+
+
+def test_filter_docs_supports_iso_uploaded_at_and_doc_types():
+    docs = [
+        {
+            "id": "a",
+            "display_name": "회의록 A",
+            "file": "DB/uploads/a/audio.m4a",
+            "uploaded_at": "2025-01-02T10:00:00Z",
+        },
+        {
+            "id": "b",
+            "display_name": "회의록 B",
+            "file": "DB/uploads/b/notes.md",
+            "uploaded_at": "2024-12-31T23:59:59Z",
+        },
+    ]
+
+    filtered, meta = similarity_matrix._filter_docs(
+        docs,
+        doc_types={"audio"},
+        start_date="2025-01-01",
+        end_date="2025-12-31",
+    )
+
+    assert [doc["id"] for doc in filtered] == ["a"]
+    assert meta["doc_types"] == ["audio"]
+    assert meta["total_before_filtering"] == 2
+    assert meta["total_after_filtering"] == 1
+
+
+def test_safe_timestamp_parses_iso_string():
+    ts = similarity_matrix._safe_timestamp("2025-01-01T00:00:00Z")
+    assert ts > 0


### PR DESCRIPTION
### Motivation
- Prevent server errors and surprising behavior when `/api/similarity-graph` receives malformed numeric/boolean params by centralizing and normalizing query parsing.  
- Make date filtering more robust by accepting ISO datetimes (including `Z`) and treating naive datetimes as UTC.  
- Surface document-type/date/keyword filters and sampling controls consistently to the frontend and cache while providing diagnostics in the graph `meta` for easier inspection and debugging.

### Description
- Added safe parsing helpers in `sttEngine/http_api/routes/similarity_routes.py` (`_first`, `_parse_int`, `_parse_float`, `_parse_bool`) and normalized incoming query parameters (including `start`/`end` aliases and `doc_types`) before calling `get_similarity_graph`.  
- Hardened graph generation in `sttEngine/similarity_matrix.py` by improving `_safe_timestamp` and `_parse_datetime`, adding `_filter_docs` and exposing sampling/filter metadata, adding `file_type` to node payloads, and incorporating filters/keyword into the cache key.  
- Updated frontend types and client to send new params (`doc_types`, `start_date`, `end_date`, `keyword`) and extended `SimilarityGraphPanel.tsx` with sampling selector, date inputs, keyword, and doc-type toggles while using `file_type` when available.  
- Added regression tests: `tests/http_api/test_similarity_graph.py` (query parsing/alias/normalization) and `tests/test_similarity_matrix_filters.py` (ISO timestamp parsing and doc-type/date filtering).

### Testing
- Ran unit/regression tests with `PYTHONPATH=. pytest tests/http_api/test_similarity_graph.py tests/test_similarity_matrix_incremental.py tests/test_similarity_matrix_filters.py` and all tests passed.  
- Built the frontend with `cd frontend && npm run build` and the production build completed successfully.  
- New tests exercise malformed params, `start`/`end` aliasing, ISO `uploaded_at` parsing, and doc-type/date filtering and are included in the test run above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994946d4040832eb0feb1645901dc12)