### PR TITLE
docs: sync TODO/llama-migration.md with current llama migration status

### DIFF
--- a/TODO/STATUS_REVIEW.md
+++ b/TODO/STATUS_REVIEW.md
@@ -122,3 +122,75 @@
 ## 테스트 증거
 - `pytest tests/providers/test_provider_factory.py`
 - `pytest tests/providers/test_llama_cpp_embedding_provider.py`
+
+---
+
+# llama 마이그레이션 진행 점검 (2026-02-18, RTD 재검토)
+
+요청: "llama 마이그레이션 작업이 잘 진행됐는지"를 현재 코드/문서/테스트 기준으로 재검토.
+
+## [Step 1] 계획 수립 — PASS
+- 범위(In): provider 추상화, `/models` 계약, `/process model_settings` 정합성, 핵심 회귀 테스트.
+- 범위(Out): 실제 clean 환경 배포(run/setup) 실측, 대규모 성능 벤치.
+- 검증 방식: 코드 근거 확인 + 핵심/공급자 테스트 실행.
+
+## [Step 2] 계획 검토 — PASS
+- 문서 체크리스트와 실제 코드 간 드리프트 가능성을 핵심 위험으로 포함.
+
+## [Step 3] 검토 재검토 — PASS
+- DoD를 "코드에서 llama provider 경로가 실제 동작 가능한가"로 한정.
+- 가정: 테스트가 현재 계약의 최소 보증선 역할을 한다.
+
+## [Step 4] 과도성 검토 — PASS
+- 기능 변경 없이 상태 진단만 수행.
+
+## [Step 5] 구현(점검 수행) — PASS
+- `sttEngine/providers/factory.py`에서 `ollama|llamacpp` 선택 + alias(`llama.cpp`, `llama_cpp`, `llama-cpp`) 처리 확인.
+- `sttEngine/http_api/handler.py`의 `_serve_available_models()`가 provider 단위 상태/모델 목록(`models_by_provider`, `provider_status`)을 반환함을 확인.
+- `sttEngine/http_api/workflow.py`에서 `model_settings.provider` 또는 `model_settings.llm_provider`를 교정/요약 경로로 전달함을 확인.
+- `frontend/src/hooks/useTaskQueue.ts`, `frontend/src/api/types.ts`에서 `whisper/summarize/correct/embedding/llm_provider` 계약이 반영됨을 확인.
+
+## [Step 6] 목적 적합성 검토 — PASS
+- llama provider 전환의 핵심 골격(백엔드 provider 팩토리 + API 계약 + 프론트 전달)은 동작 가능한 상태.
+
+## [Step 7] 잠재 이슈/보안 검토 — PASS(주의사항 있음)
+- 고위험 보안 이슈는 미발견.
+- 단, `sttEngine/one_line_summary.py`는 여전히 `ollama` 직접 import/call을 사용해 provider 중립화 범위 밖 잔존 경로로 확인.
+
+## [Step 8] 회귀 검토 — PASS
+- 아래 테스트 통과:
+  - `pytest -q tests/providers/test_provider_factory.py tests/providers/test_llama_cpp_embedding_provider.py tests/http_api/test_workflow.py tests/http_api/test_search.py tests/server/test_queue.py tests/test_vocab_system.py`
+
+## [Step 9] 대형 함수/파일 분리 검토 — PASS
+- 이번 점검에서는 구조 변경 없이 상태 확인만 수행.
+
+## [Step 10] 재사용/통합성 검토 — PASS
+- 공통 provider 경로가 `sttEngine/llm_provider.py` + `sttEngine/providers/*`로 통합되어 있음.
+
+## [Step 11] 사이드 이펙트 검토 — PASS
+- 코드 실행 경로 변경 없음(문서 점검 기록만 갱신).
+
+## [Step 12] 전체 변경사항 리뷰 — PASS
+- 변경은 상태 점검 기록 추가 1건.
+
+## [Step 13] 불필요 코드 정리 — PASS
+- 임시 코드/스크립트 없음.
+
+## [Step 14] 품질 기준 검토 — PASS
+- 관련 회귀 테스트 통과.
+
+## [Step 15] 사용자 흐름 검토 — PASS
+- 사용자 흐름 관점에서 provider 선택 + 모델 목록 조회 + 워크플로우 전달이 이어지는 경로 확인.
+
+## [Step 16] 이슈 추적 재검토 — PASS(개선 필요)
+- 문서 드리프트: `TODO/llama-migration.md` 상단/하단 체크리스트에는 미완료([ ])가 다수 남아 있으나, 실제 구현은 상당수 완료([x]) 상태와 혼재.
+- 후속 조치: 체크리스트를 현재 코드 기준으로 재정렬 필요.
+
+## [Step 17] 배포 준비 판정 — 조건부 PASS
+- **결론:** "llama 마이그레이션은 핵심 경로 기준으로 잘 진행됨".
+- 단, 아래 2건이 남아 **완전 종료 READY는 아님**:
+  1. `one_line_summary.py`의 provider 중립화 여부 결정.
+  2. clean 환경 `setup/run` 실측 검증.
+
+## [Step 18] 커밋/PR
+- 본 점검 결과를 커밋/PR로 기록.

--- a/TODO/llama-migration.md
+++ b/TODO/llama-migration.md
@@ -17,40 +17,51 @@
 4. 문서/실행 스크립트/테스트를 코드와 동기화한다.
 
 ### 성공 기준 (Definition of Done)
-- [ ] `sttEngine/workflow/*`, `embedding_pipeline.py`, `vector_search.py`에서 Ollama 하드코딩 호출 제거
-- [ ] `/models`가 provider 기반으로 모델 목록을 반환
-- [ ] `/process`의 `model_settings` 계약이 프론트와 백엔드에서 일치 (`whisper`, `summarize`, `correct`, `embedding`, `language`, `device`)
-- [ ] 핵심 회귀 테스트 통과
+- [~] `sttEngine/workflow/*`, `embedding_pipeline.py`, `vector_search.py`에서 Ollama 하드코딩 호출 제거 (핵심 경로 완료, `one_line_summary.py` 잔존)
+- [x] `/models`가 provider 기반으로 모델 목록을 반환
+- [x] `/process`의 `model_settings` 계약이 프론트와 백엔드에서 일치 (`whisper`, `summarize`, `correct`, `embedding`, `language`, `device`)
+- [x] 핵심 회귀 테스트 통과
   - `pytest tests/http_api/test_workflow.py`
   - `pytest tests/http_api/test_search.py`
   - `pytest tests/server/test_queue.py`
   - `pytest tests/test_vocab_system.py`
-- [ ] `README.md`, `AGENTS.md`에 신규 런타임/환경변수/실행 방법 반영
+- [x] `README.md`, `AGENTS.md`에 신규 런타임/환경변수/실행 방법 반영
+
+---
+
+
+## 0-1. 진행 상태 스냅샷 (2026-02-18)
+
+- 전체 판정: **조건부 완료(핵심 마이그레이션 완료)**
+- 완료:
+  - provider 추상화/팩토리, summarize/correct, embedding/search, `/models`, 에러코드 범용화, 문서/compose/환경변수 반영
+  - 핵심 회귀 테스트(`workflow/search/queue/vocab`) 통과
+- 미완료/잔여:
+  1. `sttEngine/one_line_summary.py`의 direct Ollama 경로 정리 또는 legacy 명시
+  2. clean 환경 `setup/run` 실측 검증
+  3. provider contract test 확장(chat/embed/list_models, timeout/retry, 미설치/미응답)
 
 ---
 
 ## 1. 현재 상태 진단 요약
 
-### 1-1. Ollama 결합 지점
-- 워크플로우
-  - `sttEngine/workflow/correct.py`: `ollama.chat` 직접 호출
-  - `sttEngine/workflow/summarize.py`: `ollama.chat`, 모델 체크, 타임아웃/재시도
-- 임베딩/검색
-  - `sttEngine/embedding_pipeline.py`: `embed_text_ollama`
-  - `sttEngine/vector_search.py`: Ollama 기반 쿼리 임베딩
-- 모델 API
-  - `sttEngine/http_api/handler.py` `/models`: `ollama list` subprocess 실행
-- 유틸
-  - `sttEngine/ollama_utils.py`: 서버 확인/자동시작/모델 확인/safe call
-- 에러 매핑
-  - `sttEngine/server/services/errors.py`: `dependency_ollama` 고정 분기
+### 1-1. Ollama 결합 지점 (2026-02-18 기준)
+- 핵심 경로(요약/교정/임베딩/검색/API)는 provider 추상화로 전환 완료
+  - `sttEngine/workflow/correct.py`, `sttEngine/workflow/summarize.py`: provider 호출 사용
+  - `sttEngine/embedding_pipeline.py`, `sttEngine/vector_search.py`: provider 중립 임베딩 호출 사용
+  - `sttEngine/http_api/handler.py` `/models`: provider 기반 목록/상태 응답
+- 잔존 Ollama 직접 결합
+  - `sttEngine/one_line_summary.py`: `import ollama` + `ollama.generate` 직접 사용
+- 과도기 유틸/호환
+  - `sttEngine/ollama_utils.py`: Ollama provider 경로에서 사용(호환 목적)
+  - `sttEngine/server/services/errors.py`: `dependency_ollama` → `dependency_llm_provider` alias 유지
 - 배포/의존성
-  - `docker-compose.yml`: `ollama` 서비스 전제
-  - `requirements.txt`: `ollama>=0.1.0`
+  - `docker-compose.yml`: provider profile(`ollama`, `llamacpp`) 분리
+  - `requirements.txt`: Ollama SDK optional 분리 (`requirements-ollama.txt`)
 
-### 1-2. 계약 불일치(중요)
-- 프론트 `ModelSettings.transcribe`를 전송하지만 백엔드 워크플로우는 `model_settings.whisper`를 사용.
-- 마이그레이션 전에 계약 정렬 또는 하위호환 매핑이 필요.
+### 1-2. 계약 상태(업데이트)
+- `/process` 기준 `model_settings.whisper` 계약으로 정렬 완료.
+- 프론트는 `whisper/summarize/embedding/language/provider/llm_provider` 키를 전송하며, 백엔드 워크플로우는 `provider` 또는 `llm_provider`를 수용.
 
 ---
 
@@ -97,11 +108,11 @@
 ## Phase 2 — 요약/교정 워크플로우 분리
 
 ### 작업
-- [ ] `sttEngine/workflow/summarize.py`
+- [x] `sttEngine/workflow/summarize.py`
   - [x] `call_ollama_with_timeout` → `call_llm_with_timeout`로 중립화
   - [x] `call_ollama_with_retry` → `call_llm_with_retry`로 중립화
   - [x] `check_ollama_model_available` 제거, provider `list_models()`/`healthcheck()`로 대체
-- [ ] `sttEngine/workflow/correct.py`
+- [x] `sttEngine/workflow/correct.py`
   - [x] `ollama.chat` 직접 호출 제거
   - [x] provider `chat()` 사용
 - [x] 옵션 사상 테이블 도입
@@ -121,12 +132,12 @@
 ## Phase 3 — 임베딩/검색 전환
 
 ### 작업
-- [ ] `sttEngine/embedding_pipeline.py`
+- [x] `sttEngine/embedding_pipeline.py`
   - [x] `embed_text_ollama`를 중립 함수(`embed_text`)로 교체
   - [x] 응답 파싱을 provider별 adapter로 분리
-- [ ] `sttEngine/vector_search.py`
+- [x] `sttEngine/vector_search.py`
   - [x] 쿼리 임베딩 호출을 provider 중립 함수로 전환
-- [ ] `sttEngine/http_api/embedding.py`
+- [x] `sttEngine/http_api/embedding.py`
   - [x] 임베딩 생성 경로 provider 연동
 - [x] 벡터 차원 검증 추가
   - 모델 교체 시 차원 mismatch 탐지 및 명시적 오류 반환
@@ -136,7 +147,7 @@
 - 모델 교체 가이드(재색인 필요 조건)
 
 ### 검증
-- [ ] 검색 API 회귀 (`/search`)
+- [x] 검색 API 회귀 (`/search`)
 - [ ] 임베딩 인덱스 생성/갱신 테스트
 
 ---
@@ -247,10 +258,10 @@ OLLAMA_BASE_URL=http://localhost:11434  # deprecated(과도기)
 ## 6. 테스트 계획
 
 ### 필수 회귀
-- [ ] `pytest tests/http_api/test_workflow.py`
-- [ ] `pytest tests/http_api/test_search.py`
-- [ ] `pytest tests/server/test_queue.py`
-- [ ] `pytest tests/test_vocab_system.py`
+- [x] `pytest tests/http_api/test_workflow.py`
+- [x] `pytest tests/http_api/test_search.py`
+- [x] `pytest tests/server/test_queue.py`
+- [x] `pytest tests/test_vocab_system.py`
 
 ### 추가 권장
 - [ ] provider별 contract test (chat/embed/list_models)
@@ -277,27 +288,27 @@ OLLAMA_BASE_URL=http://localhost:11434  # deprecated(과도기)
 ## 8. 우선순위 백로그 (실행 순서)
 
 P0 (즉시)
-- [ ] Provider 인터페이스 + 팩토리
-- [ ] summarize/correct에서 provider 호출로 치환
-- [ ] model_settings 키 계약 정렬
+- [x] Provider 인터페이스 + 팩토리
+- [x] summarize/correct에서 provider 호출로 치환
+- [x] model_settings 키 계약 정렬
 
 P1
-- [ ] 임베딩/검색 provider 전환
-- [ ] `/models` provider화
-- [ ] 에러코드 범용화
+- [x] 임베딩/검색 provider 전환
+- [x] `/models` provider화
+- [x] 에러코드 범용화
 
 P2
-- [ ] docker compose/profile 정리
-- [ ] 문서/운영 가이드 완전 전환
+- [x] docker compose/profile 정리
+- [x] 문서/운영 가이드 완전 전환
 - [ ] Ollama legacy 경로 정리(삭제/선택적 유지)
 
 ---
 
 ## 9. 최종 산출물 체크리스트
 
-- [ ] 코드: provider 아키텍처 + llama.cpp adapter + 기존 흐름 통합
-- [ ] API: `/models`, `/process` 계약 정합성
-- [ ] 테스트: 핵심 회귀 + provider 계약 테스트
-- [ ] 문서: `README.md`, `AGENTS.md`, `TODO/llama-migration.md`
-- [ ] 운영: `.env.example`, `docker-compose.yml`, 의존성 파일 정리
+- [x] 코드: provider 아키텍처 + llama.cpp adapter + 기존 흐름 통합
+- [x] API: `/models`, `/process` 계약 정합성
+- [~] 테스트: 핵심 회귀 + provider 계약 테스트 (핵심 회귀 통과, provider 계약 테스트는 부분 보강 필요)
+- [~] 문서: `README.md`, `AGENTS.md`, `TODO/llama-migration.md` (이번 업데이트로 `TODO/llama-migration.md` 재동기화)
+- [x] 운영: `.env.example`, `docker-compose.yml`, 의존성 파일 정리
 


### PR DESCRIPTION
### Motivation
- Align the llama migration roadmap with the repository's actual provider abstraction work and remove drift between docs and implementation. 
- Make remaining risks and follow-ups explicit (legacy Ollama use, clean env verification, provider contract tests) so next tasks are clear. 
- Provide a dated snapshot to help reviewers and operators understand what is complete vs. outstanding.

### Description
- Updated `TODO/llama-migration.md` to mark completed items (provider abstraction, `/models` providerization, `model_settings` contract alignment, core regression test completion, docs/runtime sync) and converted several checklist items to partial/completed states. 
- Added a `0-1. 진행 상태 스냅샷 (2026-02-18)` section summarizing completed scope and remaining work, and revised the “current coupling points” section to call out the remaining direct `ollama` usage in `sttEngine/one_line_summary.py`. 
- Adjusted Phase/P0–P2 backlog and final checklist entries to reflect actual progress and noted where provider contract tests and clean setup/run validation are still needed.

### Testing
- Ran the core regression and provider tests: `pytest -q tests/http_api/test_workflow.py tests/http_api/test_search.py tests/server/test_queue.py tests/test_vocab_system.py tests/providers/test_provider_factory.py tests/providers/test_llama_cpp_embedding_provider.py`. 
- All tests passed (`22 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69954a30d954832eab8609e91e0ef09e)