### PR TITLE
fix: Phase 3 follow-up for embedding index normalization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,10 @@
 # EMBEDDING_MAX_PROMPT_CHARS=7500
 # Fallback embedding model if platform specific one isn't found
 # EMBEDDING_MODEL=bge-m3:latest
+# llama.cpp/OpenAI-compatible embedding endpoint base URL
+# EMBEDDING_BASE_URL=http://localhost:8081
+# Embedding provider request timeout seconds
+# EMBEDDING_TIMEOUT=300
 
 # --- Cloudflare Tunnel Configuration ---
 # Enable/disable Cloudflare Tunnel integration.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ GET
 - `/file_search`, `/search`
   - `/search` 파라미터 정규화: `sort_by(similarity|date, uploaded_at→date)`, `sort_order(asc|desc)`, `status(completed|pending, done/success/incomplete/todo 별칭 지원)`, `status_task(stt|summary|embedding)`
   - `min_score`는 0~1 범위만 유효, 응답은 항상 `contract_version: search-v2` 포함
+- 검색 시 쿼리 임베딩과 문서 임베딩의 벡터 차원이 다르면 해당 문서는 자동 제외되며 로그에 차원 불일치가 기록됩니다.
 - `/api/similarity-graph`, `/api/documents/metadata`
   - `/api/similarity-graph`는 `min_similarity/max_neighbors/max_nodes/sampling/neighbor_strategy(auto|exact|lsh)` + 필터(`doc_types`, `start_date`, `end_date`, `keyword`)를 지원
   - 응답 `meta`는 `sampling`, `neighbor_strategy(requested/effective)`, `filters`, `incremental(...)` 진단 정보를 포함

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ venv\Scripts\python.exe -m sttEngine.server
 - `LLM_PROVIDER`: 교정/요약 LLM provider 선택 (`ollama` 기본, `llamacpp` 지원)
 - 교정/요약 워크플로우는 provider 중립 옵션(`temperature`, `context_window`, `max_tokens`)을 사용하며 내부에서 provider별 키로 매핑됩니다.
 - `EMBEDDING_PROVIDER`: 임베딩 provider 선택 (미지정 시 `LLM_PROVIDER` 상속)
+- `EMBEDDING_BASE_URL`: llama.cpp(OpenAI 호환) 임베딩 endpoint 기본 URL (기본 `http://localhost:8081`)
+- `EMBEDDING_TIMEOUT`: 임베딩 provider 호출 타임아웃(초, 기본 `LLAMA_CPP_TIMEOUT` 또는 300)
 - `LLAMA_CPP_COMMAND`: llama.cpp 실행 커맨드 (기본 `llama-cli`)
 - `LLAMA_CPP_MODEL_PATH`: llama.cpp 기본 모델 경로 (`.gguf`)
 - `LLAMA_CPP_TIMEOUT`: llama.cpp 호출 타임아웃(초, 기본 300)

--- a/TODO/llama-migration.md
+++ b/TODO/llama-migration.md
@@ -122,13 +122,13 @@
 
 ### 작업
 - [ ] `sttEngine/embedding_pipeline.py`
-  - [ ] `embed_text_ollama`를 중립 함수(`embed_text`)로 교체
-  - [ ] 응답 파싱을 provider별 adapter로 분리
+  - [x] `embed_text_ollama`를 중립 함수(`embed_text`)로 교체
+  - [x] 응답 파싱을 provider별 adapter로 분리
 - [ ] `sttEngine/vector_search.py`
-  - [ ] 쿼리 임베딩 호출을 provider 중립 함수로 전환
+  - [x] 쿼리 임베딩 호출을 provider 중립 함수로 전환
 - [ ] `sttEngine/http_api/embedding.py`
-  - [ ] 임베딩 생성 경로 provider 연동
-- [ ] 벡터 차원 검증 추가
+  - [x] 임베딩 생성 경로 provider 연동
+- [x] 벡터 차원 검증 추가
   - 모델 교체 시 차원 mismatch 탐지 및 명시적 오류 반환
 
 ### 산출물

--- a/sttEngine/embedding_pipeline.py
+++ b/sttEngine/embedding_pipeline.py
@@ -12,14 +12,12 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import sys
 from pathlib import Path
 from typing import Dict
 import os
 from datetime import datetime
 
 import numpy as np
-import requests
 
 from .config import (
     DB_ALIAS,
@@ -29,7 +27,8 @@ from .config import (
     resolve_db_path,
     to_db_record_path,
 )
-from .ollama_utils import ensure_ollama_server
+from .providers import get_embedding_provider
+from .providers.base import ProviderError
 from .vocabulary_manager import VocabularyManager
 
 DB_BASE_PATH = get_db_base_path()
@@ -64,6 +63,38 @@ def _index_key_for_path(path: Path) -> str:
     if record_path.startswith(f"{DB_ALIAS}/"):
         record_path = record_path[len(DB_ALIAS) + 1 :]
     return record_path.replace("/", os.sep)
+
+
+def index_key_for_path(path: Path) -> str:
+    """Public helper for canonical index-key generation."""
+    return _index_key_for_path(path)
+
+
+def _resolve_index_base(path: Path) -> str | None:
+    resolved = path.resolve()
+    for label, base_path in (("whisper_output", WHISPER_OUTPUT_DIR), ("db", DB_BASE_PATH)):
+        try:
+            resolved.relative_to(base_path)
+            return label
+        except ValueError:
+            continue
+    return None
+
+
+def build_index_entry(*, path: Path, checksum: str, vector_file: Path, vector: np.ndarray, model_name: str) -> Dict[str, str]:
+    """Build normalized index metadata payload for a vectorized document."""
+    entry: Dict[str, str] = {
+        "sha256": checksum,
+        "vector": vector_file.name,
+        "timestamp": datetime.fromtimestamp(path.stat().st_mtime).isoformat(),
+        "vector_dimension": int(vector.shape[0]) if getattr(vector, "ndim", 0) == 1 else None,
+        "embedding_model": model_name,
+        "embedding_provider": os.getenv("EMBEDDING_PROVIDER", os.getenv("LLM_PROVIDER", "ollama")),
+    }
+    base = _resolve_index_base(path)
+    if base:
+        entry["base"] = base
+    return entry
 
 
 def _normalize_index_key(key: str) -> str:
@@ -248,58 +279,32 @@ def _chunk_text(text: str, max_chars: int = DEFAULT_MAX_CHARS) -> list[str]:
     return chunks or [text]
 
 
-def _request_embedding(model_name: str, prompt: str) -> np.ndarray:
-    response = requests.post(
-        "http://localhost:11434/api/embeddings",
-        json={
-            "model": model_name,
-            "prompt": prompt
-        },
-        timeout=30
-    )
+def embed_text(text: str, model_name: str, provider_name: str | None = None) -> np.ndarray:
+    """Provider 중립 임베딩 함수.
 
-    try:
-        response.raise_for_status()
-    except requests.HTTPError as exc:
-        detail = response.text.strip()
-        message = f"Ollama 응답 오류 {response.status_code}: {detail or 'no details'}"
-        raise requests.HTTPError(message) from exc
-
-    result = response.json()
-    embedding = result.get("embedding", [])
-    if not embedding:
-        raise ValueError("Empty embedding received from Ollama")
-    return np.array(embedding, dtype=np.float32)
-
-
-def embed_text_ollama(text: str, model_name: str) -> np.ndarray:
-    """Ollama API를 사용하여 텍스트를 임베딩.
-
-    Ollama가 긴 입력에서 500 오류를 반환하는 문제를 피하기 위해 입력을 여러 조각으로
-    나누어 호출한 뒤 평균 임베딩을 사용한다.
+    긴 입력은 조각으로 나누어 임베딩한 뒤 평균 벡터를 반환한다.
     """
 
+    text = text.strip()
+    if not text:
+        raise ValueError("임베딩할 텍스트가 비어 있습니다.")
+
+    provider = get_embedding_provider(provider_name)
+    server_ok, server_msg = provider.healthcheck()
+    if not server_ok:
+        raise RuntimeError(f"임베딩 provider를 사용할 수 없습니다: {server_msg}")
+
     try:
-        server_ok, server_msg = ensure_ollama_server()
-        if not server_ok:
-            raise Exception(f"Ollama 서버를 사용할 수 없습니다: {server_msg}")
-
-        text = text.strip()
-        if not text:
-            raise ValueError("임베딩할 텍스트가 비어 있습니다.")
-
         chunks = _chunk_text(text)
-        vectors = []
-        for chunk in chunks:
-            vectors.append(_request_embedding(model_name, chunk))
+        vectors = [provider.embed(chunk, model=model_name) for chunk in chunks]
 
         if len(vectors) == 1:
             return vectors[0]
 
         stacked = np.vstack(vectors)
         return np.mean(stacked, axis=0)
-    except Exception as e:
-        print(f"Ollama 임베딩 실패: {e}")
+    except ProviderError as exc:
+        print(f"임베딩 provider 호출 실패: {exc}")
         raise
 
 
@@ -323,23 +328,17 @@ def process_file(model_name: str, path: Path, index: Dict[str, Dict[str, str]]) 
     if already_indexed:
         return  # already up-to-date, vocab updated above
 
-    vector = embed_text_ollama(text, model_name)
+    vector = embed_text(text, model_name)
     out_file = VECTOR_DIR / f"{path.stem}.npy"
     np.save(out_file, vector)
 
-    entry = {
-        "sha256": checksum,
-        "vector": out_file.name,
-        "timestamp": datetime.fromtimestamp(path.stat().st_mtime).isoformat()
-    }
-
-    for label, base_path in (("whisper_output", WHISPER_OUTPUT_DIR), ("db", DB_BASE_PATH)):
-        try:
-            path.resolve().relative_to(base_path)
-            entry["base"] = label
-            break
-        except ValueError:
-            continue
+    entry = build_index_entry(
+        path=path,
+        checksum=checksum,
+        vector_file=out_file,
+        vector=vector,
+        model_name=model_name,
+    )
 
     index[key] = entry
 
@@ -348,7 +347,7 @@ def main(src_dir: str) -> None:
     """Scan for summary files under ``src_dir`` and embed newly added ones."""
     try:
         model_name = get_model_for_task("EMBEDDING", get_default_model("EMBEDDING"))
-    except:
+    except Exception:
         # 환경변수 설정이 없을 때 기본 모델 사용
         model_name = os.environ.get("EMBEDDING_MODEL", "bge-m3:latest")
     

--- a/sttEngine/http_api/embedding.py
+++ b/sttEngine/http_api/embedding.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import numpy as np
 
-from ..embedding_pipeline import embed_text_ollama, load_index, save_index
+from ..embedding_pipeline import build_index_entry, embed_text, index_key_for_path, load_index, save_index
 from ..vector_search import refresh_similarity_data
 from .paths import OUTPUT_DIR, VECTOR_DIR, to_record_path
 from .registry import update_task_completion
@@ -48,7 +48,7 @@ def run_incremental_embedding(base_dir: Path | None = None) -> int:
 
             # Check if already processed and up-to-date
             checksum = file_hash(md_file)
-            key = str(md_file.resolve())
+            key = index_key_for_path(md_file)
             if index.get(key, {}).get("sha256") == checksum:
                 continue  # Already up-to-date
 
@@ -57,7 +57,7 @@ def run_incremental_embedding(base_dir: Path | None = None) -> int:
                 text = md_file.read_text(encoding="utf-8")
 
                 # Generate embedding
-                vector = embed_text_ollama(text, model_name)
+                vector = embed_text(text, model_name)
 
                 # Create vector directory if not exists
                 VECTOR_DIR.mkdir(parents=True, exist_ok=True)
@@ -67,13 +67,19 @@ def run_incremental_embedding(base_dir: Path | None = None) -> int:
                 np.save(vector_file, vector)
 
                 # Update index
-                index[key] = {
-                    "sha256": checksum,
-                    "vector": vector_file.name,
+                entry = build_index_entry(
+                    path=md_file,
+                    checksum=checksum,
+                    vector_file=vector_file,
+                    vector=vector,
+                    model_name=model_name,
+                )
+                entry.update({
                     "deleted": False,
                     "deleted_path": None,
                     "vector_deleted_path": None,
-                }
+                })
+                index[key] = entry
 
                 processed_count += 1
                 print(f"임베딩 생성 완료: {md_file.name}")
@@ -109,7 +115,7 @@ def generate_embedding(file_path: Path, record_id: str | None = None) -> bool:
         text = file_path.read_text(encoding="utf-8")
 
         # Generate embedding
-        vector = embed_text_ollama(text, model_name)
+        vector = embed_text(text, model_name)
 
         # Create vector directory if not exists
         VECTOR_DIR.mkdir(parents=True, exist_ok=True)
@@ -122,13 +128,20 @@ def generate_embedding(file_path: Path, record_id: str | None = None) -> bool:
         index = load_index()
         checksum = file_hash(file_path)
 
-        index[str(file_path.resolve())] = {
-            "sha256": checksum,
-            "vector": vector_file.name,
+        key = index_key_for_path(file_path)
+        entry = build_index_entry(
+            path=file_path,
+            checksum=checksum,
+            vector_file=vector_file,
+            vector=vector,
+            model_name=model_name,
+        )
+        entry.update({
             "deleted": False,
             "deleted_path": None,
             "vector_deleted_path": None,
-        }
+        })
+        index[key] = entry
         save_index(index)
         refresh_similarity_data()
 

--- a/sttEngine/providers/llama_cpp_provider.py
+++ b/sttEngine/providers/llama_cpp_provider.py
@@ -5,6 +5,7 @@ import subprocess
 from typing import Any, Dict, List, Optional, Sequence
 
 import numpy as np
+import requests
 
 from .base import ProviderConfigurationError, ProviderRequestError
 from .embedding_provider import BaseEmbeddingProvider
@@ -100,13 +101,78 @@ class LlamaCppLLMProvider(BaseLLMProvider):
 
 
 class LlamaCppEmbeddingProvider(BaseEmbeddingProvider):
+    def _resolve_base_url(self) -> str:
+        return (
+            os.getenv("EMBEDDING_BASE_URL")
+            or os.getenv("LLM_BASE_URL")
+            or "http://localhost:8081"
+        ).rstrip("/")
+
+    def _resolve_timeout_seconds(self) -> int:
+        return int(os.getenv("EMBEDDING_TIMEOUT", os.getenv("LLAMA_CPP_TIMEOUT", "300")))
+
     def embed(self, text: str, *, model: str) -> np.ndarray:
-        _ = text
-        _ = model
-        raise ProviderRequestError("llama.cpp embedding provider는 아직 구현되지 않았습니다. (Phase 1 skeleton)")
+        prompt = (text or "").strip()
+        if not prompt:
+            raise ProviderRequestError("llama.cpp embedding 호출용 텍스트가 비어 있습니다.")
+
+        model_name = (model or "").strip() or os.getenv("EMBEDDING_MODEL", "")
+        if not model_name:
+            raise ProviderConfigurationError("llama.cpp embedding provider는 model 이름이 필요합니다.")
+
+        base_url = self._resolve_base_url()
+        timeout_seconds = self._resolve_timeout_seconds()
+
+        try:
+            response = requests.post(
+                f"{base_url}/v1/embeddings",
+                json={"model": model_name, "input": prompt},
+                timeout=timeout_seconds,
+            )
+        except requests.RequestException as exc:
+            raise ProviderRequestError(f"llama.cpp embedding 요청 실패: {exc}") from exc
+
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            detail = response.text.strip()
+            raise ProviderRequestError(
+                f"llama.cpp embedding 응답 오류 {response.status_code}: {detail or 'no details'}"
+            ) from exc
+
+        payload = response.json() if response.content else {}
+        data = payload.get("data") if isinstance(payload, dict) else None
+        if not isinstance(data, list) or not data:
+            raise ProviderRequestError("llama.cpp embedding 응답(data)이 비어 있습니다.")
+
+        first = data[0] if isinstance(data[0], dict) else {}
+        embedding = first.get("embedding") if isinstance(first, dict) else None
+        if not isinstance(embedding, list) or not embedding:
+            raise ProviderRequestError("llama.cpp embedding 벡터가 비어 있습니다.")
+        return np.array(embedding, dtype=np.float32)
 
     def embed_batch(self, texts: Sequence[str], *, model: str) -> list[np.ndarray]:
         return [self.embed(text, model=model) for text in texts]
 
     def healthcheck(self) -> tuple[bool, str]:
-        return LlamaCppLLMProvider().healthcheck()
+        base_url = self._resolve_base_url()
+        timeout_seconds = self._resolve_timeout_seconds()
+        try:
+            response = requests.get(f"{base_url}/health", timeout=min(timeout_seconds, 5))
+            if response.status_code < 500:
+                return True, f"llama.cpp embedding endpoint 확인 완료: {base_url}"
+        except requests.RequestException:
+            pass
+
+        # /health 미구현 서버를 위해 embeddings endpoint에 probe
+        try:
+            response = requests.post(
+                f"{base_url}/v1/embeddings",
+                json={"model": os.getenv("EMBEDDING_MODEL", "__healthcheck__"), "input": "ping"},
+                timeout=min(timeout_seconds, 8),
+            )
+            if response.status_code in {200, 400, 404, 422}:
+                return True, f"llama.cpp embedding endpoint 확인 완료: {base_url}"
+            return False, f"llama.cpp embedding endpoint 응답 이상({response.status_code}): {base_url}"
+        except requests.RequestException as exc:
+            return False, f"llama.cpp embedding endpoint 접근 실패: {base_url} ({exc})"

--- a/sttEngine/vector_search.py
+++ b/sttEngine/vector_search.py
@@ -9,9 +9,18 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 
 from .config import get_default_model, get_model_for_task, normalize_db_record_path
-from .embedding_pipeline import INDEX_FILE, VECTOR_DIR, embed_text_ollama, load_index, resolve_index_path
+from .embedding_pipeline import INDEX_FILE, VECTOR_DIR, embed_text, load_index, resolve_index_path
 from .search_cache import cache_search_result, get_cached_search_result
 from .similarity_matrix import invalidate_similarity_cache
+
+
+def _resolve_vector_dimension(meta: Dict[str, Any], doc_vec: np.ndarray) -> int:
+    configured = meta.get("vector_dimension") if isinstance(meta, dict) else None
+    if isinstance(configured, int) and configured > 0:
+        return configured
+    if getattr(doc_vec, "ndim", 0) == 1:
+        return int(doc_vec.shape[0])
+    return 0
 
 
 def _build_index_signature() -> str:
@@ -87,7 +96,7 @@ def search(query: str, base_dir: Path, top_k: int = 10,
 
     try:
         embedding_start = time.perf_counter()
-        query_vec = embed_text_ollama(query, model_name)
+        query_vec = embed_text(query, model_name)
         timing["embedding_ms"] = (time.perf_counter() - embedding_start) * 1000
 
         index_load_start = time.perf_counter()
@@ -119,6 +128,14 @@ def search(query: str, base_dir: Path, top_k: int = 10,
             if not vec_file.exists():
                 continue
             doc_vec = np.load(vec_file)
+            expected_dim = _resolve_vector_dimension(meta, doc_vec)
+            query_dim = int(query_vec.shape[0]) if getattr(query_vec, "ndim", 0) == 1 else 0
+            if expected_dim and query_dim and expected_dim != query_dim:
+                print(
+                    "벡터 차원 불일치 감지 "
+                    f"(file={path_str}, expected={expected_dim}, query={query_dim}, model={meta.get('embedding_model')})"
+                )
+                continue
             denom = (np.linalg.norm(query_vec) * np.linalg.norm(doc_vec))
             if denom == 0:
                 continue

--- a/tests/providers/test_llama_cpp_embedding_provider.py
+++ b/tests/providers/test_llama_cpp_embedding_provider.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from sttEngine.providers.base import ProviderConfigurationError, ProviderRequestError
+from sttEngine.providers.llama_cpp_provider import LlamaCppEmbeddingProvider
+
+
+class _Response:
+    def __init__(self, status_code: int, payload: dict | None = None, text: str = "") -> None:
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+        self.content = b"{}"
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            import requests
+
+            raise requests.HTTPError(f"status={self.status_code}")
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def test_llamacpp_embedding_provider_calls_openai_compatible_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = LlamaCppEmbeddingProvider()
+
+    monkeypatch.setenv("EMBEDDING_BASE_URL", "http://127.0.0.1:8081")
+
+    def fake_post(url: str, json: dict, timeout: int):
+        assert url == "http://127.0.0.1:8081/v1/embeddings"
+        assert json["model"] == "bge-m3"
+        assert json["input"] == "hello"
+        assert timeout > 0
+        return _Response(200, payload={"data": [{"embedding": [0.1, 0.2, 0.3]}]})
+
+    monkeypatch.setattr("requests.post", fake_post)
+
+    vector = provider.embed("hello", model="bge-m3")
+
+    assert isinstance(vector, np.ndarray)
+    assert vector.tolist() == pytest.approx([0.1, 0.2, 0.3])
+
+
+def test_llamacpp_embedding_provider_requires_model() -> None:
+    provider = LlamaCppEmbeddingProvider()
+    with pytest.raises(ProviderConfigurationError):
+        provider.embed("hello", model="")
+
+
+def test_llamacpp_embedding_provider_raises_for_invalid_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = LlamaCppEmbeddingProvider()
+
+    def fake_post(url: str, json: dict, timeout: int):
+        return _Response(200, payload={"data": []})
+
+    monkeypatch.setattr("requests.post", fake_post)
+
+    with pytest.raises(ProviderRequestError):
+        provider.embed("hello", model="bge-m3")

--- a/tests/test_vector_search_dimension.py
+++ b/tests/test_vector_search_dimension.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from sttEngine import vector_search
+
+
+def test_search_skips_dimension_mismatch(tmp_path: Path, monkeypatch) -> None:
+    base_dir = tmp_path / "DB"
+    vector_dir = base_dir / "vector_store"
+    vector_dir.mkdir(parents=True)
+
+    np.save(vector_dir / "a.npy", np.array([0.1, 0.2, 0.3], dtype=np.float32))
+
+    index = {
+        "doc-a": {
+            "vector": "a.npy",
+            "timestamp": "2024-01-01T00:00:00",
+            "vector_dimension": 3,
+        }
+    }
+
+    monkeypatch.setattr(vector_search, "VECTOR_DIR", vector_dir)
+    monkeypatch.setattr(vector_search, "load_index", lambda: index)
+    monkeypatch.setattr(vector_search, "resolve_index_path", lambda *_args, **_kwargs: base_dir / "doc-a.md")
+    monkeypatch.setattr(vector_search, "get_model_for_task", lambda *_args, **_kwargs: "bge-m3")
+    monkeypatch.setattr(vector_search, "get_default_model", lambda *_args, **_kwargs: "bge-m3")
+    monkeypatch.setattr(vector_search, "embed_text", lambda *_args, **_kwargs: np.array([1.0, 2.0], dtype=np.float32))
+    monkeypatch.setattr(vector_search, "get_cached_search_result", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(vector_search, "cache_search_result", lambda *_args, **_kwargs: None)
+
+    results = vector_search.search("hello", base_dir=base_dir, include_timing=False)
+
+    assert results == []


### PR DESCRIPTION
### Motivation
- Normalize and de-duplicate index key/metadata generation so the embedding index uses a single canonical key format and consistent metadata across different embedding entrypoints. 
- Prevent drift between `embedding_pipeline` and `http_api/embedding` where absolute-path keys and canonical keys were mixed. 
- Improve provider-neutral embedding plumbing and surface-safe error handling and vector-dimension validation during search.

### Description
- Added public helper `index_key_for_path()` and consolidated metadata construction into `build_index_entry()` in `sttEngine/embedding_pipeline.py`, and factored `_resolve_index_base()` to decide index `base` consistently. 
- Replaced Ollama-specific embedding callers with the provider-neutral `embed_text()` and tightened exception handling (avoid bare `except:`). 
- Updated `sttEngine/http_api/embedding.py` to use `index_key_for_path()` and `build_index_entry()` for both incremental and single-file embedding flows to ensure a single key/meta convention. 
- Implemented `LlamaCppEmbeddingProvider` HTTP/OpenAI-compatible embedding support and robust healthcheck/payload handling in `sttEngine/providers/llama_cpp_provider.py`, and added vector-dimension validation in `sttEngine/vector_search.py` to skip mismatched documents and log the mismatch.

### Testing
- Ran the core and provider unit suites via `pytest tests/providers/test_provider_factory.py tests/providers/test_llama_cpp_embedding_provider.py tests/test_vector_search_dimension.py tests/http_api/test_search.py tests/http_api/test_workflow.py tests/server/test_queue.py tests/test_vocab_system.py`. 
- All tests passed (`23 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995118f3600832e808963536f577184)