### PR TITLE
docs(graph): align backlog status with current graph implementation

### DIFF
--- a/TODO/Graph.md
+++ b/TODO/Graph.md
@@ -16,15 +16,15 @@
 | 노드 스타일(타입/중심성) + 엣지 가중치 시각화 | 완료 | - | - | 타입별 컬러, 중심성 기반 반지름, edge opacity/두께 + 범례 UI 반영 |
 | 성능 계측 자동화(100/500/1000 문서) | 완료 | - | - | `benchmark-similarity-graph.mjs` + `docs/perf/*` 산출물 유지 |
 | 증분 유사도 재사용(변경 없는 문서쌍 재계산 생략) | 완료 | - | - | `_INCREMENTAL_STATE` + fingerprint 기반 `reused_pairs/computed_pairs` 계산 |
-| 고급 필터(문서타입/기간/키워드) | 미착수 | P1 | metadata 확장 + UI 컨트롤 | 현재 UI/API는 similarity/max_nodes(+sampling) 중심 |
+| 고급 필터(문서타입/기간/키워드) | 완료 | - | - | API(`doc_types/start_date/end_date/keyword`) + 패널 입력 컨트롤/요청 연동 완료 |
 | 대용량 성능 전략(O(n²) 근본 대응: ANN/근사 최근접) | 부분완료 | P0 | 인덱스/정확도 기준/벤치 시나리오 | LSH 기반 후보 축소(`neighbor_strategy=lsh/auto`) 도입, 정확도 벤치/전용 인덱스는 후속 |
 
 ## 2) 유효 백로그 (다음 스프린트)
 
 | 항목 | 상태 | 우선순위 | 의존관계 |
 |---|---|---|---|
-| 필터 UI(threshold + 날짜/타입/키워드) | 미착수 | P1 | API 파라미터 + metadata 필드 확장 |
-| sampling 전략 선택 UI(recent/random/hybrid) 노출 | 미착수 | P1 | 프론트 컨트롤 + API 파라미터 동기화 |
+| 필터 UI(threshold + 날짜/타입/키워드) | 완료 | - | - |
+| sampling 전략 선택 UI(recent/random/hybrid) 노출 | 완료 | - | - |
 | 증분 업데이트 고도화(메모리/TTL/캐시 정책) | 완료 | - | - |
 | 근사 최근접(ANN) 또는 후보 축소 전략 PoC | 부분완료 | P0 | 정확도 허용오차 + 성능 목표 합의 |
 | 벤치마크 확장(실서버 + 대용량 구간 2k/5k) | 완료 | - | - |
@@ -41,8 +41,13 @@
 | 증분 캐시 정책(TTL/최대 엔트리) + 캐시 진단 메타 확장 | `sttEngine/similarity_matrix.py` (`RECORDROUTE_SIMILARITY_*` 환경변수, `meta.cache.policy`) |
 | 벤치마크 대용량 구간(2k/5k) 실행 옵션 추가 | `frontend/scripts/benchmark-similarity-graph.mjs` (`--include-large`, `--dataset-sizes`) |
 
-## 4) 실행 순서
+## 4) 이번 재검토에서 확인된 불일치 정리
+
+- 문서의 `미착수` 표기와 달리, 고급 필터/샘플링 UI는 이미 `SimilarityGraphPanel`에 구현되어 있으며 API 호출 파라미터와 동기화되어 있음.
+- `neighbor_strategy`는 백엔드/API 타입에는 반영되어 있으나 현재 그래프 패널 UI에서는 선택 컨트롤이 없어 후속 백로그로 유지가 타당함.
+
+## 5) 실행 순서
 
 1. **P0** LSH 후보축소 PoC를 기준으로 정확도/성능 기준 정의 및 ANN 인덱스 확장 검토
-2. **P1** 사용자 필터(날짜/타입/키워드) + sampling 선택 UI/API 동기화
-3. **P2** 증분 캐시 정책(메모리/TTL/무효화) 및 벤치마크 시나리오 확장
+2. **P1** `neighbor_strategy`(auto/exact/lsh) 사용자 선택 UI 제공 및 메타 정보 노출 강화
+3. **P2** 증분 캐시 정책 실측(메모리/TTL/무효화) 튜닝 및 벤치마크 시나리오 고도화


### PR DESCRIPTION
### Motivation
- Update `TODO/Graph.md` to reflect the actual implemented graph features (filters, sampling UI and API wiring) and to record discovered document↔code mismatches so backlog/priority decisions remain accurate.

### Description
- Adjust `TODO/Graph.md` statuses: mark advanced filters and sampling UI as `완료`, add a new section `이번 재검토에서 확인된 불일치 정리` that documents the findings, and update the execution/priorities to focus P1 on `neighbor_strategy` UI exposure.

### Testing
- Verified code↔doc evidence by inspecting `sttEngine/http_api/routes/similarity_routes.py`, `sttEngine/similarity_matrix.py`, `frontend/src/components/SimilarityGraphPanel.tsx`, `frontend/src/api/client.ts`, and `frontend/scripts/benchmark-similarity-graph.mjs` using `rg`/`sed`/`nl` commands and confirmed the parameter/UI wiring; these checks succeeded.
- Committed the change with message `docs(graph): align backlog status with current graph implementation` and confirmed the commit (`git show`); commit step succeeded.
- No runtime or unit test suites (`pytest` / `npm run build`) were executed because this PR is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69954eaef8ec832e8f036076a9660f73)