### PR TITLE
[Graph] Add filters + candidate_strategy to similarity-graph API, LSH PoC, and cache-key regression tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,8 @@ GET
   - `/search` 파라미터 정규화: `sort_by(similarity|date, uploaded_at→date)`, `sort_order(asc|desc)`, `status(completed|pending, done/success/incomplete/todo 별칭 지원)`, `status_task(stt|summary|embedding)`
   - `min_score`는 0~1 범위만 유효, 응답은 항상 `contract_version: search-v2` 포함
 - `/api/similarity-graph`, `/api/documents/metadata`
-  - `/api/similarity-graph` 응답 `meta`는 `sampling` + `incremental(reused_pairs/computed_pairs/added_docs/removed_docs/changed_docs)` 진단 정보를 포함
+  - `/api/similarity-graph`는 `min_similarity/max_neighbors/max_nodes/sampling` + 필터(`doc_types`, `start_date`, `end_date`, `keyword`) + `candidate_strategy(auto|exact|lsh)`를 지원
+  - `/api/similarity-graph` 응답 `meta`는 `sampling`, `filters`, `incremental(reused_pairs/computed_pairs/added_docs/removed_docs/changed_docs)`, `candidate_reduction(strategy/total_pairs/candidate_pairs/reduction_ratio/estimated_recall_at_k)` 진단 정보를 포함
 - `/similar/<uuid_or_path>`, `/models`
 - `/cache/stats`, `/cache/cleanup`
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ venv\Scripts\python.exe -m sttEngine.server
 - `/history`, `/tasks`, `/progress/<task_id>` (진행률 %, ETA, 표준 오류 payload 포함)
 - `/search`, `/models`, `/cache/stats`, `/cache/cleanup`
 - `/api/similarity-graph`, `/api/documents/metadata`
-  - `/api/similarity-graph` 응답 `meta`에는 `sampling`과 `incremental(reused_pairs/computed_pairs/added_docs/removed_docs/changed_docs)` 진단 필드 포함
+  - `/api/similarity-graph`는 `min_similarity/max_neighbors/max_nodes/sampling` + 필터(`doc_types`, `start_date`, `end_date`, `keyword`) + `candidate_strategy(auto|exact|lsh)`를 지원
+  - `/api/similarity-graph` 응답 `meta`에는 `sampling`, `filters`, `incremental(reused_pairs/computed_pairs/added_docs/removed_docs/changed_docs)`, `candidate_reduction(strategy/total_pairs/candidate_pairs/reduction_ratio/estimated_recall_at_k)` 진단 필드 포함
 
 주요 POST:
 - `/upload`, `/process`, `/cancel`, `/shutdown`

--- a/TODO/Graph.md
+++ b/TODO/Graph.md
@@ -9,7 +9,7 @@
 | 항목 | 상태 | 우선순위 | 의존관계 | 근거 |
 |---|---|---|---|---|
 | 유사도 그래프 계산 모듈(`similarity_matrix.py`) | 완료 | - | - | 코사인 유사도, threshold/max_neighbors, 캐시, 서브그래프 제공 |
-| 그래프 API(`/api/similarity-graph`, `/api/documents/metadata`) | 완료 | - | - | GET 엔드포인트 동작 + `sampling`/`max_nodes` 파라미터 처리 |
+| 그래프 API(`/api/similarity-graph`, `/api/documents/metadata`) | 완료 | - | - | GET 엔드포인트 동작 + `sampling`/`max_nodes`/`candidate_strategy` + 필터(`doc_types/start_date/end_date/keyword`) 처리 |
 | React 그래프 패널 메인 탭 통합 | 완료 | - | - | `App.tsx` `graph` 탭 + `SimilarityGraphPanel` 연동 |
 | 인터랙션(드래그/줌/팬) | 완료 | - | - | 패널에서 휠 줌/배경 팬/노드 드래그 지원 |
 | 기본 필터(min_similarity/max_nodes) | 완료 | - | - | 패널 제어값이 API 요청 파라미터로 연결 |
@@ -17,7 +17,7 @@
 | 성능 계측 자동화(100/500/1000 문서) | 완료 | - | - | `benchmark-similarity-graph.mjs` + `docs/perf/*` 산출물 유지 |
 | 증분 유사도 재사용(변경 없는 문서쌍 재계산 생략) | 완료 | - | - | `_INCREMENTAL_STATE` + fingerprint 기반 `reused_pairs/computed_pairs` 계산 |
 | 고급 필터(문서타입/기간/키워드) | 미착수 | P1 | metadata 확장 + UI 컨트롤 | 현재 UI/API는 similarity/max_nodes(+sampling) 중심 |
-| 대용량 성능 전략(O(n²) 근본 대응: ANN/근사 최근접) | 미착수 | P0 | 인덱스/정확도 기준/벤치 시나리오 | 샘플링/증분은 있으나 유사도 계산 자체는 여전히 pairwise |
+| 대용량 성능 전략(O(n²) 근본 대응: ANN/근사 최근접) | 부분완료 | P0 | 인덱스/정확도 기준/벤치 시나리오 | LSH 기반 후보 축소 PoC(`candidate_strategy=auto|exact|lsh`) 도입, `candidate_reduction` 메타로 축소율/추정 recall@k 노출 |
 
 ## 2) 유효 백로그 (다음 스프린트)
 
@@ -26,7 +26,7 @@
 | 필터 UI(threshold + 날짜/타입/키워드) | 미착수 | P1 | API 파라미터 + metadata 필드 확장 |
 | sampling 전략 선택 UI(recent/random/hybrid) 노출 | 미착수 | P1 | 프론트 컨트롤 + API 파라미터 동기화 |
 | 증분 업데이트 고도화(메모리/TTL/캐시 정책) | 부분완료 | P2 | 인덱스/캐시 구조 변경 |
-| 근사 최근접(ANN) 또는 후보 축소 전략 PoC | 미착수 | P0 | 정확도 허용오차 + 성능 목표 합의 |
+| 근사 최근접(ANN) 또는 후보 축소 전략 PoC | 완료 | P0 | 정확도 허용오차 + 성능 목표 합의 |
 | 벤치마크 확장(실서버 + 대용량 구간 2k/5k) | 미착수 | P2 | 테스트 데이터셋/실서버 계측 환경 |
 
 ## 3) 최근 완료 항목
@@ -40,6 +40,6 @@
 
 ## 4) 실행 순서
 
-1. **P0** O(n²) 병목 완화를 위한 ANN/후보축소 PoC 및 정확도/성능 기준 정의
-2. **P1** 사용자 필터(날짜/타입/키워드) + sampling 선택 UI/API 동기화
-3. **P2** 증분 캐시 정책(메모리/TTL/무효화) 및 벤치마크 시나리오 확장
+1. **P1** 사용자 필터(날짜/타입/키워드) + sampling 선택 UI/API 동기화
+2. **P2** 증분 캐시 정책(메모리/TTL/무효화) 및 벤치마크 시나리오 확장
+3. **P2** ANN PoC 정확도 허용오차(예: recall@k 하한) 및 대용량(2k/5k) 성능 목표 수치화

--- a/frontend/scripts/benchmark-similarity-graph.mjs
+++ b/frontend/scripts/benchmark-similarity-graph.mjs
@@ -15,6 +15,7 @@ function parseArgs(argv) {
     apiBaseUrl: null,
     minSimilarity: 0.65,
     sampling: 'hybrid',
+    candidateStrategy: 'auto',
     mockResponseDelayMs: 8,
   };
 
@@ -26,6 +27,10 @@ function parseArgs(argv) {
     } else if (arg.startsWith('--min-similarity=')) {
       const parsed = Number(arg.slice('--min-similarity='.length));
       if (!Number.isNaN(parsed)) options.minSimilarity = parsed;
+    } else if (arg.startsWith('--sampling=')) {
+      options.sampling = arg.slice('--sampling='.length) || 'hybrid';
+    } else if (arg.startsWith('--candidate-strategy=')) {
+      options.candidateStrategy = arg.slice('--candidate-strategy='.length) || 'auto';
     } else if (arg.startsWith('--mock-response-delay-ms=')) {
       const parsed = Number(arg.slice('--mock-response-delay-ms='.length));
       if (!Number.isNaN(parsed) && parsed >= 0) options.mockResponseDelayMs = parsed;
@@ -157,6 +162,7 @@ async function measureResponseTimeMs(size, options) {
   url.searchParams.set('min_similarity', String(options.minSimilarity));
   url.searchParams.set('max_nodes', String(size));
   url.searchParams.set('sampling', options.sampling);
+  url.searchParams.set('candidate_strategy', options.candidateStrategy);
 
   const start = performance.now();
   const response = await fetch(url);
@@ -226,6 +232,8 @@ function makeMarkdownReport(result) {
 - Response source: ${result.mode === 'real_api' ? `real API (${result.apiBaseUrl})` : `mock delay (${result.mockResponseDelayMs} ms)`}
 - Iterations per scenario: ${result.iterations}
 - Dataset sizes: ${result.scenarios.map((scenario) => scenario.nodeCount).join(', ')}
+- Sampling strategy: ${result.sampling}
+- Candidate strategy: ${result.candidateStrategy}
 
 ## Summary
 
@@ -256,6 +264,8 @@ async function run() {
     apiBaseUrl: options.apiBaseUrl,
     mockResponseDelayMs: options.mockResponseDelayMs,
     iterations: ITERATIONS,
+    sampling: options.sampling,
+    candidateStrategy: options.candidateStrategy,
     scenarios,
   };
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -182,6 +182,11 @@ export async function getSimilarityGraph(request: SimilarityGraphRequest = {}): 
   if (request.max_neighbors !== undefined) params.set('max_neighbors', String(request.max_neighbors));
   if (request.max_nodes !== undefined) params.set('max_nodes', String(request.max_nodes));
   if (request.sampling) params.set('sampling', request.sampling);
+  if (request.candidate_strategy) params.set('candidate_strategy', request.candidate_strategy);
+  if (request.doc_types?.length) params.set('doc_types', request.doc_types.join(','));
+  if (request.start_date) params.set('start_date', request.start_date);
+  if (request.end_date) params.set('end_date', request.end_date);
+  if (request.keyword) params.set('keyword', request.keyword);
   if (request.doc_id) params.set('doc_id', request.doc_id);
   if (request.refresh !== undefined) params.set('refresh', String(request.refresh));
   const query = params.toString();

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -149,6 +149,11 @@ export interface SimilarityGraphRequest {
   max_neighbors?: number;
   max_nodes?: number;
   sampling?: 'recent' | 'random' | 'hybrid';
+  candidate_strategy?: 'auto' | 'exact' | 'lsh';
+  doc_types?: Array<'audio' | 'document' | 'other'>;
+  start_date?: string;
+  end_date?: string;
+  keyword?: string;
   doc_id?: string;
   refresh?: boolean;
 }

--- a/frontend/src/components/SimilarityGraphPanel.tsx
+++ b/frontend/src/components/SimilarityGraphPanel.tsx
@@ -331,6 +331,16 @@ export function SimilarityGraphPanel() {
           <Button type="button" variant="outline" onClick={resetView} className="gap-2"><Move className="size-4" /> 뷰 리셋</Button>
           <div className={`text-xs ml-auto ${theme === 'dark' ? 'text-slate-400' : 'text-slate-600'}`}>
             {graph ? `nodes ${graph.nodes.length} / edges ${graph.edges.length}` : '그래프 없음'}
+            {graph?.meta && typeof graph.meta === 'object' && (graph.meta as { candidate_reduction?: { strategy?: string; reduction_ratio?: number; estimated_recall_at_k?: number } }).candidate_reduction ? (
+              <div>
+                {(() => {
+                  const candidate = (graph.meta as { candidate_reduction?: { strategy?: string; reduction_ratio?: number; estimated_recall_at_k?: number } }).candidate_reduction;
+                  const reduction = Number(candidate?.reduction_ratio ?? 0) * 100;
+                  const recall = Number(candidate?.estimated_recall_at_k ?? 1) * 100;
+                  return `candidate ${candidate?.strategy ?? 'exact'} · reduction ${reduction.toFixed(1)}% · recall@k ${recall.toFixed(1)}%`;
+                })()}
+              </div>
+            ) : null}
           </div>
         </div>
 

--- a/sttEngine/http_api/routes/similarity_routes.py
+++ b/sttEngine/http_api/routes/similarity_routes.py
@@ -12,23 +12,84 @@ def _read_json_payload(handler):
     return json.loads(handler.rfile.read(length)) if length else {}
 
 
+def _bad_request(handler, message: str) -> None:
+    handler.send_response(400)
+    handler.send_header('Content-Type', 'application/json')
+    handler.end_headers()
+    handler.wfile.write(json.dumps({'error': message}, ensure_ascii=False).encode())
+
+
+def _first(params, *names: str, default: str = "") -> str:
+    for name in names:
+        values = params.get(name)
+        if values:
+            return values[0]
+    return default
+
+
+def _parse_int(value: str, default: int, *, minimum: int | None = None, maximum: int | None = None) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    if minimum is not None:
+        parsed = max(minimum, parsed)
+    if maximum is not None:
+        parsed = min(maximum, parsed)
+    return parsed
+
+
+def _parse_float(value: str, default: float, *, minimum: float | None = None, maximum: float | None = None) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        parsed = default
+    if minimum is not None:
+        parsed = max(minimum, parsed)
+    if maximum is not None:
+        parsed = min(maximum, parsed)
+    return parsed
+
+
+def _parse_bool(value: str) -> bool:
+    return (value or '').strip().lower() in {'1', 'true', 't', 'yes', 'y', 'on'}
+
+
 def handle_get(handler) -> bool:
     if handler.path.startswith('/api/similarity-graph'):
         parsed = urlparse(handler.path)
         params = parse_qs(parsed.query)
-        min_similarity = float(params.get('min_similarity', params.get('threshold', ['0.65']))[0])
-        max_neighbors = int(params.get('max_neighbors', ['12'])[0])
-        max_nodes = int(params.get('max_nodes', ['150'])[0])
-        sampling_strategy = (params.get('sampling', ['hybrid'])[0] or 'hybrid').lower()
-        doc_id = (params.get('doc_id', [''])[0] or '').strip() or None
-        refresh = params.get('refresh', ['false'])[0].lower() == 'true'
+        min_similarity = _parse_float(_first(params, 'min_similarity', 'threshold', default='0.65'), 0.65, minimum=0.0, maximum=1.0)
+        max_neighbors = _parse_int(_first(params, 'max_neighbors', default='12'), 12, minimum=1)
+        max_nodes = _parse_int(_first(params, 'max_nodes', default='150'), 150, minimum=1)
+        sampling_strategy = (_first(params, 'sampling', default='hybrid') or 'hybrid').strip().lower()
+        doc_id = (_first(params, 'doc_id', default='') or '').strip() or None
+        refresh = _parse_bool(_first(params, 'refresh', default='false'))
+
+        candidate_strategy = (_first(params, 'candidate_strategy', default='auto') or 'auto').strip().lower()
+        if candidate_strategy not in {'auto', 'exact', 'lsh'}:
+            _bad_request(handler, 'Invalid candidate_strategy. Use one of: auto, exact, lsh')
+            return True
+
+        raw_doc_types = params.get('doc_types', params.get('file_type', []))
+        doc_types: list[str] = []
+        for item in raw_doc_types:
+            doc_types.extend([part.strip().lower() for part in item.split(',') if part.strip()])
+        start_date = (_first(params, 'start_date', 'start', default='') or '').strip() or None
+        end_date = (_first(params, 'end_date', 'end', default='') or '').strip() or None
+        keyword = (_first(params, 'keyword', default='') or '').strip() or None
 
         payload = get_similarity_graph(
             min_similarity=min_similarity,
             max_neighbors=max_neighbors,
             max_nodes=max_nodes,
             sampling_strategy=sampling_strategy,
+            candidate_strategy=candidate_strategy,
             doc_id=doc_id,
+            doc_types=doc_types,
+            start_date=start_date,
+            end_date=end_date,
+            keyword=keyword,
             refresh=refresh,
         )
 

--- a/sttEngine/similarity_matrix.py
+++ b/sttEngine/similarity_matrix.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import threading
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 import random
 from typing import Any
@@ -15,7 +16,7 @@ from .http_api.paths import BASE_DIR, normalize_record_path
 from .http_api.registry import load_file_registry
 
 _CACHE_LOCK = threading.RLock()
-_GRAPH_CACHE: dict[tuple[float, int, int, str], dict[str, Any]] = {}
+_GRAPH_CACHE: dict[tuple[Any, ...], dict[str, Any]] = {}
 _INCREMENTAL_STATE: dict[tuple[int, str], dict[str, Any]] = {}
 
 DEFAULT_MIN_SIMILARITY = 0.65
@@ -23,6 +24,16 @@ DEFAULT_MAX_NEIGHBORS = 12
 DEFAULT_MAX_NODES = 150
 DEFAULT_SAMPLING_STRATEGY = "hybrid"
 ALLOWED_SAMPLING_STRATEGIES = {"hybrid", "recent", "random"}
+DEFAULT_CANDIDATE_STRATEGY = "auto"
+ALLOWED_CANDIDATE_STRATEGIES = {"auto", "exact", "lsh"}
+LSH_AUTO_MIN_DOCS = 320
+LSH_NUM_TABLES = 6
+LSH_NUM_PLANES = 14
+LSH_RECALL_SAMPLE_LIMIT = 24
+LSH_MAX_BUCKET_SIZE = 80
+ALLOWED_DOC_TYPES = {"audio", "document", "other"}
+AUDIO_EXTENSIONS = {".mp3", ".wav", ".m4a", ".aac", ".ogg", ".flac", ".wma", ".opus"}
+DOCUMENT_EXTENSIONS = {".txt", ".md", ".pdf", ".doc", ".docx", ".ppt", ".pptx", ".xls", ".xlsx", ".hwp"}
 
 
 def _cosine_similarity(vec_a: np.ndarray, vec_b: np.ndarray) -> float:
@@ -87,12 +98,103 @@ def _build_doc_catalog() -> list[dict[str, Any]]:
 
 
 def _safe_timestamp(value: Any) -> float:
-    try:
-        if value is None:
-            return 0.0
-        return float(value)
-    except Exception:
+    if value is None:
         return 0.0
+
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return 0.0
+        try:
+            return float(raw)
+        except ValueError:
+            parsed = _parse_datetime(raw)
+            return parsed if parsed is not None else 0.0
+
+    return 0.0
+
+
+def _resolve_doc_type(file_path: str | None) -> str:
+    if not file_path:
+        return "other"
+    suffix = Path(file_path).suffix.lower()
+    if suffix in AUDIO_EXTENSIONS:
+        return "audio"
+    if suffix in DOCUMENT_EXTENSIONS:
+        return "document"
+    return "other"
+
+
+def _parse_datetime(value: str | None) -> float | None:
+    if not value:
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+
+    try:
+        return float(raw)
+    except ValueError:
+        pass
+
+    normalized = raw.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+
+    return parsed.timestamp()
+
+
+def _filter_docs(
+    docs: list[dict[str, Any]],
+    *,
+    doc_types: set[str] | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    keyword: str | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    normalized_types = {item.lower() for item in (doc_types or set()) if item.lower() in ALLOWED_DOC_TYPES}
+    keyword_norm = (keyword or "").strip().lower()
+    start_ts = _parse_datetime(start_date)
+    end_ts = _parse_datetime(end_date)
+
+    filtered: list[dict[str, Any]] = []
+    for doc in docs:
+        current_type = _resolve_doc_type(doc.get("file"))
+        if normalized_types and current_type not in normalized_types:
+            continue
+
+        uploaded_ts = _safe_timestamp(doc.get("uploaded_at"))
+        if start_ts is not None and uploaded_ts < start_ts:
+            continue
+        if end_ts is not None and uploaded_ts > end_ts:
+            continue
+
+        if keyword_norm:
+            haystack = " ".join(
+                str(part or "")
+                for part in (doc.get("display_name"), doc.get("file"), doc.get("id"))
+            ).lower()
+            if keyword_norm not in haystack:
+                continue
+
+        filtered.append(doc)
+
+    return filtered, {
+        "doc_types": sorted(normalized_types),
+        "start_date": start_date,
+        "end_date": end_date,
+        "keyword": keyword_norm or None,
+        "total_before_filtering": len(docs),
+        "total_after_filtering": len(filtered),
+    }
 
 
 def _sample_docs(docs: list[dict[str, Any]], max_nodes: int, strategy: str) -> tuple[list[dict[str, Any]], dict[str, Any]]:
@@ -136,8 +238,20 @@ def _compute_graph(
     max_neighbors: int = DEFAULT_MAX_NEIGHBORS,
     max_nodes: int = DEFAULT_MAX_NODES,
     sampling_strategy: str = DEFAULT_SAMPLING_STRATEGY,
+    candidate_strategy: str = DEFAULT_CANDIDATE_STRATEGY,
+    doc_types: set[str] | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    keyword: str | None = None,
 ) -> dict[str, Any]:
     docs = _build_doc_catalog()
+    docs, filter_meta = _filter_docs(
+        docs,
+        doc_types=doc_types,
+        start_date=start_date,
+        end_date=end_date,
+        keyword=keyword,
+    )
     docs, sampling_meta = _sample_docs(docs, max_nodes=max_nodes, strategy=sampling_strategy)
 
     if not docs:
@@ -148,6 +262,7 @@ def _compute_graph(
                 "min_similarity": min_similarity,
                 "count": 0,
                 "generated_at": time.time(),
+                "filters": filter_meta,
                 "sampling": sampling_meta,
             },
         }
@@ -170,28 +285,107 @@ def _compute_graph(
                 "min_similarity": min_similarity,
                 "count": 0,
                 "generated_at": time.time(),
+                "filters": filter_meta,
                 "sampling": sampling_meta,
             },
         }
 
-    state_key = (max_nodes, sampling_strategy)
-    matrix, incremental_meta = _build_similarity_matrix(
-        state_key=state_key,
-        docs=valid_docs,
-        vectors=vectors,
-    )
+    effective_candidate_strategy = _resolve_candidate_strategy(candidate_strategy, node_count)
+    incremental_meta: dict[str, Any]
+    candidate_meta: dict[str, Any]
+    if effective_candidate_strategy == "exact":
+        state_key = (max_nodes, sampling_strategy)
+        matrix, incremental_meta = _build_similarity_matrix(
+            state_key=state_key,
+            docs=valid_docs,
+            vectors=vectors,
+        )
+        edges = _build_edges_from_matrix(
+            docs=valid_docs,
+            matrix=matrix,
+            min_similarity=min_similarity,
+            max_neighbors=max_neighbors,
+        )
+        total_pairs = (node_count * (node_count - 1)) // 2
+        candidate_meta = {
+            "strategy": "exact",
+            "total_pairs": total_pairs,
+            "candidate_pairs": total_pairs,
+            "reduction_ratio": 0.0,
+            "estimated_recall_at_k": 1.0,
+        }
+    else:
+        edges, ann_meta = _build_edges_lsh(
+            docs=valid_docs,
+            vectors=vectors,
+            min_similarity=min_similarity,
+            max_neighbors=max_neighbors,
+        )
+        incremental_meta = {
+            "reused_pairs": 0,
+            "computed_pairs": ann_meta["computed_pairs"],
+            "added_docs": node_count,
+            "removed_docs": 0,
+            "changed_docs": 0,
+            "strategy": "ann_lsh",
+        }
+        candidate_meta = {
+            "strategy": "lsh",
+            "total_pairs": ann_meta["total_pairs"],
+            "candidate_pairs": ann_meta["candidate_pairs"],
+            "computed_pairs": ann_meta["computed_pairs"],
+            "reduction_ratio": ann_meta["reduction_ratio"],
+            "estimated_recall_at_k": ann_meta["estimated_recall_at_k"],
+            "num_tables": ann_meta["num_tables"],
+            "num_planes": ann_meta["num_planes"],
+        }
 
     nodes = [
         {
             "id": doc["id"],
             "label": doc["display_name"],
             "file": doc["file"],
+            "file_type": _resolve_doc_type(doc.get("file")),
             "record_id": doc.get("record_id"),
             "uploaded_at": doc.get("uploaded_at"),
         }
         for doc in valid_docs
     ]
 
+    return {
+        "nodes": nodes,
+        "edges": edges,
+        "meta": {
+            "node_schema": {"id": "string", "label": "string", "record_id": "string|null", "file": "string", "file_type": "audio|document|other"},
+            "edge_schema": {"source": "string", "target": "string", "weight": "number"},
+            "min_similarity": min_similarity,
+            "count": node_count,
+            "max_neighbors": max_neighbors,
+            "max_nodes": max_nodes,
+            "filters": filter_meta,
+            "sampling": sampling_meta,
+            "incremental": incremental_meta,
+            "candidate_reduction": candidate_meta,
+            "generated_at": time.time(),
+        },
+    }
+
+
+def _resolve_candidate_strategy(strategy: str, node_count: int) -> str:
+    if strategy == "exact":
+        return "exact"
+    if strategy == "lsh":
+        return "lsh"
+    return "lsh" if node_count >= LSH_AUTO_MIN_DOCS else "exact"
+
+
+def _build_edges_from_matrix(
+    docs: list[dict[str, Any]],
+    matrix: np.ndarray,
+    min_similarity: float,
+    max_neighbors: int,
+) -> list[dict[str, Any]]:
+    node_count = len(docs)
     edges: list[dict[str, Any]] = []
     for i in range(node_count):
         row = matrix[i]
@@ -200,27 +394,142 @@ def _compute_graph(
             if i < j:
                 edges.append(
                     {
-                        "source": valid_docs[i]["id"],
-                        "target": valid_docs[j]["id"],
+                        "source": docs[i]["id"],
+                        "target": docs[j]["id"],
                         "weight": float(row[j]),
                     }
                 )
+    return edges
 
-    return {
-        "nodes": nodes,
-        "edges": edges,
-        "meta": {
-            "node_schema": {"id": "string", "label": "string", "record_id": "string|null", "file": "string"},
-            "edge_schema": {"source": "string", "target": "string", "weight": "number"},
-            "min_similarity": min_similarity,
-            "count": node_count,
-            "max_neighbors": max_neighbors,
-            "max_nodes": max_nodes,
-            "sampling": sampling_meta,
-            "incremental": incremental_meta,
-            "generated_at": time.time(),
-        },
+
+def _build_edges_lsh(
+    docs: list[dict[str, Any]],
+    vectors: list[np.ndarray],
+    min_similarity: float,
+    max_neighbors: int,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    node_count = len(docs)
+    normalized = np.vstack([_normalize_vector(vec) for vec in vectors])
+    candidate_pairs = _collect_lsh_candidate_pairs(normalized)
+
+    scores_by_node: list[dict[int, float]] = [dict() for _ in range(node_count)]
+    computed_pairs = 0
+    for i, j in candidate_pairs:
+        score = float(np.dot(normalized[i], normalized[j]))
+        computed_pairs += 1
+        if score < min_similarity:
+            continue
+        scores_by_node[i][j] = score
+        scores_by_node[j][i] = score
+
+    edges = _build_edges_from_candidates(docs, scores_by_node, max_neighbors)
+    total_pairs = (node_count * (node_count - 1)) // 2
+    recall = _estimate_lsh_recall(
+        normalized=normalized,
+        scores_by_node=scores_by_node,
+        max_neighbors=max_neighbors,
+    )
+    return edges, {
+        "strategy": "lsh",
+        "total_pairs": total_pairs,
+        "candidate_pairs": len(candidate_pairs),
+        "computed_pairs": computed_pairs,
+        "reduction_ratio": 0.0 if total_pairs == 0 else 1.0 - (len(candidate_pairs) / total_pairs),
+        "estimated_recall_at_k": recall,
+        "num_tables": LSH_NUM_TABLES,
+        "num_planes": LSH_NUM_PLANES,
     }
+
+
+def _normalize_vector(vector: np.ndarray) -> np.ndarray:
+    v = np.asarray(vector, dtype=float).reshape(-1)
+    norm = float(np.linalg.norm(v))
+    if norm == 0.0:
+        return np.zeros_like(v)
+    return v / norm
+
+
+def _collect_lsh_candidate_pairs(vectors: np.ndarray) -> set[tuple[int, int]]:
+    _, dim = vectors.shape
+    rng = np.random.default_rng(42)
+    pairs: set[tuple[int, int]] = set()
+
+    for _ in range(LSH_NUM_TABLES):
+        hyperplanes = rng.normal(size=(LSH_NUM_PLANES, dim))
+        projections = vectors @ hyperplanes.T
+        signatures = projections >= 0
+        buckets: dict[bytes, list[int]] = {}
+        for idx, signature in enumerate(signatures):
+            key = signature.tobytes()
+            buckets.setdefault(key, []).append(idx)
+        for bucket in buckets.values():
+            if len(bucket) < 2:
+                continue
+            if len(bucket) > LSH_MAX_BUCKET_SIZE:
+                continue
+            for i_pos in range(len(bucket)):
+                for j_pos in range(i_pos + 1, len(bucket)):
+                    i = bucket[i_pos]
+                    j = bucket[j_pos]
+                    pairs.add((i, j) if i < j else (j, i))
+
+    return pairs
+
+
+def _build_edges_from_candidates(
+    docs: list[dict[str, Any]],
+    scores_by_node: list[dict[int, float]],
+    max_neighbors: int,
+) -> list[dict[str, Any]]:
+    edges: list[dict[str, Any]] = []
+    for i, neighbors in enumerate(scores_by_node):
+        sorted_neighbors = sorted(neighbors.items(), key=lambda item: item[1], reverse=True)[:max_neighbors]
+        for j, score in sorted_neighbors:
+            if i < j:
+                edges.append(
+                    {
+                        "source": docs[i]["id"],
+                        "target": docs[j]["id"],
+                        "weight": float(score),
+                    }
+                )
+    return edges
+
+
+def _estimate_lsh_recall(
+    normalized: np.ndarray,
+    scores_by_node: list[dict[int, float]],
+    max_neighbors: int,
+) -> float:
+    node_count = normalized.shape[0]
+    if node_count <= 1 or max_neighbors <= 0:
+        return 1.0
+
+    sample_count = min(node_count, LSH_RECALL_SAMPLE_LIMIT)
+    rng = random.Random(42)
+    sampled_indices = list(range(node_count))
+    if sample_count < node_count:
+        sampled_indices = rng.sample(sampled_indices, sample_count)
+
+    recalls: list[float] = []
+    for idx in sampled_indices:
+        exact_scores = normalized @ normalized[idx]
+        exact_order = [
+            i for i in np.argsort(exact_scores)[::-1]
+            if i != idx
+        ]
+        exact_top = set(exact_order[:max_neighbors])
+        if not exact_top:
+            continue
+        approx_top = {
+            neighbor_idx
+            for neighbor_idx, _ in sorted(scores_by_node[idx].items(), key=lambda item: item[1], reverse=True)[:max_neighbors]
+        }
+        recalls.append(len(exact_top & approx_top) / len(exact_top))
+
+    if not recalls:
+        return 1.0
+    return float(sum(recalls) / len(recalls))
 
 
 def _vector_fingerprint(vector: np.ndarray) -> tuple[str, tuple[int, ...], str]:
@@ -327,11 +636,29 @@ def get_similarity_graph(
     max_neighbors: int = DEFAULT_MAX_NEIGHBORS,
     max_nodes: int = DEFAULT_MAX_NODES,
     sampling_strategy: str = DEFAULT_SAMPLING_STRATEGY,
+    candidate_strategy: str = DEFAULT_CANDIDATE_STRATEGY,
     doc_id: str | None = None,
+    doc_types: list[str] | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    keyword: str | None = None,
     refresh: bool = False,
 ) -> dict[str, Any]:
     strategy = sampling_strategy if sampling_strategy in ALLOWED_SAMPLING_STRATEGIES else DEFAULT_SAMPLING_STRATEGY
-    key = (round(float(min_similarity), 4), int(max_neighbors), int(max_nodes), strategy)
+    candidate = candidate_strategy if candidate_strategy in ALLOWED_CANDIDATE_STRATEGIES else DEFAULT_CANDIDATE_STRATEGY
+    normalized_doc_types = tuple(sorted({item.lower() for item in (doc_types or []) if item.lower() in ALLOWED_DOC_TYPES}))
+    normalized_keyword = (keyword or "").strip().lower()
+    key = (
+        round(float(min_similarity), 4),
+        int(max_neighbors),
+        int(max_nodes),
+        strategy,
+        candidate,
+        normalized_doc_types,
+        (start_date or "").strip(),
+        (end_date or "").strip(),
+        normalized_keyword,
+    )
     with _CACHE_LOCK:
         if not refresh and key in _GRAPH_CACHE:
             graph = _GRAPH_CACHE[key]
@@ -341,6 +668,11 @@ def get_similarity_graph(
                 max_neighbors=max_neighbors,
                 max_nodes=max_nodes,
                 sampling_strategy=strategy,
+                candidate_strategy=candidate,
+                doc_types=set(normalized_doc_types),
+                start_date=start_date,
+                end_date=end_date,
+                keyword=normalized_keyword or None,
             )
             _GRAPH_CACHE[key] = graph
 
@@ -388,6 +720,7 @@ def get_documents_metadata() -> dict[str, Any]:
                 "id": doc["id"],
                 "file": doc["file"],
                 "display_name": doc["display_name"],
+                "file_type": _resolve_doc_type(doc.get("file")),
                 "record_id": doc.get("record_id"),
                 "uploaded_at": doc.get("uploaded_at"),
             }

--- a/tests/http_api/test_file_and_similarity_routes.py
+++ b/tests/http_api/test_file_and_similarity_routes.py
@@ -127,3 +127,93 @@ def test_find_similar_documents_deduplicates_record_ids(monkeypatch: pytest.Monk
     assert len(docs) == 1
     assert docs[0]["record_id"] == "r2"
     assert docs[0]["display_name"] == "doc1"
+
+
+def test_similarity_graph_route_forwards_candidate_strategy(monkeypatch: pytest.MonkeyPatch):
+    captured = {}
+
+    class DummyHandler:
+        def __init__(self):
+            self.path = '/api/similarity-graph?min_similarity=1.7&max_neighbors=0&max_nodes=-5&candidate_strategy=lsh&doc_types=audio,document&start=2026-01-01T00:00:00Z&end=2026-12-31T23:59:59Z&keyword=회의록'
+            self.headers = {}
+            self.wfile = io.BytesIO()
+            self.status = None
+            self.response_headers = {}
+
+        def send_response(self, code):
+            self.status = code
+
+        def send_header(self, key, value):
+            self.response_headers[key] = value
+
+        def end_headers(self):
+            return None
+
+    def fake_get_similarity_graph(**kwargs):
+        captured.update(kwargs)
+        return {'nodes': [], 'edges': [], 'meta': {'ok': True}}
+
+    monkeypatch.setattr(similarity_routes, 'get_similarity_graph', fake_get_similarity_graph)
+
+    handler = DummyHandler()
+    assert similarity_routes.handle_get(handler) is True
+    assert handler.status == 200
+    assert captured['candidate_strategy'] == 'lsh'
+    assert captured['min_similarity'] == 1.0
+    assert captured['max_neighbors'] == 1
+    assert captured['max_nodes'] == 1
+    assert captured['doc_types'] == ['audio', 'document']
+    assert captured['start_date'] == '2026-01-01T00:00:00Z'
+    assert captured['end_date'] == '2026-12-31T23:59:59Z'
+    assert captured['keyword'] == '회의록'
+
+
+def test_similarity_graph_route_rejects_invalid_candidate_strategy():
+    class DummyHandler:
+        def __init__(self):
+            self.path = '/api/similarity-graph?candidate_strategy=bogus'
+            self.headers = {}
+            self.wfile = io.BytesIO()
+            self.status = None
+            self.response_headers = {}
+
+        def send_response(self, code):
+            self.status = code
+
+        def send_header(self, key, value):
+            self.response_headers[key] = value
+
+        def end_headers(self):
+            return None
+
+    handler = DummyHandler()
+    assert similarity_routes.handle_get(handler) is True
+    assert handler.status == 400
+    payload = json.loads(handler.wfile.getvalue().decode('utf-8'))
+    assert 'Invalid candidate_strategy' in payload['error']
+
+
+def test_similarity_graph_filters_apply_in_backend(monkeypatch: pytest.MonkeyPatch):
+    docs = [
+        {'id': 'a', 'display_name': 'meeting audio', 'file': 'DB/uploads/a/audio.m4a', 'uploaded_at': '2026-01-10T00:00:00Z', 'vector_path': 'x.npy', 'record_id': None},
+        {'id': 'b', 'display_name': 'spec doc', 'file': 'DB/uploads/b/spec.md', 'uploaded_at': '2026-03-10T00:00:00Z', 'vector_path': 'y.npy', 'record_id': None},
+    ]
+
+    monkeypatch.setattr('sttEngine.similarity_matrix._build_doc_catalog', lambda: docs)
+    monkeypatch.setattr('sttEngine.similarity_matrix.np.load', lambda _p: [1.0, 0.0, 0.0])
+    monkeypatch.setattr('sttEngine.similarity_matrix._build_similarity_matrix', lambda **_k: (__import__('numpy').eye(1), {'reused_pairs': 0, 'computed_pairs': 0, 'added_docs': 0, 'removed_docs': 0, 'changed_docs': 0, 'strategy': 'incremental'}))
+
+    from sttEngine import similarity_matrix
+
+    payload = similarity_matrix.get_similarity_graph(
+        candidate_strategy='exact',
+        doc_types=['audio'],
+        start_date='2026-01-01T00:00:00Z',
+        end_date='2026-01-31T23:59:59Z',
+        keyword='meeting',
+    )
+
+    assert len(payload['nodes']) == 1
+    assert payload['nodes'][0]['id'] == 'a'
+    assert payload['nodes'][0]['file_type'] == 'audio'
+    assert payload['meta']['filters']['doc_types'] == ['audio']

--- a/tests/test_similarity_matrix_incremental.py
+++ b/tests/test_similarity_matrix_incremental.py
@@ -56,3 +56,77 @@ def test_incremental_similarity_matrix_recomputes_changed_docs(tmp_path):
     assert meta["changed_docs"] == 1
     assert meta["computed_pairs"] == 2
     assert meta["reused_pairs"] == 1
+
+
+def test_lsh_candidate_reduction_reports_meta():
+    docs = [{"id": f"doc-{idx}", "display_name": f"doc-{idx}", "file": f"DB/uploads/{idx}.txt", "record_id": None, "uploaded_at": None} for idx in range(64)]
+    vectors = []
+    rng = np.random.default_rng(0)
+    for _ in range(64):
+        vec = rng.normal(size=48)
+        vectors.append(vec)
+
+    edges, meta = similarity_matrix._build_edges_lsh(
+        docs=docs,
+        vectors=vectors,
+        min_similarity=0.2,
+        max_neighbors=8,
+    )
+
+    assert isinstance(edges, list)
+    assert meta["strategy"] == "lsh"
+    assert meta["candidate_pairs"] <= meta["total_pairs"]
+    assert 0.0 <= meta["reduction_ratio"] <= 1.0
+    assert 0.0 <= meta["estimated_recall_at_k"] <= 1.0
+
+
+def test_auto_candidate_strategy_switches_by_size():
+    assert similarity_matrix._resolve_candidate_strategy("auto", 100) == "exact"
+    assert similarity_matrix._resolve_candidate_strategy("auto", 1000) == "lsh"
+    assert similarity_matrix._resolve_candidate_strategy("exact", 1000) == "exact"
+
+
+def test_similarity_graph_cache_key_includes_candidate_and_filters(monkeypatch):
+    similarity_matrix.invalidate_similarity_cache()
+
+    calls: list[dict[str, object]] = []
+
+    def fake_compute_graph(**kwargs):
+        calls.append(kwargs)
+        return {"nodes": [], "edges": [], "meta": {"min_similarity": kwargs.get("min_similarity")}}
+
+    monkeypatch.setattr(similarity_matrix, '_compute_graph', fake_compute_graph)
+
+    similarity_matrix.get_similarity_graph(
+        min_similarity=0.7,
+        candidate_strategy='exact',
+        doc_types=['audio'],
+        keyword='alpha',
+        refresh=False,
+    )
+    similarity_matrix.get_similarity_graph(
+        min_similarity=0.7,
+        candidate_strategy='exact',
+        doc_types=['audio'],
+        keyword='alpha',
+        refresh=False,
+    )
+    similarity_matrix.get_similarity_graph(
+        min_similarity=0.7,
+        candidate_strategy='lsh',
+        doc_types=['audio'],
+        keyword='alpha',
+        refresh=False,
+    )
+    similarity_matrix.get_similarity_graph(
+        min_similarity=0.7,
+        candidate_strategy='exact',
+        doc_types=['document'],
+        keyword='alpha',
+        refresh=False,
+    )
+
+    assert len(calls) == 3
+    assert calls[0]['candidate_strategy'] == 'exact'
+    assert calls[1]['candidate_strategy'] == 'lsh'
+    assert calls[2]['doc_types'] == {'document'}


### PR DESCRIPTION
### Motivation
- Unify the `/api/similarity-graph` contract so candidate-reduction (`candidate_strategy`) and document filters (`doc_types`, `start_date`, `end_date`, `keyword`) can be used together and avoid incorrect cache reuse across semantically different queries. 
- Expose diagnostic metadata (sampling, filters, incremental reuse, candidate_reduction) to aid debugging and benchmarking of ANN/LSH behavior. 
- Provide regression coverage to prevent future regressions in cache key partitioning and to verify LSH candidate-reduction diagnostics.

### Description
- Route parsing: replaced ad-hoc parsing with helpers (`_first`, `_parse_int`, `_parse_float`, `_parse_bool`) and forward `candidate_strategy`, `doc_types`, `start_date`, `end_date`, `keyword`, and `refresh` from `sttEngine/http_api/routes/similarity_routes.py`, returning `400` for invalid `candidate_strategy`. 
- Backend graph: extended `sttEngine/similarity_matrix.py` to filter documents (`_filter_docs`), normalize `file_type`, parse timestamps, include `filters` in response `meta`, and include `candidate_strategy` in cache key generation. 
- ANN/LSH PoC: added LSH-based candidate collection, candidate-to-score computation, candidate-reduction metadata and recall estimation (`_collect_lsh_candidate_pairs`, `_build_edges_lsh`, `_estimate_lsh_recall`, `_normalize_vector`, `_build_edges_from_candidates`) and a strategy resolver (`_resolve_candidate_strategy`). 
- Exact mode: factored matrix edge construction into `_build_edges_from_matrix` and preserved the incremental similarity matrix reuse path. 
- Frontend/API: extended `SimilarityGraphRequest` and `getSimilarityGraph` in `frontend/src/api/*` to send the new params, updated `frontend/scripts/benchmark-similarity-graph.mjs` to include `candidate_strategy` in scenarios, and surfaced `candidate_reduction` info in `SimilarityGraphPanel.tsx`. 
- Tests: added/updated unit tests in `tests/test_similarity_matrix_incremental.py` and `tests/http_api/test_file_and_similarity_routes.py` covering LSH meta, auto strategy selection, route forwarding/validation, filter application in backend, and cache-key partitioning for candidate/filter changes. 

### Testing
- Ran backend unit tests with `PYTHONPATH=. pytest tests/test_similarity_matrix_incremental.py tests/http_api/test_file_and_similarity_routes.py tests/http_api/test_search.py` and `PYTHONPATH=. pytest tests/http_api/test_workflow.py tests/server/test_queue.py tests/test_vocab_system.py`, and all tests passed. 
- Executed a larger combined run `PYTHONPATH=. pytest` for the touched suites and observed successful results (all collected tests in those runs passed). 
- Built the frontend with `cd frontend && npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994944b83b4832ea00ae90101ceb260)