### PR TITLE
fix: scope /models lookup to requested provider and sync frontend settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@ GET
   - `/api/similarity-graph`는 `min_similarity/max_neighbors/max_nodes/sampling/neighbor_strategy(auto|exact|lsh)` + 필터(`doc_types`, `start_date`, `end_date`, `keyword`)를 지원
   - 응답 `meta`는 `sampling`, `neighbor_strategy(requested/effective)`, `filters`, `incremental(...)` 진단 정보를 포함
 - `/similar/<uuid_or_path>`, `/models`
+  - `/models` 응답은 `models`(요청 provider 기준) + `models_by_provider` + `provider_status` + `default.provider`를 포함
+  - 선택 쿼리: `provider=ollama|llamacpp` (미지정 시 `LLM_PROVIDER` 기준)
 - `/cache/stats`, `/cache/cleanup`
 
 POST

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ venv\Scripts\python.exe -m sttEngine.server
 - `/`, `/assets/*`, `/download/<uuid_or_path>`
 - `/history`, `/tasks`, `/progress/<task_id>` (진행률 %, ETA, 표준 오류 payload 포함)
 - `/search`, `/models`, `/cache/stats`, `/cache/cleanup`
+  - `/models` 응답은 `models`(요청 provider 기준) + `models_by_provider` + `provider_status` + `default.provider`를 포함
+  - 선택 쿼리: `provider=ollama|llamacpp` (미지정 시 `LLM_PROVIDER` 기준)
 - `/api/similarity-graph`, `/api/documents/metadata`
   - `/api/similarity-graph`는 `min_similarity/max_neighbors/max_nodes/sampling/neighbor_strategy(auto|exact|lsh)` + 필터(`doc_types`, `start_date`, `end_date`, `keyword`)를 지원
   - 응답 `meta`에는 `sampling`, `neighbor_strategy(requested/effective)`, `filters`, `incremental(...)` 진단 필드 포함

--- a/TODO/llama-migration.md
+++ b/TODO/llama-migration.md
@@ -144,23 +144,23 @@
 ## Phase 4 — 모델 조회 API & 프론트 계약 정비
 
 ### 작업
-- [ ] `sttEngine/http_api/handler.py` `/models`
-  - [ ] `ollama list` subprocess 제거
-  - [ ] provider `list_models()` 기반 응답
-- [ ] `frontend/src/api/types.ts`
-  - [ ] `ModelSettings` 키를 백엔드 계약과 일치시킴 (`whisper` 우선)
-  - [ ] 과도기 호환(`transcribe` 별칭) 처리 여부 결정
-- [ ] `frontend/src/hooks/useTaskQueue.ts`
-  - [ ] `/process`에 전달하는 `model_settings` 키를 계약과 동기화
-- [ ] `frontend/src/components/SettingsDialog.tsx`
-  - [ ] provider별 모델 목록 UX 반영
+- [x] `sttEngine/http_api/handler.py` `/models`
+  - [x] `ollama list` subprocess 제거
+  - [x] provider `list_models()` 기반 응답
+- [x] `frontend/src/api/types.ts`
+  - [x] `ModelSettings` 키를 백엔드 계약과 일치시킴 (`whisper` 우선)
+  - [x] 과도기 호환(`transcribe` 별칭) 처리 여부 결정
+- [x] `frontend/src/hooks/useTaskQueue.ts`
+  - [x] `/process`에 전달하는 `model_settings` 키를 계약과 동기화
+- [x] `frontend/src/components/SettingsDialog.tsx`
+  - [x] provider별 모델 목록 UX 반영
 
 ### 산출물
 - 모델 조회/선택 플로우 정합성 확보
 
 ### 검증
-- [ ] `/models` 응답 계약 테스트
-- [ ] 프론트 `npm run build` 성공
+- [x] `/models` 응답 계약 테스트
+- [x] 프론트 `npm run build` 성공
 
 ---
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -219,7 +219,10 @@ export async function deleteFile(fileIdentifier: string, fileType: ViewerFileTyp
 
 export const getDownloadUrl = (fileIdentifier: string): string => `/download/${encodeURIComponent(fileIdentifier)}`;
 
-export const getModels = () => apiRequest<ModelsResponse>('/models');
+export const getModels = (provider?: 'ollama' | 'llamacpp') => {
+  const query = provider ? `?provider=${encodeURIComponent(provider)}` : '';
+  return apiRequest<ModelsResponse>(`/models${query}`);
+};
 
 export async function shutdown(auth?: DestructiveApiAuth): Promise<void> {
   const authOptions = buildDestructiveApiAuthOptions(auth);

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -165,7 +165,10 @@ export interface ModelsResponse {
     whisper: string;
     summarize: string;
     embedding: string;
+    provider?: 'ollama' | 'llamacpp';
   };
+  models_by_provider?: Partial<Record<'ollama' | 'llamacpp', string[]>>;
+  provider_status?: Partial<Record<'ollama' | 'llamacpp', { ok: boolean; message: string }>>;
 }
 
 export interface RunningTask {
@@ -218,7 +221,7 @@ export interface QueueTask {
 }
 
 export interface ModelSettings {
-  transcribe: string;
+  whisper: string;
   summarize: string;
   embedding: string;
   language: string;

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -20,18 +20,20 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   const [localSettings, setLocalSettings] = useState(modelSettings);
   const [darkMode, setDarkMode] = useState(theme === 'dark');
   const [availableModels, setAvailableModels] = useState<string[]>([]);
-  const [defaults, setDefaults] = useState<{ whisper: string; summarize: string; embedding: string } | null>(null);
+  const [defaults, setDefaults] = useState<{ whisper: string; summarize: string; embedding: string; provider?: 'ollama' | 'llamacpp' } | null>(null);
+
+  const selectedProvider = (localSettings?.provider || localSettings?.llm_provider || defaults?.provider || 'ollama') as 'ollama' | 'llamacpp';
 
   useEffect(() => {
     if (open) {
       setLocalSettings(modelSettings);
       setDarkMode(theme === 'dark');
-      api.getModels().then(data => {
+      api.getModels(selectedProvider).then(data => {
         setAvailableModels(data.models || []);
         setDefaults(data.default);
       }).catch(() => { });
     }
-  }, [open, modelSettings, theme]);
+  }, [open, modelSettings, theme, selectedProvider]);
 
   const handleSave = () => {
     setTheme(darkMode ? 'dark' : 'light');
@@ -60,7 +62,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
         <div className="space-y-6 py-4">
           <div className="space-y-2">
             <Label className={theme === 'dark' ? 'text-slate-200' : 'text-slate-700'}>Whisper 모델 (STT):</Label>
-            <Select value={localSettings.transcribe} onValueChange={(v: string) => setLocalSettings(s => ({ ...s, transcribe: v }))}>
+            <Select value={localSettings.whisper} onValueChange={(v: string) => setLocalSettings(s => ({ ...s, whisper: v }))}>
               <SelectTrigger className={theme === 'dark' ? 'bg-slate-800 border-slate-700 text-slate-200' : 'bg-slate-50 border-slate-300'}>
                 <SelectValue />
               </SelectTrigger>
@@ -84,6 +86,20 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                 <SelectItem value="en">English</SelectItem>
                 <SelectItem value="ja">日本語</SelectItem>
                 <SelectItem value="zh">中文</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+
+          <div className="space-y-2">
+            <Label className={theme === 'dark' ? 'text-slate-200' : 'text-slate-700'}>LLM Provider:</Label>
+            <Select value={selectedProvider} onValueChange={(v: 'ollama' | 'llamacpp') => setLocalSettings(s => ({ ...s, provider: v, llm_provider: v }))}>
+              <SelectTrigger className={theme === 'dark' ? 'bg-slate-800 border-slate-700 text-slate-200' : 'bg-slate-50 border-slate-300'}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent className={theme === 'dark' ? 'bg-slate-800 border-slate-700' : ''}>
+                <SelectItem value="ollama">ollama</SelectItem>
+                <SelectItem value="llamacpp">llamacpp</SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/frontend/src/hooks/useModelSettings.ts
+++ b/frontend/src/hooks/useModelSettings.ts
@@ -4,7 +4,7 @@ import type { ModelSettings } from '../api/types';
 const STORAGE_KEY = 'modelSettings';
 
 const defaultSettings: ModelSettings = {
-  transcribe: 'large-v3-turbo',
+  whisper: 'large-v3-turbo',
   summarize: '',
   embedding: '',
   language: 'ko',
@@ -15,7 +15,11 @@ export function useModelSettings() {
     try {
       const stored = localStorage.getItem(STORAGE_KEY);
       if (stored) {
-        return { ...defaultSettings, ...JSON.parse(stored) };
+        const parsed = JSON.parse(stored);
+        const migrated = parsed?.transcribe && !parsed?.whisper
+          ? { ...parsed, whisper: parsed.transcribe }
+          : parsed;
+        return { ...defaultSettings, ...migrated };
       }
     } catch {}
     return defaultSettings;

--- a/frontend/src/hooks/useTaskQueue.ts
+++ b/frontend/src/hooks/useTaskQueue.ts
@@ -148,9 +148,12 @@ export function useTaskQueue(modelSettings: ModelSettings, onTaskComplete?: () =
         task.recordId,
         processingTask.taskId,
         {
-          transcribe: ms.transcribe,
+          whisper: ms.whisper,
           summarize: ms.summarize,
+          embedding: ms.embedding,
           language: ms.language,
+          provider: ms.provider,
+          llm_provider: ms.llm_provider,
         },
         abortController.signal,
         'new_task',

--- a/sttEngine/http_api/handler.py
+++ b/sttEngine/http_api/handler.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import json
+import os
 import threading
 import time
 from http.server import BaseHTTPRequestHandler
 
-from ..ollama_utils import ensure_ollama_server
+from ..providers.factory import get_llm_provider
 from ..vector_search import search as search_vectors
 from ..server.routes import history as history_route
 from ..server.routes import process as process_route
@@ -63,38 +64,51 @@ class UploadHandler(BaseHTTPRequestHandler):
 
 
 
-    def _serve_available_models(self):
+    def _serve_available_models(self, provider_name: str | None = None):
         try:
-            server_ok, server_msg = ensure_ollama_server()
-            if not server_ok:
-                raise Exception(f"Ollama 서버를 사용할 수 없습니다: {server_msg}")
+            provider_aliases = {
+                "llama.cpp": "llamacpp",
+                "llama_cpp": "llamacpp",
+                "llama-cpp": "llamacpp",
+            }
+            provider_models: dict[str, list[str]] = {"ollama": [], "llamacpp": []}
+            provider_status: dict[str, dict[str, str | bool]] = {
+                "ollama": {"ok": False, "message": "not_checked"},
+                "llamacpp": {"ok": False, "message": "not_checked"},
+            }
 
-            import subprocess
+            configured_provider = (os.getenv("LLM_PROVIDER") or "ollama").strip().lower()
+            active_provider = provider_aliases.get(configured_provider, configured_provider)
+            normalized_requested_provider = (provider_name or "").strip().lower()
+            requested_provider = provider_aliases.get(normalized_requested_provider, normalized_requested_provider or None)
+            if requested_provider not in {"ollama", "llamacpp"}:
+                requested_provider = active_provider if active_provider in {"ollama", "llamacpp"} else "ollama"
 
-            result = subprocess.run(["ollama", "list"], capture_output=True, text=True, timeout=10)
-            if result.returncode != 0:
-                raise Exception(f"Ollama list failed: {result.stderr}")
+            for resolved_provider in (requested_provider,):
+                try:
+                    provider = get_llm_provider(resolved_provider)
+                    ok, message = provider.healthcheck()
+                    models = provider.list_models() if ok else []
+                    provider_models[resolved_provider] = models
+                    provider_status[resolved_provider] = {"ok": ok, "message": message}
+                except Exception as provider_exc:
+                    provider_models[resolved_provider] = []
+                    provider_status[resolved_provider] = {"ok": False, "message": str(provider_exc)}
 
-            lines = result.stdout.strip().split("\n")
-            models = []
-
-            for line in lines[1:] if len(lines) > 1 else lines:
-                if line.strip():
-                    parts = line.split()
-                    if parts:
-                        model_name = parts[0]
-                        if "/" not in model_name and model_name not in ["mxbai-embed-large"]:
-                            models.append(model_name)
+            models = provider_models.get(requested_provider, [])
 
             from ..workflow.summarize import DEFAULT_MODEL
             from ..config import get_default_model
 
             response_data = {
                 "models": models,
+                "models_by_provider": provider_models,
+                "provider_status": provider_status,
                 "default": {
                     "whisper": "large-v3-turbo",
                     "summarize": DEFAULT_MODEL,
                     "embedding": get_default_model("EMBEDDING"),
+                    "provider": requested_provider,
                 },
             }
 
@@ -109,7 +123,7 @@ class UploadHandler(BaseHTTPRequestHandler):
             self.send_header("Content-Type", "application/json")
             self.end_headers()
             error_response = {
-                "error": "모델 목록을 조회할 수 없습니다. Ollama가 실행 중인지 확인해주세요.",
+                "error": "모델 목록을 조회할 수 없습니다. LLM provider 설정을 확인해주세요.",
                 "details": str(e),
             }
             self.wfile.write(json.dumps(error_response, ensure_ascii=False).encode())
@@ -144,4 +158,3 @@ class UploadHandler(BaseHTTPRequestHandler):
 
         self.send_response(404)
         self.end_headers()
-

--- a/sttEngine/http_api/routes/admin_routes.py
+++ b/sttEngine/http_api/routes/admin_routes.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import json
+from urllib.parse import parse_qs, urlparse
 
 from ..destructive_guard import check_destructive_api_access, reject_destructive_api_request
 
 
 def handle_get(handler) -> bool:
-    if handler.path == '/models':
-        handler._serve_available_models()
+    parsed = urlparse(handler.path)
+    if parsed.path == '/models':
+        query = parse_qs(parsed.query)
+        provider_name = query.get('provider', [None])[0]
+        handler._serve_available_models(provider_name=provider_name)
         return True
     return False
 

--- a/tests/http_api/test_admin_models.py
+++ b/tests/http_api/test_admin_models.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+from io import BytesIO
+
+from sttEngine.http_api.handler import UploadHandler
+
+
+class _DummyModelsHandler:
+    def __init__(self):
+        self.status_code: int | None = None
+        self.headers_sent: list[tuple[str, str]] = []
+        self.wfile = BytesIO()
+
+    def send_response(self, status_code: int) -> None:
+        self.status_code = status_code
+
+    def send_header(self, key: str, value: str) -> None:
+        self.headers_sent.append((key, value))
+
+    def end_headers(self) -> None:
+        return
+
+
+class _FakeProvider:
+    def __init__(self, models: list[str], ok: bool = True, message: str = "ok"):
+        self._models = models
+        self._ok = ok
+        self._message = message
+
+    def healthcheck(self):
+        return self._ok, self._message
+
+    def list_models(self):
+        return self._models
+
+
+def test_models_endpoint_uses_provider_contract(monkeypatch):
+    handler = _DummyModelsHandler()
+
+    providers = {
+        "ollama": _FakeProvider(["gpt-oss:20b"]),
+        "llamacpp": _FakeProvider(["/models/llama-3.1.gguf"]),
+    }
+
+    monkeypatch.setenv("LLM_PROVIDER", "llama_cpp")
+    monkeypatch.setattr("sttEngine.http_api.handler.get_llm_provider", lambda name: providers[name])
+
+    UploadHandler._serve_available_models(handler)
+
+    assert handler.status_code == 200
+    payload = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    assert payload["models"] == ["/models/llama-3.1.gguf"]
+    assert payload["models_by_provider"]["ollama"] == []
+    assert payload["models_by_provider"]["llamacpp"] == ["/models/llama-3.1.gguf"]
+    assert payload["default"]["provider"] == "llamacpp"
+    assert payload["provider_status"]["ollama"]["message"] == "not_checked"
+
+
+def test_models_endpoint_respects_explicit_provider_query(monkeypatch):
+    handler = _DummyModelsHandler()
+
+    providers = {
+        "ollama": _FakeProvider(["gpt-oss:20b"]),
+        "llamacpp": _FakeProvider(["/models/llama-3.1.gguf"]),
+    }
+
+    monkeypatch.setenv("LLM_PROVIDER", "llama_cpp")
+    monkeypatch.setattr("sttEngine.http_api.handler.get_llm_provider", lambda name: providers[name])
+
+    UploadHandler._serve_available_models(handler, provider_name="ollama")
+
+    assert handler.status_code == 200
+    payload = json.loads(handler.wfile.getvalue().decode("utf-8"))
+    assert payload["models"] == ["gpt-oss:20b"]
+    assert payload["default"]["provider"] == "ollama"
+    assert payload["provider_status"]["ollama"]["ok"] is True
+    assert payload["provider_status"]["llamacpp"]["message"] == "not_checked"


### PR DESCRIPTION
### Motivation
- Prevent unnecessary provider probes and side-effects by making `/models` respond for the explicitly requested provider (or fall back to `LLM_PROVIDER`).
- Ensure frontend UI and API client fetch model lists for the currently selected provider so provider switches immediately reflect available models.
- Keep the `/models` response contract while marking non-queried providers as `not_checked` to preserve diagnostic fields.

### Description
- Added provider query parsing to the admin route and changed `GET /models` to accept `provider=ollama|llamacpp` via `sttEngine/http_api/routes/admin_routes.py` and `UploadHandler._serve_available_models(provider_name)` in `sttEngine/http_api/handler.py`.
- Updated `_serve_available_models` to resolve a requested provider (falling back to `LLM_PROVIDER`) and only call `healthcheck()` + `list_models()` for that provider while returning `models_by_provider` and `provider_status` with non-queried providers marked as `not_checked`.
- Frontend client `getModels` now accepts an optional `provider` and sends it as a query parameter in `frontend/src/api/client.ts`, and `SettingsDialog` refetches models when the selected provider changes to use the provider-scoped `availableModels` in `frontend/src/components/SettingsDialog.tsx`.
- Adjusted model settings handling and migration in `frontend/src/hooks/useModelSettings.ts` and updated the payload mapping in `frontend/src/hooks/useTaskQueue.ts` to use backend contract keys (`whisper`, `summarize`, `embedding`, plus `provider`/`llm_provider`).
- Added/updated tests in `tests/http_api/test_admin_models.py` to cover default fallback and explicit `provider` query behavior, and updated documentation lines in `README.md` and `AGENTS.md` to document the `provider` query option.

### Testing
- Ran unit/regression tests with `pytest tests/http_api/test_admin_models.py tests/http_api/test_workflow.py tests/http_api/test_search.py tests/server/test_queue.py tests/test_vocab_system.py` and all tests passed (`13 passed`).
- Built the frontend with `cd frontend && npm run build` which completed successfully.
- Started the dev frontend with `npm run dev -- --host 0.0.0.0 --port 4173` and captured a Playwright screenshot of the Settings dialog to validate provider-aware UI updates (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995179ae0f8832ea3cd192d076b7838)