### PR TITLE
docs: add speaker diarization roadmap in TODO

### DIFF
--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -29,6 +29,9 @@
 - [ ] API 버전 관리/OpenAPI 초안
   - 범위: 버전 전략, `/process`/`/search`/`/progress` 계약서 초안
 
+- [ ] 화자 분리(Speaker Diarization) 도입 설계/구현
+  - 범위: 실행 로드맵(`TODO/화자분리_로드맵.md`) 기준으로 Phase 0~4 순차 적용
+
 - [ ] 훅/컴포넌트 테스트 보강
   - 범위: `useTaskQueue`, `SearchPanel`, `TextOverlay`, `SimilarityGraphPanel`
 

--- a/TODO/화자분리_로드맵.md
+++ b/TODO/화자분리_로드맵.md
@@ -1,187 +1,152 @@
-# 대화 화자 분리(Speaker Diarization) 도입 로드맵
+# 화자 분리(Speaker Diarization) 실행 로드맵
 
-## 1) 목표와 범위
+- 문서 목적: RecordRoute에 화자 분리를 **기존 계약을 깨지 않고** 도입하기 위한 실행 백로그
+- 기준 문서 반영: `README.md`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- 작성 원칙: TODO 관례에 맞춰 **실행 항목/완료 기준(DoD)/리스크** 중심으로 유지
+
+---
+
+## 0) 목표 / 비목표
 
 ### 목표
-- RecordRoute의 음성 처리 결과에서 **화자(예: 화자 A/B/C)**를 자동 분리해 STT 결과에 반영합니다.
-- 기존 워크플로우(`stt -> correct -> summary -> embedding`)를 깨지 않고, 점진적으로 화자 정보를 추가합니다.
-- UI/검색/내보내기에서 화자 단위 활용이 가능하도록 데이터 계약(API/타입/저장 포맷)을 확장합니다.
+- `/process` 워크플로우에 화자 분리 결과를 추가해 STT 결과(`segments`)에 `speaker`를 반영한다.
+- 실패 시에도 기존 사용자 흐름(STT/교정/요약/검색)이 깨지지 않도록 backward compatibility를 보장한다.
+- 프론트(`frontend/src`)에서 화자 라벨을 읽고 표시할 수 있게 API 타입/클라이언트를 동기화한다.
 
-### 비목표(초기 단계)
-- 실명 기반 화자 식별(Voice ID) 강제
-- 회의실 마이크 어레이 기반 고급 빔포밍
-- 실시간 스트리밍 diarization 완성형 제공(초기에는 배치 처리 우선)
-
----
-
-## 2) 현재 아키텍처 기준 반영 포인트
-
-- 백엔드 엔트리/라우팅은 `sttEngine/http_api/app.py`, `sttEngine/http_api/handler.py`, `sttEngine/http_api/routes/*` 중심이므로, diarization 관련 API는 기존 `/process`, `/progress`, `/history` 흐름에 맞춰 추가합니다.
-- 워크플로우는 `sttEngine/http_api/workflow.py`에서 단계 실행을 관리하므로 `diarize` 단계를 `stt`와 결합 또는 독립 step으로 설계합니다.
-- 프론트는 `frontend/src` 기준으로 API 클라이언트(`frontend/src/api/client.ts`)와 타입(`frontend/src/api/types.ts`)을 반드시 동기화합니다.
-- 파일/레코드 경로는 `DB/...` alias 규칙을 유지하고, 경로 유틸(`sttEngine/http_api/paths.py`)을 사용합니다.
+### 비목표(초기)
+- 실명 화자 식별(voice fingerprint)
+- 실시간 스트리밍 diarization 완성형
+- 복수 겹화자(overlap) 고급 라벨링(초기에는 단일 주 화자 정책)
 
 ---
 
-## 3) 단계별 실행 로드맵
+## 1) 아키텍처 반영 지점(필수)
 
-## Phase 0. 요구사항/평가 지표 확정 (1주)
-
-### 해야 할 일
-- 실제 사용 시나리오 3종 정의
-  - 1:1 인터뷰
-  - 3~5인 회의
-  - 잡음 환경(카페/원격회의 녹음)
-- 성공 기준(KPI) 정의
-  - DER(Diarization Error Rate)
-  - 화자 전환점 오차(초)
-  - 요약 품질 영향(화자 정보 포함 요약 만족도)
-- 샘플 데이터셋(내부/공개) 및 평가 스크립트 위치 확정 (`tests` 또는 `scripts`)
-
-### 산출물
-- 평가 기준 문서
-- 샘플셋 목록/메타데이터
+- 워크플로우 실행: `sttEngine/http_api/workflow.py`
+- 라우팅/요청 처리: `sttEngine/http_api/handler.py`, `sttEngine/http_api/routes/*`
+- provider 계층: `sttEngine/providers/*`, `sttEngine/llm_provider.py`
+- 프론트 API 동기화: `frontend/src/api/client.ts`, `frontend/src/api/types.ts`
+- 데이터 경로 규칙: `DB/...` alias + `sttEngine/http_api/paths.py` 유틸 사용
 
 ---
 
-## Phase 1. 백엔드 최소 기능(MVP) 도입 (1~2주)
+## 2) 단계별 계획(Phase 0~4)
 
-### 1-1. 워크플로우 단계 설계
-- `steps`에 `diarize`를 추가하는 안과 `stt` 내부 옵션으로 처리하는 안을 비교합니다.
-- 권장: `steps=["stt", "diarize", "correct", "summary"]` 형태를 지원하되,
-  - 기존 요청과 호환되도록 `diarize` 미지정 시 기존 동작 유지
-  - `model_settings`에 diarization 옵션 추가
+## Phase 0. 계약/지표 고정 (1주)
 
-예시(확장안):
-```json
-{
-  "steps": ["stt", "diarize", "correct", "summary"],
-  "model_settings": {
-    "whisper": "large-v3-turbo",
-    "diarization_provider": "pyannote",
-    "num_speakers": null,
-    "min_speakers": 2,
-    "max_speakers": 6
-  }
-}
-```
+### TODO
+- [ ] 화자 분리 성공 기준 확정: `DER`, 화자 전환점 오차, 요약 품질 영향
+- [ ] 샘플 데이터셋(1:1, 3~5인, 잡음환경) 선정 및 보관 위치 확정
+- [ ] 실패 정의(모델 불가/타임아웃/오디오 무효) 및 공통 에러코드 초안 작성
 
-### 1-2. 결과 스키마 확장
-- STT 산출물에 `segments` 단위 화자 라벨 추가:
-  - `speaker`: `"SPEAKER_00"` 형식
-  - `start`, `end`, `text`
-- 실패 응답은 기존 규약(`error`, `error_code`, `retryable`, `failed_step`) 유지
-- `/progress/<task_id>` 및 WebSocket 진행률에 diarization 단계 표시
-
-### 1-3. 저장 포맷/마이그레이션
-- 기존 레코드는 화자 정보가 없으므로 **nullable + backward compatible**로 저장
-- `DB/upload_history.json` 및 관련 record payload에 `speaker_segments` 또는 `segments[].speaker` 구조를 추가
-- 과거 데이터 재처리 없이도 UI가 깨지지 않도록 기본값 처리
-
-### 1-4. 최소 API/UI 노출
-- 상세 보기에서 화자 라벨 표시(예: 배지)
-- 화자별 텍스트 묶음 보기 토글 제공(원문 타임라인 유지)
+### DoD
+- [ ] 합의된 KPI 문서 1건
+- [ ] 재현 가능한 평가 입력셋 목록 1건
 
 ---
 
-## Phase 2. 정확도/안정성 개선 (2~3주)
+## Phase 1. 백엔드 MVP (1~2주)
 
-### 2-1. Provider 추상화
-- `sttEngine/providers/*` 패턴에 맞춰 diarization provider 인터페이스 추가
-- 후보:
-  - `pyannote` 기반
-  - Whisper timestamp + clustering fallback
-- `LLM_PROVIDER`와 분리된 `DIARIZATION_PROVIDER` 환경변수 도입 검토
+### TODO
+- [ ] `/process`에서 `steps` 확장안 적용
+  - 권장: `"diarize"` step 추가(기존 step 미변경 요청도 100% 호환)
+- [ ] `model_settings` 확장
+  - 예: `diarization_provider`, `num_speakers`, `min_speakers`, `max_speakers`
+- [ ] STT 결과 스키마 확장
+  - `segments[].speaker`(`SPEAKER_00` 형식)
+- [ ] 진행률 반영
+  - `/progress/<task_id>` 및 WS에서 diarization 단계 표시
+- [ ] 실패 응답 규약 유지
+  - `error`, `error_code`, `retryable`, `failed_step`
 
-### 2-2. 후처리 고도화
-- 짧은 구간 병합, 급격한 speaker switching 완화
-- 무음 구간 처리 규칙 정교화
-- 겹화자(overlap) 정책 명시
-  - 초기: 주 화자 1명만 표시
-  - 확장: 멀티 라벨 지원
+### DoD
+- [ ] 기존 요청 payload(화자 옵션 없음) 회귀 0건
+- [ ] 화자 옵션 요청 시 `segments[].speaker` 반환
 
-### 2-3. 오류/복구 전략
-- diarization 실패 시 fallback 정책
-  - STT 텍스트는 반환, 화자 라벨만 비활성화
-- 표준 오류 코드 예시
+---
+
+## Phase 2. 저장/호환/복구 (1주)
+
+### TODO
+- [ ] 저장 포맷에 화자 정보 nullable로 추가
+  - 과거 데이터(화자 없음) 그대로 읽기 가능해야 함
+- [ ] fallback 정책 적용
+  - diarization 실패 시 STT 텍스트는 반환, 화자 라벨만 비활성화
+- [ ] 표준 오류코드 확정
   - `diarization_model_unavailable`
   - `diarization_timeout`
   - `diarization_invalid_audio`
 
----
-
-## Phase 3. 프론트 경험 확장 (1~2주)
-
-### 3-1. 뷰어 개선
-- 세그먼트 리스트에 화자 색상/필터 제공
-- 화자 클릭 시 해당 구간 하이라이트 + 오디오 seek
-- 모바일 레이아웃에서 배지 가독성 점검
-
-### 3-2. 요약 연계
-- 요약 프롬프트에 화자 정보를 전달해
-  - "결정 사항 by 화자"
-  - "액션 아이템 담당 화자"
-  를 구조적으로 생성
-- 단, 화자 라벨 불확실할 때는 과신 표현 방지 문구 포함
-
-### 3-3. 검색 연계(선택)
-- `/search` 확장 파라미터(예: `speaker=`) 검토
-- 유사 문서 비교 시 화자 분포 메타데이터 노출 검토
+### DoD
+- [ ] 기존 DB 데이터로 UI/검색 회귀 없음
+- [ ] diarization 실패 케이스에서 사용자 오류카드 규약 유지
 
 ---
 
-## Phase 4. 운영/배포 준비 (1주)
+## Phase 3. 프론트/UI 연동 (1~2주)
 
-### 4-1. 성능/비용 관리
-- 긴 오디오(>60분) 처리 시간 측정 및 큐 정책 보정
-- 캐시 전략 검토(동일 파일 재요청 시 diarization 재사용)
+### TODO
+- [ ] 상세 화면 세그먼트에 화자 배지 표시
+- [ ] 화자 필터/묶음 보기 토글 추가
+- [ ] API 클라이언트/타입 동기화
+  - `frontend/src/api/client.ts`
+  - `frontend/src/api/types.ts`
+- [ ] 요약 연계(선택)
+  - 화자 정보 포함 요약 템플릿(불확실성 문구 포함)
 
-### 4-2. 관측성(Observability)
-- 단계별 소요시간 로깅(`stt`, `diarize`, `correct`, `summary`)
-- 품질 모니터링 지표
-  - 화자 수 추정 실패율
-  - diarization fallback 비율
-
-### 4-3. 보안/컴플라이언스
-- 화자 정보는 민감정보로 간주 가능하므로 보존/삭제 정책 명시
-- 파괴적 API 안전 모드와 충돌 없는 삭제 플로우 검증
-
----
-
-## 4) 구현 체크리스트 (실행 TODO)
-
-- [ ] `/process` 스키마에 diarization 옵션 추가
-- [ ] `workflow.py`에 `diarize` 단계 및 진행률 반영
-- [ ] provider 추상화/구현 추가 (`sttEngine/providers/*`)
-- [ ] 결과 저장 포맷 backward compatibility 보장
-- [ ] `frontend/src/api/client.ts`, `frontend/src/api/types.ts` 동기화
-- [ ] 화자 표시 UI(상세/세그먼트) 추가
-- [ ] 회귀 테스트 추가
-  - [ ] `tests/http_api/test_workflow.py`
-  - [ ] `tests/http_api/test_search.py` (확장 시)
-- [ ] 문서 동기화
-  - [ ] `README.md` (사용자 관점)
-  - [ ] `AGENTS.md` (에이전트 관점)
+### DoD
+- [ ] 화자 라벨이 있는/없는 레코드 모두 렌더 오류 0건
+- [ ] 프론트 빌드 성공
 
 ---
 
-## 5) 리스크 및 대응
+## Phase 4. 운영 안정화 (1주)
 
-- 모델 의존성 리스크: 특정 diarization 모델 설치/라이선스 이슈
-  - 대응: provider 플러그인화 + fallback 경로 유지
-- 한국어 다자간 대화 정확도 편차
-  - 대응: 도메인별 샘플셋으로 DER 기준선 지속 측정
-- 처리 지연 증가
-  - 대응: 비동기 큐/배치 전략 및 품질-속도 모드 제공(빠름/정확)
+### TODO
+- [ ] 처리 시간/실패율 모니터링 지표 추가
+  - `stt`, `diarize`, `correct`, `summary` 단계별 소요시간
+- [ ] 긴 오디오(60분+) 처리 정책 점검(큐/타임아웃)
+- [ ] 보존/삭제 정책 점검(화자 정보 민감정보 취급 여부 포함)
+
+### DoD
+- [ ] 운영 지표 대시보드/로그에서 diarization 상태 추적 가능
+- [ ] 삭제/리셋 API와 충돌 없는 데이터 정리 검증
 
 ---
 
-## 6) 제안 일정(예시, 총 5~9주)
+## 3) 공통 회귀 테스트 체크리스트
 
-- 1주차: Phase 0 완료(지표/데이터셋/성공 기준)
-- 2~3주차: Phase 1(MVP API + 저장 포맷 + 최소 UI)
-- 4~6주차: Phase 2(정확도/안정성 + fallback)
-- 7~8주차: Phase 3(UX/요약 연계)
-- 9주차: Phase 4(운영 지표/배포 안정화)
+- [ ] `pytest tests/http_api/test_workflow.py`
+- [ ] `pytest tests/http_api/test_search.py` (검색 연계 변경 시)
+- [ ] `pytest tests/server/test_queue.py`
+- [ ] `pytest tests/test_vocab_system.py`
+- [ ] (프론트 변경 시) `cd frontend && npm run build`
 
-> 초기 출시 기준은 "STT 결과에 화자 라벨이 안정적으로 표시되고, 실패 시에도 기존 사용자 흐름이 깨지지 않는 것"으로 정의합니다.
+---
+
+## 4) 리스크 / 롤백
+
+### 주요 리스크
+- 모델/의존성 설치 실패(환경별)
+- 한국어 다화자 환경 정확도 편차
+- 처리시간 증가로 인한 큐 적체
+
+### 롤백 전략
+- 기능 플래그(예: `DIARIZATION_ENABLED=false`)로 즉시 비활성화
+- 저장 포맷은 nullable 유지로 기존 데이터/화면 호환 보장
+- 실패 시 STT 텍스트 우선 반환 정책으로 사용자 흐름 보전
+
+---
+
+## 5) 제안 일정(총 4~7주)
+
+- 1주차: Phase 0
+- 2~3주차: Phase 1
+- 4주차: Phase 2
+- 5~6주차: Phase 3
+- 7주차: Phase 4
+
+> 출시 최소 조건(MVP):
+> 1) 화자 라벨이 포함된 STT 결과 반환,
+> 2) 실패 시 기존 흐름 유지,
+> 3) 프론트에서 라벨 표시 가능.

--- a/TODO/화자분리_로드맵.md
+++ b/TODO/화자분리_로드맵.md
@@ -1,0 +1,187 @@
+# 대화 화자 분리(Speaker Diarization) 도입 로드맵
+
+## 1) 목표와 범위
+
+### 목표
+- RecordRoute의 음성 처리 결과에서 **화자(예: 화자 A/B/C)**를 자동 분리해 STT 결과에 반영합니다.
+- 기존 워크플로우(`stt -> correct -> summary -> embedding`)를 깨지 않고, 점진적으로 화자 정보를 추가합니다.
+- UI/검색/내보내기에서 화자 단위 활용이 가능하도록 데이터 계약(API/타입/저장 포맷)을 확장합니다.
+
+### 비목표(초기 단계)
+- 실명 기반 화자 식별(Voice ID) 강제
+- 회의실 마이크 어레이 기반 고급 빔포밍
+- 실시간 스트리밍 diarization 완성형 제공(초기에는 배치 처리 우선)
+
+---
+
+## 2) 현재 아키텍처 기준 반영 포인트
+
+- 백엔드 엔트리/라우팅은 `sttEngine/http_api/app.py`, `sttEngine/http_api/handler.py`, `sttEngine/http_api/routes/*` 중심이므로, diarization 관련 API는 기존 `/process`, `/progress`, `/history` 흐름에 맞춰 추가합니다.
+- 워크플로우는 `sttEngine/http_api/workflow.py`에서 단계 실행을 관리하므로 `diarize` 단계를 `stt`와 결합 또는 독립 step으로 설계합니다.
+- 프론트는 `frontend/src` 기준으로 API 클라이언트(`frontend/src/api/client.ts`)와 타입(`frontend/src/api/types.ts`)을 반드시 동기화합니다.
+- 파일/레코드 경로는 `DB/...` alias 규칙을 유지하고, 경로 유틸(`sttEngine/http_api/paths.py`)을 사용합니다.
+
+---
+
+## 3) 단계별 실행 로드맵
+
+## Phase 0. 요구사항/평가 지표 확정 (1주)
+
+### 해야 할 일
+- 실제 사용 시나리오 3종 정의
+  - 1:1 인터뷰
+  - 3~5인 회의
+  - 잡음 환경(카페/원격회의 녹음)
+- 성공 기준(KPI) 정의
+  - DER(Diarization Error Rate)
+  - 화자 전환점 오차(초)
+  - 요약 품질 영향(화자 정보 포함 요약 만족도)
+- 샘플 데이터셋(내부/공개) 및 평가 스크립트 위치 확정 (`tests` 또는 `scripts`)
+
+### 산출물
+- 평가 기준 문서
+- 샘플셋 목록/메타데이터
+
+---
+
+## Phase 1. 백엔드 최소 기능(MVP) 도입 (1~2주)
+
+### 1-1. 워크플로우 단계 설계
+- `steps`에 `diarize`를 추가하는 안과 `stt` 내부 옵션으로 처리하는 안을 비교합니다.
+- 권장: `steps=["stt", "diarize", "correct", "summary"]` 형태를 지원하되,
+  - 기존 요청과 호환되도록 `diarize` 미지정 시 기존 동작 유지
+  - `model_settings`에 diarization 옵션 추가
+
+예시(확장안):
+```json
+{
+  "steps": ["stt", "diarize", "correct", "summary"],
+  "model_settings": {
+    "whisper": "large-v3-turbo",
+    "diarization_provider": "pyannote",
+    "num_speakers": null,
+    "min_speakers": 2,
+    "max_speakers": 6
+  }
+}
+```
+
+### 1-2. 결과 스키마 확장
+- STT 산출물에 `segments` 단위 화자 라벨 추가:
+  - `speaker`: `"SPEAKER_00"` 형식
+  - `start`, `end`, `text`
+- 실패 응답은 기존 규약(`error`, `error_code`, `retryable`, `failed_step`) 유지
+- `/progress/<task_id>` 및 WebSocket 진행률에 diarization 단계 표시
+
+### 1-3. 저장 포맷/마이그레이션
+- 기존 레코드는 화자 정보가 없으므로 **nullable + backward compatible**로 저장
+- `DB/upload_history.json` 및 관련 record payload에 `speaker_segments` 또는 `segments[].speaker` 구조를 추가
+- 과거 데이터 재처리 없이도 UI가 깨지지 않도록 기본값 처리
+
+### 1-4. 최소 API/UI 노출
+- 상세 보기에서 화자 라벨 표시(예: 배지)
+- 화자별 텍스트 묶음 보기 토글 제공(원문 타임라인 유지)
+
+---
+
+## Phase 2. 정확도/안정성 개선 (2~3주)
+
+### 2-1. Provider 추상화
+- `sttEngine/providers/*` 패턴에 맞춰 diarization provider 인터페이스 추가
+- 후보:
+  - `pyannote` 기반
+  - Whisper timestamp + clustering fallback
+- `LLM_PROVIDER`와 분리된 `DIARIZATION_PROVIDER` 환경변수 도입 검토
+
+### 2-2. 후처리 고도화
+- 짧은 구간 병합, 급격한 speaker switching 완화
+- 무음 구간 처리 규칙 정교화
+- 겹화자(overlap) 정책 명시
+  - 초기: 주 화자 1명만 표시
+  - 확장: 멀티 라벨 지원
+
+### 2-3. 오류/복구 전략
+- diarization 실패 시 fallback 정책
+  - STT 텍스트는 반환, 화자 라벨만 비활성화
+- 표준 오류 코드 예시
+  - `diarization_model_unavailable`
+  - `diarization_timeout`
+  - `diarization_invalid_audio`
+
+---
+
+## Phase 3. 프론트 경험 확장 (1~2주)
+
+### 3-1. 뷰어 개선
+- 세그먼트 리스트에 화자 색상/필터 제공
+- 화자 클릭 시 해당 구간 하이라이트 + 오디오 seek
+- 모바일 레이아웃에서 배지 가독성 점검
+
+### 3-2. 요약 연계
+- 요약 프롬프트에 화자 정보를 전달해
+  - "결정 사항 by 화자"
+  - "액션 아이템 담당 화자"
+  를 구조적으로 생성
+- 단, 화자 라벨 불확실할 때는 과신 표현 방지 문구 포함
+
+### 3-3. 검색 연계(선택)
+- `/search` 확장 파라미터(예: `speaker=`) 검토
+- 유사 문서 비교 시 화자 분포 메타데이터 노출 검토
+
+---
+
+## Phase 4. 운영/배포 준비 (1주)
+
+### 4-1. 성능/비용 관리
+- 긴 오디오(>60분) 처리 시간 측정 및 큐 정책 보정
+- 캐시 전략 검토(동일 파일 재요청 시 diarization 재사용)
+
+### 4-2. 관측성(Observability)
+- 단계별 소요시간 로깅(`stt`, `diarize`, `correct`, `summary`)
+- 품질 모니터링 지표
+  - 화자 수 추정 실패율
+  - diarization fallback 비율
+
+### 4-3. 보안/컴플라이언스
+- 화자 정보는 민감정보로 간주 가능하므로 보존/삭제 정책 명시
+- 파괴적 API 안전 모드와 충돌 없는 삭제 플로우 검증
+
+---
+
+## 4) 구현 체크리스트 (실행 TODO)
+
+- [ ] `/process` 스키마에 diarization 옵션 추가
+- [ ] `workflow.py`에 `diarize` 단계 및 진행률 반영
+- [ ] provider 추상화/구현 추가 (`sttEngine/providers/*`)
+- [ ] 결과 저장 포맷 backward compatibility 보장
+- [ ] `frontend/src/api/client.ts`, `frontend/src/api/types.ts` 동기화
+- [ ] 화자 표시 UI(상세/세그먼트) 추가
+- [ ] 회귀 테스트 추가
+  - [ ] `tests/http_api/test_workflow.py`
+  - [ ] `tests/http_api/test_search.py` (확장 시)
+- [ ] 문서 동기화
+  - [ ] `README.md` (사용자 관점)
+  - [ ] `AGENTS.md` (에이전트 관점)
+
+---
+
+## 5) 리스크 및 대응
+
+- 모델 의존성 리스크: 특정 diarization 모델 설치/라이선스 이슈
+  - 대응: provider 플러그인화 + fallback 경로 유지
+- 한국어 다자간 대화 정확도 편차
+  - 대응: 도메인별 샘플셋으로 DER 기준선 지속 측정
+- 처리 지연 증가
+  - 대응: 비동기 큐/배치 전략 및 품질-속도 모드 제공(빠름/정확)
+
+---
+
+## 6) 제안 일정(예시, 총 5~9주)
+
+- 1주차: Phase 0 완료(지표/데이터셋/성공 기준)
+- 2~3주차: Phase 1(MVP API + 저장 포맷 + 최소 UI)
+- 4~6주차: Phase 2(정확도/안정성 + fallback)
+- 7~8주차: Phase 3(UX/요약 연계)
+- 9주차: Phase 4(운영 지표/배포 안정화)
+
+> 초기 출시 기준은 "STT 결과에 화자 라벨이 안정적으로 표시되고, 실패 시에도 기존 사용자 흐름이 깨지지 않는 것"으로 정의합니다.


### PR DESCRIPTION
### Motivation
- Provide a clear, implementation-focused roadmap for adding speaker diarization to RecordRoute that preserves the existing `stt -> correct -> summary -> embedding` workflow. 
- Align the roadmap with the repository documentation conventions and architecture summaries from `README.md`, `CLAUDE.md`, and `GEMINI.md`. 
- Surface expected API/DB/UX changes and risks so implementers can follow a phased, backward-compatible plan.

### Description
- Add a new roadmap document at `TODO/화자분리_로드맵.md` describing goal/ non-goals, architecture touchpoints, and phased plan (Phase 0–4) for diarization integration. 
- Document proposed API/schema/workflow changes including a `diarize` step, expanded STT `segments` schema with `speaker` labels, storage compatibility notes, provider abstraction suggestions, UI/summary/search integration ideas, and migration/checklist items. 
- Include an actionable implementation checklist and a suggested 5–9 week timeline with risk mitigations and observability considerations.

### Testing
- No automated tests were executed for this documentation-only change; no test failures were observed because no code was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699552f7eab8832e9ebac9f8974b3606)