### PR TITLE
feat(graph): add LSH candidate-pruning strategy for similarity graph

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,8 +51,8 @@ GET
   - `/search` 파라미터 정규화: `sort_by(similarity|date, uploaded_at→date)`, `sort_order(asc|desc)`, `status(completed|pending, done/success/incomplete/todo 별칭 지원)`, `status_task(stt|summary|embedding)`
   - `min_score`는 0~1 범위만 유효, 응답은 항상 `contract_version: search-v2` 포함
 - `/api/similarity-graph`, `/api/documents/metadata`
-  - `/api/similarity-graph`는 `min_similarity/max_neighbors/max_nodes/sampling` + 필터(`doc_types`, `start_date`, `end_date`, `keyword`)를 지원
-  - 응답 `meta`는 `sampling`, `filters`, `incremental(reused_pairs/computed_pairs/added_docs/removed_docs/changed_docs)` 진단 정보를 포함
+  - `/api/similarity-graph`는 `min_similarity/max_neighbors/max_nodes/sampling/neighbor_strategy(auto|exact|lsh)` + 필터(`doc_types`, `start_date`, `end_date`, `keyword`)를 지원
+  - 응답 `meta`는 `sampling`, `neighbor_strategy(requested/effective)`, `filters`, `incremental(...)` 진단 정보를 포함
 - `/similar/<uuid_or_path>`, `/models`
 - `/cache/stats`, `/cache/cleanup`
 

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ venv\Scripts\python.exe -m sttEngine.server
 - `/history`, `/tasks`, `/progress/<task_id>` (진행률 %, ETA, 표준 오류 payload 포함)
 - `/search`, `/models`, `/cache/stats`, `/cache/cleanup`
 - `/api/similarity-graph`, `/api/documents/metadata`
-  - `/api/similarity-graph`는 `min_similarity/max_neighbors/max_nodes/sampling` + 필터(`doc_types`, `start_date`, `end_date`, `keyword`)를 지원
-  - 응답 `meta`에는 `sampling`, `filters`, `incremental(reused_pairs/computed_pairs/added_docs/removed_docs/changed_docs)` 진단 필드 포함
+  - `/api/similarity-graph`는 `min_similarity/max_neighbors/max_nodes/sampling/neighbor_strategy(auto|exact|lsh)` + 필터(`doc_types`, `start_date`, `end_date`, `keyword`)를 지원
+  - 응답 `meta`에는 `sampling`, `neighbor_strategy(requested/effective)`, `filters`, `incremental(...)` 진단 필드 포함
 
 주요 POST:
 - `/upload`, `/process`, `/cancel`, `/shutdown`

--- a/TODO/Graph.md
+++ b/TODO/Graph.md
@@ -17,7 +17,7 @@
 | 성능 계측 자동화(100/500/1000 문서) | 완료 | - | - | `benchmark-similarity-graph.mjs` + `docs/perf/*` 산출물 유지 |
 | 증분 유사도 재사용(변경 없는 문서쌍 재계산 생략) | 완료 | - | - | `_INCREMENTAL_STATE` + fingerprint 기반 `reused_pairs/computed_pairs` 계산 |
 | 고급 필터(문서타입/기간/키워드) | 미착수 | P1 | metadata 확장 + UI 컨트롤 | 현재 UI/API는 similarity/max_nodes(+sampling) 중심 |
-| 대용량 성능 전략(O(n²) 근본 대응: ANN/근사 최근접) | 미착수 | P0 | 인덱스/정확도 기준/벤치 시나리오 | 샘플링/증분은 있으나 유사도 계산 자체는 여전히 pairwise |
+| 대용량 성능 전략(O(n²) 근본 대응: ANN/근사 최근접) | 부분완료 | P0 | 인덱스/정확도 기준/벤치 시나리오 | LSH 기반 후보 축소(`neighbor_strategy=lsh/auto`) 도입, 정확도 벤치/전용 인덱스는 후속 |
 
 ## 2) 유효 백로그 (다음 스프린트)
 
@@ -26,7 +26,7 @@
 | 필터 UI(threshold + 날짜/타입/키워드) | 미착수 | P1 | API 파라미터 + metadata 필드 확장 |
 | sampling 전략 선택 UI(recent/random/hybrid) 노출 | 미착수 | P1 | 프론트 컨트롤 + API 파라미터 동기화 |
 | 증분 업데이트 고도화(메모리/TTL/캐시 정책) | 부분완료 | P2 | 인덱스/캐시 구조 변경 |
-| 근사 최근접(ANN) 또는 후보 축소 전략 PoC | 미착수 | P0 | 정확도 허용오차 + 성능 목표 합의 |
+| 근사 최근접(ANN) 또는 후보 축소 전략 PoC | 부분완료 | P0 | 정확도 허용오차 + 성능 목표 합의 |
 | 벤치마크 확장(실서버 + 대용량 구간 2k/5k) | 미착수 | P2 | 테스트 데이터셋/실서버 계측 환경 |
 
 ## 3) 최근 완료 항목
@@ -37,9 +37,10 @@
 | 엣지 범례/스케일 표준화 + 노드 스타일 개선 | `frontend/src/components/SimilarityGraphPanel.tsx` |
 | 증분 유사도 행렬 재사용(변경 없는 문서 쌍 score 재계산 생략) | `sttEngine/similarity_matrix.py` (`_build_similarity_matrix`, `_INCREMENTAL_STATE`) |
 | 그래프 응답 메타 진단 정보 확장(`sampling`, `incremental`) | `sttEngine/similarity_matrix.py`, `sttEngine/http_api/routes/similarity_routes.py` |
+| LSH 기반 후보 축소 전략(ANN PoC) + `neighbor_strategy` 메타 확장 | `sttEngine/similarity_matrix.py`, `sttEngine/http_api/routes/similarity_routes.py`, `frontend/src/api/*` |
 
 ## 4) 실행 순서
 
-1. **P0** O(n²) 병목 완화를 위한 ANN/후보축소 PoC 및 정확도/성능 기준 정의
+1. **P0** LSH 후보축소 PoC를 기준으로 정확도/성능 기준 정의 및 ANN 인덱스 확장 검토
 2. **P1** 사용자 필터(날짜/타입/키워드) + sampling 선택 UI/API 동기화
 3. **P2** 증분 캐시 정책(메모리/TTL/무효화) 및 벤치마크 시나리오 확장

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -182,6 +182,7 @@ export async function getSimilarityGraph(request: SimilarityGraphRequest = {}): 
   if (request.max_neighbors !== undefined) params.set('max_neighbors', String(request.max_neighbors));
   if (request.max_nodes !== undefined) params.set('max_nodes', String(request.max_nodes));
   if (request.sampling) params.set('sampling', request.sampling);
+  if (request.neighbor_strategy) params.set('neighbor_strategy', request.neighbor_strategy);
   if (request.doc_id) params.set('doc_id', request.doc_id);
   if (request.doc_types?.length) params.set('doc_types', request.doc_types.join(','));
   if (request.start_date) params.set('start_date', request.start_date);

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -150,6 +150,7 @@ export interface SimilarityGraphRequest {
   max_neighbors?: number;
   max_nodes?: number;
   sampling?: 'recent' | 'random' | 'hybrid';
+  neighbor_strategy?: 'auto' | 'exact' | 'lsh';
   doc_id?: string;
   doc_types?: Array<'audio' | 'document' | 'other'>;
   start_date?: string;

--- a/sttEngine/http_api/routes/similarity_routes.py
+++ b/sttEngine/http_api/routes/similarity_routes.py
@@ -57,6 +57,7 @@ def handle_get(handler) -> bool:
         max_neighbors = _parse_int(_first(params, 'max_neighbors', default='12'), 12, minimum=1)
         max_nodes = _parse_int(_first(params, 'max_nodes', default='150'), 150, minimum=1)
         sampling_strategy = (_first(params, 'sampling', default='hybrid') or 'hybrid').strip().lower()
+        neighbor_strategy = (_first(params, 'neighbor_strategy', 'neighbor_mode', default='auto') or 'auto').strip().lower()
         doc_id = (_first(params, 'doc_id', default='') or '').strip() or None
         refresh = _parse_bool(_first(params, 'refresh', default='false'))
         raw_doc_types = params.get('doc_types', params.get('file_type', []))
@@ -72,6 +73,7 @@ def handle_get(handler) -> bool:
             max_neighbors=max_neighbors,
             max_nodes=max_nodes,
             sampling_strategy=sampling_strategy,
+            neighbor_strategy=neighbor_strategy,
             doc_id=doc_id,
             doc_types=doc_types,
             start_date=start_date,

--- a/sttEngine/similarity_matrix.py
+++ b/sttEngine/similarity_matrix.py
@@ -23,8 +23,13 @@ DEFAULT_MIN_SIMILARITY = 0.65
 DEFAULT_MAX_NEIGHBORS = 12
 DEFAULT_MAX_NODES = 150
 DEFAULT_SAMPLING_STRATEGY = "hybrid"
+DEFAULT_NEIGHBOR_STRATEGY = "auto"
 ALLOWED_SAMPLING_STRATEGIES = {"hybrid", "recent", "random"}
+ALLOWED_NEIGHBOR_STRATEGIES = {"auto", "exact", "lsh"}
 ALLOWED_DOC_TYPES = {"audio", "document", "other"}
+ANN_AUTO_MIN_NODES = 220
+LSH_TABLES = 6
+LSH_BITS = 14
 AUDIO_EXTENSIONS = {".mp3", ".wav", ".m4a", ".aac", ".ogg", ".flac", ".wma", ".opus"}
 DOCUMENT_EXTENSIONS = {".txt", ".md", ".pdf", ".doc", ".docx", ".ppt", ".pptx", ".xls", ".xlsx", ".hwp"}
 
@@ -235,6 +240,7 @@ def _compute_graph(
     start_date: str | None = None,
     end_date: str | None = None,
     keyword: str | None = None,
+    neighbor_strategy: str = DEFAULT_NEIGHBOR_STRATEGY,
 ) -> dict[str, Any]:
     docs = _build_doc_catalog()
     docs, filter_meta = _filter_docs(
@@ -283,11 +289,7 @@ def _compute_graph(
         }
 
     state_key = (max_nodes, sampling_strategy)
-    matrix, incremental_meta = _build_similarity_matrix(
-        state_key=state_key,
-        docs=valid_docs,
-        vectors=vectors,
-    )
+    effective_strategy = _resolve_neighbor_strategy(neighbor_strategy, node_count)
 
     nodes = [
         {
@@ -301,19 +303,25 @@ def _compute_graph(
         for doc in valid_docs
     ]
 
-    edges: list[dict[str, Any]] = []
-    for i in range(node_count):
-        row = matrix[i]
-        candidate_idx = [j for j in np.argsort(row)[::-1] if j != i and row[j] >= min_similarity][:max_neighbors]
-        for j in candidate_idx:
-            if i < j:
-                edges.append(
-                    {
-                        "source": valid_docs[i]["id"],
-                        "target": valid_docs[j]["id"],
-                        "weight": float(row[j]),
-                    }
-                )
+    if effective_strategy == "lsh":
+        edges, incremental_meta = _build_similarity_edges_lsh(
+            docs=valid_docs,
+            vectors=vectors,
+            min_similarity=min_similarity,
+            max_neighbors=max_neighbors,
+        )
+    else:
+        matrix, incremental_meta = _build_similarity_matrix(
+            state_key=state_key,
+            docs=valid_docs,
+            vectors=vectors,
+        )
+        edges = _build_similarity_edges_from_matrix(
+            matrix=matrix,
+            docs=valid_docs,
+            min_similarity=min_similarity,
+            max_neighbors=max_neighbors,
+        )
 
     return {
         "nodes": nodes,
@@ -327,9 +335,141 @@ def _compute_graph(
             "max_nodes": max_nodes,
             "filters": filter_meta,
             "sampling": sampling_meta,
+            "neighbor_strategy": {
+                "requested": neighbor_strategy,
+                "effective": effective_strategy,
+            },
             "incremental": incremental_meta,
             "generated_at": time.time(),
         },
+    }
+
+
+def _resolve_neighbor_strategy(strategy: str, node_count: int) -> str:
+    normalized = (strategy or DEFAULT_NEIGHBOR_STRATEGY).strip().lower()
+    if normalized not in ALLOWED_NEIGHBOR_STRATEGIES:
+        normalized = DEFAULT_NEIGHBOR_STRATEGY
+    if normalized == "auto":
+        return "lsh" if node_count >= ANN_AUTO_MIN_NODES else "exact"
+    return normalized
+
+
+def _build_similarity_edges_from_matrix(
+    *,
+    matrix: np.ndarray,
+    docs: list[dict[str, Any]],
+    min_similarity: float,
+    max_neighbors: int,
+) -> list[dict[str, Any]]:
+    node_count = len(docs)
+    edges: list[dict[str, Any]] = []
+    for i in range(node_count):
+        row = matrix[i]
+        candidate_idx = [j for j in np.argsort(row)[::-1] if j != i and row[j] >= min_similarity][:max_neighbors]
+        for j in candidate_idx:
+            if i < j:
+                edges.append(
+                    {
+                        "source": docs[i]["id"],
+                        "target": docs[j]["id"],
+                        "weight": float(row[j]),
+                    }
+                )
+    return edges
+
+
+def _normalize_vectors(vectors: list[np.ndarray]) -> np.ndarray:
+    matrix = np.asarray(vectors, dtype=float)
+    if matrix.ndim == 1:
+        matrix = matrix.reshape(1, -1)
+    norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+    safe_norms = np.where(norms == 0.0, 1.0, norms)
+    return matrix / safe_norms
+
+
+def _build_similarity_edges_lsh(
+    *,
+    docs: list[dict[str, Any]],
+    vectors: list[np.ndarray],
+    min_similarity: float,
+    max_neighbors: int,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    node_count = len(docs)
+    full_pairs = node_count * (node_count - 1) // 2
+    if node_count <= 1:
+        return [], {
+            "strategy": "lsh",
+            "full_pairs": full_pairs,
+            "candidate_pairs": 0,
+            "computed_pairs": 0,
+            "pruned_pairs": 0,
+            "reused_pairs": 0,
+            "added_docs": 0,
+            "removed_docs": 0,
+            "changed_docs": 0,
+            "tables": LSH_TABLES,
+            "bits": LSH_BITS,
+        }
+
+    normalized = _normalize_vectors(vectors)
+    dimensions = normalized.shape[1]
+    candidate_sets: list[set[int]] = [set() for _ in range(node_count)]
+
+    rng = np.random.default_rng(42)
+    for _table_idx in range(LSH_TABLES):
+        hyperplanes = rng.standard_normal((LSH_BITS, dimensions))
+        projections = normalized @ hyperplanes.T
+        signatures = projections > 0
+        buckets: dict[tuple[bool, ...], list[int]] = {}
+        for idx in range(node_count):
+            key = tuple(bool(value) for value in signatures[idx])
+            buckets.setdefault(key, []).append(idx)
+        for members in buckets.values():
+            if len(members) <= 1:
+                continue
+            for i in members:
+                for j in members:
+                    if i != j:
+                        candidate_sets[i].add(j)
+
+    candidate_pairs = sum(len(item) for item in candidate_sets) // 2
+    edges: list[dict[str, Any]] = []
+
+    for i in range(node_count):
+        candidates = sorted(candidate_sets[i])
+        if not candidates:
+            continue
+
+        scored: list[tuple[int, float]] = []
+        row = normalized[i]
+        for j in candidates:
+            score = float(np.dot(row, normalized[j]))
+            if score >= min_similarity:
+                scored.append((j, score))
+
+        scored.sort(key=lambda item: item[1], reverse=True)
+        for j, score in scored[:max_neighbors]:
+            if i < j:
+                edges.append(
+                    {
+                        "source": docs[i]["id"],
+                        "target": docs[j]["id"],
+                        "weight": score,
+                    }
+                )
+
+    return edges, {
+        "strategy": "lsh",
+        "full_pairs": full_pairs,
+        "candidate_pairs": candidate_pairs,
+        "computed_pairs": candidate_pairs,
+        "pruned_pairs": max(0, full_pairs - candidate_pairs),
+        "reused_pairs": 0,
+        "added_docs": 0,
+        "removed_docs": 0,
+        "changed_docs": 0,
+        "tables": LSH_TABLES,
+        "bits": LSH_BITS,
     }
 
 
@@ -442,16 +582,21 @@ def get_similarity_graph(
     start_date: str | None = None,
     end_date: str | None = None,
     keyword: str | None = None,
+    neighbor_strategy: str = DEFAULT_NEIGHBOR_STRATEGY,
     refresh: bool = False,
 ) -> dict[str, Any]:
     strategy = sampling_strategy if sampling_strategy in ALLOWED_SAMPLING_STRATEGIES else DEFAULT_SAMPLING_STRATEGY
     normalized_doc_types = tuple(sorted({item.lower() for item in (doc_types or []) if item.lower() in ALLOWED_DOC_TYPES}))
     normalized_keyword = (keyword or "").strip().lower()
+    normalized_neighbor_strategy = (neighbor_strategy or DEFAULT_NEIGHBOR_STRATEGY).strip().lower()
+    if normalized_neighbor_strategy not in ALLOWED_NEIGHBOR_STRATEGIES:
+        normalized_neighbor_strategy = DEFAULT_NEIGHBOR_STRATEGY
     key = (
         round(float(min_similarity), 4),
         int(max_neighbors),
         int(max_nodes),
         strategy,
+        normalized_neighbor_strategy,
         normalized_doc_types,
         (start_date or "").strip(),
         (end_date or "").strip(),
@@ -470,6 +615,7 @@ def get_similarity_graph(
                 start_date=start_date,
                 end_date=end_date,
                 keyword=normalized_keyword or None,
+                neighbor_strategy=normalized_neighbor_strategy,
             )
             _GRAPH_CACHE[key] = graph
 

--- a/tests/http_api/test_similarity_graph.py
+++ b/tests/http_api/test_similarity_graph.py
@@ -80,3 +80,12 @@ def test_similarity_graph_accepts_start_end_alias(server):
     assert payload["meta"]["ok"] is True
     assert captured["start_date"] == "2025-01-01"
     assert captured["end_date"] == "2025-12-31"
+
+
+def test_similarity_graph_accepts_neighbor_strategy(server):
+    base_url, captured = server
+    with urlopen(f"{base_url}/api/similarity-graph?neighbor_strategy=lsh") as response:
+        payload = json.loads(response.read().decode("utf-8"))
+
+    assert payload["meta"]["ok"] is True
+    assert captured["neighbor_strategy"] == "lsh"

--- a/tests/test_similarity_matrix_incremental.py
+++ b/tests/test_similarity_matrix_incremental.py
@@ -56,3 +56,48 @@ def test_incremental_similarity_matrix_recomputes_changed_docs(tmp_path):
     assert meta["changed_docs"] == 1
     assert meta["computed_pairs"] == 2
     assert meta["reused_pairs"] == 1
+
+
+def test_resolve_neighbor_strategy_auto_threshold():
+    assert similarity_matrix._resolve_neighbor_strategy('auto', 40) == 'exact'
+    assert similarity_matrix._resolve_neighbor_strategy('auto', 300) == 'lsh'
+    assert similarity_matrix._resolve_neighbor_strategy('invalid', 300) == 'lsh'
+
+
+def test_compute_graph_uses_lsh_neighbor_strategy(monkeypatch, tmp_path):
+    similarity_matrix.invalidate_similarity_cache()
+
+    doc_count = 230
+    docs = []
+    vectors = []
+    for idx in range(doc_count):
+        vector = np.array([float((idx * 3) % 11), float((idx * 5) % 13), float((idx * 7) % 17)], dtype=float)
+        if np.linalg.norm(vector) == 0:
+            vector = np.array([1.0, 0.0, 0.0], dtype=float)
+        vec_path = tmp_path / f"{idx}.npy"
+        np.save(vec_path, vector)
+        vectors.append(vector)
+        docs.append({
+            'id': f'doc-{idx}',
+            'display_name': f'Doc {idx}',
+            'file': f'DB/uploads/{idx}.txt',
+            'vector_path': vec_path,
+            'record_id': None,
+            'uploaded_at': '2025-01-01T00:00:00Z',
+        })
+
+    monkeypatch.setattr(similarity_matrix, '_build_doc_catalog', lambda: docs)
+
+    graph = similarity_matrix.get_similarity_graph(
+        min_similarity=0.3,
+        max_neighbors=4,
+        max_nodes=300,
+        sampling_strategy='hybrid',
+        neighbor_strategy='auto',
+        refresh=True,
+    )
+
+    meta = graph['meta']
+    assert meta['neighbor_strategy']['effective'] == 'lsh'
+    assert meta['incremental']['strategy'] == 'lsh'
+    assert meta['incremental']['full_pairs'] > meta['incremental']['candidate_pairs']


### PR DESCRIPTION
### Motivation
- Implement the P0 PoC to mitigate the O(n²) bottleneck in similarity graph generation by adding an ANN-style candidate-pruning path. 
- Provide a selectable strategy so callers can choose between exact pairwise computation and a lightweight LSH-based candidate pruning while preserving diagnostics to observe approximation impact.

### Description
- Add `neighbor_strategy` support to the graph pipeline with `DEFAULT_NEIGHBOR_STRATEGY='auto'`, allowed values `auto|exact|lsh`, and an `_resolve_neighbor_strategy()` selector that uses a node-count threshold to pick `lsh` or `exact`. 
- Implement an LSH candidate-pruning path (`_build_similarity_edges_lsh`) and helper functions (`_normalize_vectors`, `_build_similarity_edges_from_matrix`) and wire the effective strategy into the graph `meta` and cache key. 
- Extend the HTTP route to accept `neighbor_strategy` (alias `neighbor_mode`) and pass it to `get_similarity_graph`, and update frontend types (`SimilarityGraphRequest`) and client query serialization to include `neighbor_strategy`. 
- Add tests: route parameter passthrough test and unit tests validating `auto` threshold and that `get_similarity_graph(..., neighbor_strategy='auto')` triggers the LSH path for large node counts. 
- Update `README.md`, `AGENTS.md`, and `TODO/Graph.md` to document the new `neighbor_strategy` parameter and mark the P0 PoC status.

### Testing
- Ran targeted tests with module path set and the modified tests: `PYTHONPATH=. pytest tests/http_api/test_similarity_graph.py tests/test_similarity_matrix_incremental.py` and they passed. 
- Ran core regression tests `PYTHONPATH=. pytest tests/http_api/test_workflow.py tests/http_api/test_search.py tests/server/test_queue.py tests/test_vocab_system.py` and they passed. 
- Confirmed modules compile (`python -m compileall`) as part of validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69949e6d3cf8832e9199bf38305882af)