### PR TITLE
feat(graph): complete P2 similarity cache policy and benchmark scaling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,3 +70,16 @@ OBSIDIAN_MCP_ENABLED=false
 # Option B) Session credentials (both required)
 # RECORDROUTE_DESTRUCTIVE_API_SESSION_ID=session-1
 # RECORDROUTE_DESTRUCTIVE_API_SESSION_TOKEN=session-secret
+
+# --- Similarity Graph Cache Policy ---
+# Similarity graph response cache TTL in seconds. 0 disables TTL expiration.
+# RECORDROUTE_SIMILARITY_GRAPH_CACHE_TTL_SECONDS=300
+
+# Maximum number of similarity graph cache entries to keep.
+# RECORDROUTE_SIMILARITY_GRAPH_CACHE_MAX_ENTRIES=24
+
+# Incremental similarity matrix state TTL in seconds. 0 disables TTL expiration.
+# RECORDROUTE_SIMILARITY_INCREMENTAL_STATE_TTL_SECONDS=900
+
+# Maximum number of incremental matrix states to keep.
+# RECORDROUTE_SIMILARITY_INCREMENTAL_STATE_MAX_ENTRIES=8

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,8 @@ POST
 - `pytest tests/server/test_queue.py`
 - `pytest tests/test_vocab_system.py`
 - 그래프 성능 기준선 생성: `node frontend/scripts/benchmark-similarity-graph.mjs`
+  - 대용량 구간(2k/5k) 포함: `node frontend/scripts/benchmark-similarity-graph.mjs --include-large`
+  - 사용자 정의 구간/반복: `node frontend/scripts/benchmark-similarity-graph.mjs --dataset-sizes=100,500,1000,2000,5000 --iterations=3`
   - 출력: `docs/perf/similarity-graph-baseline.json`, `docs/perf/similarity-graph-baseline.md`
   - 실서버 응답 포함: `node frontend/scripts/benchmark-similarity-graph.mjs --api-base-url=http://localhost:8080`
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ venv\Scripts\python.exe -m sttEngine.server
 - `RECORDROUTE_DESTRUCTIVE_API_SAFE_MODE` (기본 `true`): 파괴적 API 안전 모드
 - `RECORDROUTE_DESTRUCTIVE_API_TOKEN`: 파괴적 API 공용 토큰
 - `RECORDROUTE_DESTRUCTIVE_API_SESSION_ID`, `RECORDROUTE_DESTRUCTIVE_API_SESSION_TOKEN`: 세션 기반 보호 값
+- `RECORDROUTE_SIMILARITY_GRAPH_CACHE_TTL_SECONDS`: 그래프 응답 캐시 TTL(초, 기본 300)
+- `RECORDROUTE_SIMILARITY_GRAPH_CACHE_MAX_ENTRIES`: 그래프 응답 캐시 최대 엔트리 수(기본 24)
+- `RECORDROUTE_SIMILARITY_INCREMENTAL_STATE_TTL_SECONDS`: 증분 유사도 상태 TTL(초, 기본 900)
+- `RECORDROUTE_SIMILARITY_INCREMENTAL_STATE_MAX_ENTRIES`: 증분 유사도 상태 최대 엔트리 수(기본 8)
 
 ## API 요약
 
@@ -180,9 +184,17 @@ pytest
 pytest tests/http_api/test_workflow.py tests/http_api/test_search.py tests/server/test_queue.py tests/test_vocab_system.py
 ```
 
-그래프 성능 계측(100/500/1000 문서 기준선 자동 생성):
+그래프 성능 계측(기본 100/500/1000 문서 기준선 자동 생성):
 ```bash
 node frontend/scripts/benchmark-similarity-graph.mjs
+```
+대용량 구간(2k/5k) 포함:
+```bash
+node frontend/scripts/benchmark-similarity-graph.mjs --include-large
+```
+사용자 정의 구간/반복:
+```bash
+node frontend/scripts/benchmark-similarity-graph.mjs --dataset-sizes=100,500,1000,2000,5000 --iterations=3
 ```
 결과물: `docs/perf/similarity-graph-baseline.json`, `docs/perf/similarity-graph-baseline.md`
 

--- a/TODO/Graph.md
+++ b/TODO/Graph.md
@@ -1,6 +1,6 @@
 # Graph 백로그 (문서 유사도 네트워크)
 
-- 마지막 점검일: 2026-02-17
+- 마지막 점검일: 2026-02-18
 - 점검 방법: 코드 기준 재검토(`similarity_matrix`, `similarity_routes`, `SimilarityGraphPanel`, 벤치 스크립트/산출물)
 - 대조 기준 파일: `sttEngine/similarity_matrix.py`, `sttEngine/http_api/routes/similarity_routes.py`, `frontend/src/components/SimilarityGraphPanel.tsx`, `frontend/scripts/benchmark-similarity-graph.mjs`, `docs/perf/similarity-graph-baseline.*`
 
@@ -25,9 +25,9 @@
 |---|---|---|---|
 | 필터 UI(threshold + 날짜/타입/키워드) | 미착수 | P1 | API 파라미터 + metadata 필드 확장 |
 | sampling 전략 선택 UI(recent/random/hybrid) 노출 | 미착수 | P1 | 프론트 컨트롤 + API 파라미터 동기화 |
-| 증분 업데이트 고도화(메모리/TTL/캐시 정책) | 부분완료 | P2 | 인덱스/캐시 구조 변경 |
+| 증분 업데이트 고도화(메모리/TTL/캐시 정책) | 완료 | - | - |
 | 근사 최근접(ANN) 또는 후보 축소 전략 PoC | 부분완료 | P0 | 정확도 허용오차 + 성능 목표 합의 |
-| 벤치마크 확장(실서버 + 대용량 구간 2k/5k) | 미착수 | P2 | 테스트 데이터셋/실서버 계측 환경 |
+| 벤치마크 확장(실서버 + 대용량 구간 2k/5k) | 완료 | - | - |
 
 ## 3) 최근 완료 항목
 
@@ -38,6 +38,8 @@
 | 증분 유사도 행렬 재사용(변경 없는 문서 쌍 score 재계산 생략) | `sttEngine/similarity_matrix.py` (`_build_similarity_matrix`, `_INCREMENTAL_STATE`) |
 | 그래프 응답 메타 진단 정보 확장(`sampling`, `incremental`) | `sttEngine/similarity_matrix.py`, `sttEngine/http_api/routes/similarity_routes.py` |
 | LSH 기반 후보 축소 전략(ANN PoC) + `neighbor_strategy` 메타 확장 | `sttEngine/similarity_matrix.py`, `sttEngine/http_api/routes/similarity_routes.py`, `frontend/src/api/*` |
+| 증분 캐시 정책(TTL/최대 엔트리) + 캐시 진단 메타 확장 | `sttEngine/similarity_matrix.py` (`RECORDROUTE_SIMILARITY_*` 환경변수, `meta.cache.policy`) |
+| 벤치마크 대용량 구간(2k/5k) 실행 옵션 추가 | `frontend/scripts/benchmark-similarity-graph.mjs` (`--include-large`, `--dataset-sizes`) |
 
 ## 4) 실행 순서
 

--- a/frontend/scripts/benchmark-similarity-graph.mjs
+++ b/frontend/scripts/benchmark-similarity-graph.mjs
@@ -3,8 +3,9 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { performance } from 'node:perf_hooks';
 
-const DATASET_SIZES = [100, 500, 1000];
-const ITERATIONS = 10;
+const BASE_DATASET_SIZES = [100, 500, 1000];
+const LARGE_DATASET_SIZES = [2000, 5000];
+const DEFAULT_ITERATIONS = 10;
 const EDGE_LENGTH = 120;
 const REPULSION = 18000;
 const SPRING_K = 0.0018;
@@ -16,6 +17,9 @@ function parseArgs(argv) {
     minSimilarity: 0.65,
     sampling: 'hybrid',
     mockResponseDelayMs: 8,
+    includeLarge: false,
+    datasetSizes: [...BASE_DATASET_SIZES],
+    iterations: DEFAULT_ITERATIONS,
   };
 
   for (const arg of argv) {
@@ -29,7 +33,26 @@ function parseArgs(argv) {
     } else if (arg.startsWith('--mock-response-delay-ms=')) {
       const parsed = Number(arg.slice('--mock-response-delay-ms='.length));
       if (!Number.isNaN(parsed) && parsed >= 0) options.mockResponseDelayMs = parsed;
+    } else if (arg.startsWith('--iterations=')) {
+      const parsed = Number(arg.slice('--iterations='.length));
+      if (Number.isFinite(parsed) && parsed > 0) options.iterations = Math.trunc(parsed);
+    } else if (arg === '--include-large') {
+      options.includeLarge = true;
+    } else if (arg.startsWith('--dataset-sizes=')) {
+      const parsedSizes = arg
+        .slice('--dataset-sizes='.length)
+        .split(',')
+        .map((part) => Number(part.trim()))
+        .filter((value) => Number.isFinite(value) && value > 0)
+        .map((value) => Math.trunc(value));
+      if (parsedSizes.length > 0) {
+        options.datasetSizes = [...new Set(parsedSizes)].sort((a, b) => a - b);
+      }
     }
+  }
+
+  if (options.includeLarge && !argv.some((arg) => arg.startsWith('--dataset-sizes='))) {
+    options.datasetSizes = [...BASE_DATASET_SIZES, ...LARGE_DATASET_SIZES];
   }
 
   return options;
@@ -178,10 +201,11 @@ function percentile(values, targetPercentile) {
 }
 
 async function benchmarkSize(size, options) {
+  const iterations = Math.max(1, options.iterations || DEFAULT_ITERATIONS);
   const syntheticGraph = createSyntheticGraph(size);
   const samples = [];
 
-  for (let i = 0; i < ITERATIONS; i += 1) {
+  for (let i = 0; i < iterations; i += 1) {
     const responseTimeMs = await measureResponseTimeMs(size, options);
 
     const renderStart = performance.now();
@@ -245,7 +269,7 @@ async function run() {
   const options = parseArgs(process.argv.slice(2));
   const scenarios = [];
 
-  for (const size of DATASET_SIZES) {
+  for (const size of options.datasetSizes) {
     // eslint-disable-next-line no-await-in-loop
     scenarios.push(await benchmarkSize(size, options));
   }
@@ -255,7 +279,7 @@ async function run() {
     mode: options.apiBaseUrl ? 'real_api' : 'mock_api',
     apiBaseUrl: options.apiBaseUrl,
     mockResponseDelayMs: options.mockResponseDelayMs,
-    iterations: ITERATIONS,
+    iterations: options.iterations,
     scenarios,
   };
 

--- a/sttEngine/similarity_matrix.py
+++ b/sttEngine/similarity_matrix.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import threading
 import time
 from datetime import datetime, timezone
@@ -19,6 +20,28 @@ _CACHE_LOCK = threading.RLock()
 _GRAPH_CACHE: dict[tuple[Any, ...], dict[str, Any]] = {}
 _INCREMENTAL_STATE: dict[tuple[int, str], dict[str, Any]] = {}
 
+
+def _env_float(name: str, default: float, *, minimum: float | None = None) -> float:
+    raw = os.getenv(name)
+    try:
+        parsed = float(raw) if raw is not None else default
+    except (TypeError, ValueError):
+        parsed = default
+    if minimum is not None:
+        parsed = max(minimum, parsed)
+    return parsed
+
+
+def _env_int(name: str, default: int, *, minimum: int | None = None) -> int:
+    raw = os.getenv(name)
+    try:
+        parsed = int(raw) if raw is not None else default
+    except (TypeError, ValueError):
+        parsed = default
+    if minimum is not None:
+        parsed = max(minimum, parsed)
+    return parsed
+
 DEFAULT_MIN_SIMILARITY = 0.65
 DEFAULT_MAX_NEIGHBORS = 12
 DEFAULT_MAX_NODES = 150
@@ -32,6 +55,63 @@ LSH_TABLES = 6
 LSH_BITS = 14
 AUDIO_EXTENSIONS = {".mp3", ".wav", ".m4a", ".aac", ".ogg", ".flac", ".wma", ".opus"}
 DOCUMENT_EXTENSIONS = {".txt", ".md", ".pdf", ".doc", ".docx", ".ppt", ".pptx", ".xls", ".xlsx", ".hwp"}
+GRAPH_CACHE_TTL_SECONDS = _env_float("RECORDROUTE_SIMILARITY_GRAPH_CACHE_TTL_SECONDS", 300.0, minimum=0.0)
+GRAPH_CACHE_MAX_ENTRIES = _env_int("RECORDROUTE_SIMILARITY_GRAPH_CACHE_MAX_ENTRIES", 24, minimum=1)
+INCREMENTAL_STATE_TTL_SECONDS = _env_float("RECORDROUTE_SIMILARITY_INCREMENTAL_STATE_TTL_SECONDS", 900.0, minimum=0.0)
+INCREMENTAL_STATE_MAX_ENTRIES = _env_int("RECORDROUTE_SIMILARITY_INCREMENTAL_STATE_MAX_ENTRIES", 8, minimum=1)
+
+
+def _prune_graph_cache(now: float | None = None) -> None:
+    now_ts = now if now is not None else time.time()
+    expired_keys = [
+        key
+        for key, payload in _GRAPH_CACHE.items()
+        if GRAPH_CACHE_TTL_SECONDS > 0 and (now_ts - float(payload.get("cached_at", now_ts))) > GRAPH_CACHE_TTL_SECONDS
+    ]
+    for key in expired_keys:
+        _GRAPH_CACHE.pop(key, None)
+
+    if len(_GRAPH_CACHE) <= GRAPH_CACHE_MAX_ENTRIES:
+        return
+
+    overflow = len(_GRAPH_CACHE) - GRAPH_CACHE_MAX_ENTRIES
+    ordered_keys = sorted(_GRAPH_CACHE.keys(), key=lambda key: float(_GRAPH_CACHE[key].get("cached_at", 0.0)))
+    for key in ordered_keys[:overflow]:
+        _GRAPH_CACHE.pop(key, None)
+
+
+def _prune_incremental_state(now: float | None = None) -> None:
+    now_ts = now if now is not None else time.time()
+    expired_keys = [
+        key
+        for key, payload in _INCREMENTAL_STATE.items()
+        if INCREMENTAL_STATE_TTL_SECONDS > 0 and (now_ts - float(payload.get("updated_at", now_ts))) > INCREMENTAL_STATE_TTL_SECONDS
+    ]
+    for key in expired_keys:
+        _INCREMENTAL_STATE.pop(key, None)
+
+    if len(_INCREMENTAL_STATE) <= INCREMENTAL_STATE_MAX_ENTRIES:
+        return
+
+    overflow = len(_INCREMENTAL_STATE) - INCREMENTAL_STATE_MAX_ENTRIES
+    ordered_keys = sorted(_INCREMENTAL_STATE.keys(), key=lambda key: float(_INCREMENTAL_STATE[key].get("updated_at", 0.0)))
+    for key in ordered_keys[:overflow]:
+        _INCREMENTAL_STATE.pop(key, None)
+
+
+def _cache_policy_meta() -> dict[str, Any]:
+    return {
+        "graph_cache": {
+            "ttl_seconds": GRAPH_CACHE_TTL_SECONDS,
+            "max_entries": GRAPH_CACHE_MAX_ENTRIES,
+            "entries": len(_GRAPH_CACHE),
+        },
+        "incremental_state": {
+            "ttl_seconds": INCREMENTAL_STATE_TTL_SECONDS,
+            "max_entries": INCREMENTAL_STATE_MAX_ENTRIES,
+            "entries": len(_INCREMENTAL_STATE),
+        },
+    }
 
 
 def _cosine_similarity(vec_a: np.ndarray, vec_b: np.ndarray) -> float:
@@ -503,6 +583,7 @@ def _build_similarity_matrix(
     }
 
     with _CACHE_LOCK:
+        _prune_incremental_state()
         prev_state = _INCREMENTAL_STATE.get(state_key)
 
     previous_index: dict[str, int] = {}
@@ -548,7 +629,9 @@ def _build_similarity_matrix(
             "id_index": {doc_id: idx for idx, doc_id in enumerate(current_ids)},
             "fingerprints": current_fingerprints,
             "matrix": matrix,
+            "updated_at": time.time(),
         }
+        _prune_incremental_state()
 
     previous_ids = set(previous_index.keys())
     current_ids_set = set(current_ids)
@@ -603,8 +686,11 @@ def get_similarity_graph(
         normalized_keyword,
     )
     with _CACHE_LOCK:
-        if not refresh and key in _GRAPH_CACHE:
-            graph = _GRAPH_CACHE[key]
+        _prune_graph_cache()
+        cached_entry = _GRAPH_CACHE.get(key)
+        cache_hit = bool(not refresh and cached_entry is not None)
+        if cache_hit:
+            graph = cached_entry["graph"]
         else:
             graph = _compute_graph(
                 min_similarity=min_similarity,
@@ -617,7 +703,16 @@ def get_similarity_graph(
                 keyword=normalized_keyword or None,
                 neighbor_strategy=normalized_neighbor_strategy,
             )
-            _GRAPH_CACHE[key] = graph
+            _GRAPH_CACHE[key] = {"graph": graph, "cached_at": time.time()}
+            _prune_graph_cache()
+
+    graph_meta = graph.get("meta") if isinstance(graph, dict) else None
+    if isinstance(graph_meta, dict):
+        graph_meta["cache"] = {
+            "hit": cache_hit,
+            "refresh_requested": bool(refresh),
+            "policy": _cache_policy_meta(),
+        }
 
     if not doc_id:
         return graph

--- a/tests/test_similarity_matrix_incremental.py
+++ b/tests/test_similarity_matrix_incremental.py
@@ -101,3 +101,61 @@ def test_compute_graph_uses_lsh_neighbor_strategy(monkeypatch, tmp_path):
     assert meta['neighbor_strategy']['effective'] == 'lsh'
     assert meta['incremental']['strategy'] == 'lsh'
     assert meta['incremental']['full_pairs'] > meta['incremental']['candidate_pairs']
+
+
+def test_similarity_graph_cache_hit_and_policy_meta(monkeypatch, tmp_path):
+    similarity_matrix.invalidate_similarity_cache()
+
+    docs = []
+    for idx in range(3):
+        vec_path = tmp_path / f"{idx}.npy"
+        np.save(vec_path, np.array([1.0, float(idx + 1), 0.0], dtype=float))
+        docs.append({
+            'id': f'doc-{idx}',
+            'display_name': f'Doc {idx}',
+            'file': f'DB/uploads/{idx}.txt',
+            'vector_path': vec_path,
+            'record_id': None,
+            'uploaded_at': '2025-01-01T00:00:00Z',
+        })
+
+    monkeypatch.setattr(similarity_matrix, '_build_doc_catalog', lambda: docs)
+
+    first = similarity_matrix.get_similarity_graph(max_nodes=10, sampling_strategy='hybrid', refresh=False)
+    first_hit = first['meta']['cache']['hit']
+    second = similarity_matrix.get_similarity_graph(max_nodes=10, sampling_strategy='hybrid', refresh=False)
+
+    assert first_hit is False
+    assert second['meta']['cache']['hit'] is True
+    assert second['meta']['cache']['policy']['graph_cache']['entries'] >= 1
+
+
+def test_prune_incremental_state_by_ttl(monkeypatch):
+    now = 1000.0
+    monkeypatch.setattr(similarity_matrix, 'INCREMENTAL_STATE_TTL_SECONDS', 5.0)
+    monkeypatch.setattr(similarity_matrix, 'INCREMENTAL_STATE_MAX_ENTRIES', 10)
+
+    similarity_matrix._INCREMENTAL_STATE.clear()
+    similarity_matrix._INCREMENTAL_STATE[(1, 'hybrid')] = {'updated_at': now - 20.0}
+    similarity_matrix._INCREMENTAL_STATE[(2, 'hybrid')] = {'updated_at': now - 2.0}
+
+    similarity_matrix._prune_incremental_state(now)
+
+    assert (1, 'hybrid') not in similarity_matrix._INCREMENTAL_STATE
+    assert (2, 'hybrid') in similarity_matrix._INCREMENTAL_STATE
+
+
+def test_prune_graph_cache_by_entry_limit(monkeypatch):
+    monkeypatch.setattr(similarity_matrix, 'GRAPH_CACHE_TTL_SECONDS', 1000.0)
+    monkeypatch.setattr(similarity_matrix, 'GRAPH_CACHE_MAX_ENTRIES', 2)
+
+    similarity_matrix._GRAPH_CACHE.clear()
+    similarity_matrix._GRAPH_CACHE[(1,)] = {'graph': {'nodes': []}, 'cached_at': 10.0}
+    similarity_matrix._GRAPH_CACHE[(2,)] = {'graph': {'nodes': []}, 'cached_at': 20.0}
+    similarity_matrix._GRAPH_CACHE[(3,)] = {'graph': {'nodes': []}, 'cached_at': 30.0}
+
+    similarity_matrix._prune_graph_cache(now=40.0)
+
+    assert (1,) not in similarity_matrix._GRAPH_CACHE
+    assert (2,) in similarity_matrix._GRAPH_CACHE
+    assert (3,) in similarity_matrix._GRAPH_CACHE


### PR DESCRIPTION
### Motivation
- Finish P2 work from Graph backlog: harden incremental similarity-state caching (TTL/size) and add larger benchmark scenarios so large-scale behavior can be measured.
- Prevent unbounded memory growth and provide runtime diagnostics for `/api/similarity-graph` responses.

### Description
- Add environment-driven cache policy and pruning for graph results and incremental matrix state with `RECORDROUTE_SIMILARITY_*` variables (`GRAPH_CACHE_TTL_SECONDS`, `GRAPH_CACHE_MAX_ENTRIES`, `INCREMENTAL_STATE_TTL_SECONDS`, `INCREMENTAL_STATE_MAX_ENTRIES`) and helper `_env_*` functions.
- Implement `_prune_graph_cache()` and `_prune_incremental_state()` and call them from `_build_similarity_matrix()` and `get_similarity_graph()` to enforce TTL and max-entry pruning, and store timestamps (`cached_at`, `updated_at`).
- Expose cache diagnostics on responses by adding `meta.cache` with `hit`, `refresh_requested`, and `policy` returned from `_cache_policy_meta()`.
- Expand benchmark script `frontend/scripts/benchmark-similarity-graph.mjs` to support large datasets and custom options via `--include-large`, `--dataset-sizes=...`, and `--iterations=...` (defaults preserved), and update output metadata to include the chosen dataset sizes and iterations.
- Add unit tests verifying cache hit/meta behavior and pruning logic in `tests/test_similarity_matrix_incremental.py` and update docs / samples: `README.md`, `AGENTS.md`, `.env.example`, and `TODO/Graph.md` to reflect the new environment variables and benchmark options.

### Testing
- Ran unit tests with `PYTHONPATH=. pytest tests/test_similarity_matrix_incremental.py tests/http_api/test_similarity_graph.py`, which passed (`11 passed`).
- A plain `pytest` run initially failed in this environment due to import path (`ModuleNotFoundError`), fixed by running with `PYTHONPATH=.`; the successful run above validates the changes.
- Executed the expanded benchmark: `node frontend/scripts/benchmark-similarity-graph.mjs --include-large --iterations=1 --out-dir=frontend/.tmp/perf-check`, which completed and produced the baseline files as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a35ed01c832e812b5b28025b2c90)