### PR TITLE
docs: refine diarization roadmap into execution-focused TODO and add master TODO entry

### DIFF
--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -29,6 +29,9 @@
 - [ ] API 버전 관리/OpenAPI 초안
   - 범위: 버전 전략, `/process`/`/search`/`/progress` 계약서 초안
 
+- [ ] 화자 분리(Speaker Diarization) 도입 설계/구현
+  - 범위: 실행 로드맵(`TODO/화자분리_로드맵.md`) 기준으로 Phase 0~4 순차 적용
+
 - [ ] 훅/컴포넌트 테스트 보강
   - 범위: `useTaskQueue`, `SearchPanel`, `TextOverlay`, `SimilarityGraphPanel`
 

--- a/TODO/화자분리_로드맵.md
+++ b/TODO/화자분리_로드맵.md
@@ -1,0 +1,152 @@
+# 화자 분리(Speaker Diarization) 실행 로드맵
+
+- 문서 목적: RecordRoute에 화자 분리를 **기존 계약을 깨지 않고** 도입하기 위한 실행 백로그
+- 기준 문서 반영: `README.md`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- 작성 원칙: TODO 관례에 맞춰 **실행 항목/완료 기준(DoD)/리스크** 중심으로 유지
+
+---
+
+## 0) 목표 / 비목표
+
+### 목표
+- `/process` 워크플로우에 화자 분리 결과를 추가해 STT 결과(`segments`)에 `speaker`를 반영한다.
+- 실패 시에도 기존 사용자 흐름(STT/교정/요약/검색)이 깨지지 않도록 backward compatibility를 보장한다.
+- 프론트(`frontend/src`)에서 화자 라벨을 읽고 표시할 수 있게 API 타입/클라이언트를 동기화한다.
+
+### 비목표(초기)
+- 실명 화자 식별(voice fingerprint)
+- 실시간 스트리밍 diarization 완성형
+- 복수 겹화자(overlap) 고급 라벨링(초기에는 단일 주 화자 정책)
+
+---
+
+## 1) 아키텍처 반영 지점(필수)
+
+- 워크플로우 실행: `sttEngine/http_api/workflow.py`
+- 라우팅/요청 처리: `sttEngine/http_api/handler.py`, `sttEngine/http_api/routes/*`
+- provider 계층: `sttEngine/providers/*`, `sttEngine/llm_provider.py`
+- 프론트 API 동기화: `frontend/src/api/client.ts`, `frontend/src/api/types.ts`
+- 데이터 경로 규칙: `DB/...` alias + `sttEngine/http_api/paths.py` 유틸 사용
+
+---
+
+## 2) 단계별 계획(Phase 0~4)
+
+## Phase 0. 계약/지표 고정 (1주)
+
+### TODO
+- [ ] 화자 분리 성공 기준 확정: `DER`, 화자 전환점 오차, 요약 품질 영향
+- [ ] 샘플 데이터셋(1:1, 3~5인, 잡음환경) 선정 및 보관 위치 확정
+- [ ] 실패 정의(모델 불가/타임아웃/오디오 무효) 및 공통 에러코드 초안 작성
+
+### DoD
+- [ ] 합의된 KPI 문서 1건
+- [ ] 재현 가능한 평가 입력셋 목록 1건
+
+---
+
+## Phase 1. 백엔드 MVP (1~2주)
+
+### TODO
+- [ ] `/process`에서 `steps` 확장안 적용
+  - 권장: `"diarize"` step 추가(기존 step 미변경 요청도 100% 호환)
+- [ ] `model_settings` 확장
+  - 예: `diarization_provider`, `num_speakers`, `min_speakers`, `max_speakers`
+- [ ] STT 결과 스키마 확장
+  - `segments[].speaker`(`SPEAKER_00` 형식)
+- [ ] 진행률 반영
+  - `/progress/<task_id>` 및 WS에서 diarization 단계 표시
+- [ ] 실패 응답 규약 유지
+  - `error`, `error_code`, `retryable`, `failed_step`
+
+### DoD
+- [ ] 기존 요청 payload(화자 옵션 없음) 회귀 0건
+- [ ] 화자 옵션 요청 시 `segments[].speaker` 반환
+
+---
+
+## Phase 2. 저장/호환/복구 (1주)
+
+### TODO
+- [ ] 저장 포맷에 화자 정보 nullable로 추가
+  - 과거 데이터(화자 없음) 그대로 읽기 가능해야 함
+- [ ] fallback 정책 적용
+  - diarization 실패 시 STT 텍스트는 반환, 화자 라벨만 비활성화
+- [ ] 표준 오류코드 확정
+  - `diarization_model_unavailable`
+  - `diarization_timeout`
+  - `diarization_invalid_audio`
+
+### DoD
+- [ ] 기존 DB 데이터로 UI/검색 회귀 없음
+- [ ] diarization 실패 케이스에서 사용자 오류카드 규약 유지
+
+---
+
+## Phase 3. 프론트/UI 연동 (1~2주)
+
+### TODO
+- [ ] 상세 화면 세그먼트에 화자 배지 표시
+- [ ] 화자 필터/묶음 보기 토글 추가
+- [ ] API 클라이언트/타입 동기화
+  - `frontend/src/api/client.ts`
+  - `frontend/src/api/types.ts`
+- [ ] 요약 연계(선택)
+  - 화자 정보 포함 요약 템플릿(불확실성 문구 포함)
+
+### DoD
+- [ ] 화자 라벨이 있는/없는 레코드 모두 렌더 오류 0건
+- [ ] 프론트 빌드 성공
+
+---
+
+## Phase 4. 운영 안정화 (1주)
+
+### TODO
+- [ ] 처리 시간/실패율 모니터링 지표 추가
+  - `stt`, `diarize`, `correct`, `summary` 단계별 소요시간
+- [ ] 긴 오디오(60분+) 처리 정책 점검(큐/타임아웃)
+- [ ] 보존/삭제 정책 점검(화자 정보 민감정보 취급 여부 포함)
+
+### DoD
+- [ ] 운영 지표 대시보드/로그에서 diarization 상태 추적 가능
+- [ ] 삭제/리셋 API와 충돌 없는 데이터 정리 검증
+
+---
+
+## 3) 공통 회귀 테스트 체크리스트
+
+- [ ] `pytest tests/http_api/test_workflow.py`
+- [ ] `pytest tests/http_api/test_search.py` (검색 연계 변경 시)
+- [ ] `pytest tests/server/test_queue.py`
+- [ ] `pytest tests/test_vocab_system.py`
+- [ ] (프론트 변경 시) `cd frontend && npm run build`
+
+---
+
+## 4) 리스크 / 롤백
+
+### 주요 리스크
+- 모델/의존성 설치 실패(환경별)
+- 한국어 다화자 환경 정확도 편차
+- 처리시간 증가로 인한 큐 적체
+
+### 롤백 전략
+- 기능 플래그(예: `DIARIZATION_ENABLED=false`)로 즉시 비활성화
+- 저장 포맷은 nullable 유지로 기존 데이터/화면 호환 보장
+- 실패 시 STT 텍스트 우선 반환 정책으로 사용자 흐름 보전
+
+---
+
+## 5) 제안 일정(총 4~7주)
+
+- 1주차: Phase 0
+- 2~3주차: Phase 1
+- 4주차: Phase 2
+- 5~6주차: Phase 3
+- 7주차: Phase 4
+
+> 출시 최소 조건(MVP):
+> 1) 화자 라벨이 포함된 STT 결과 반환,
+> 2) 실패 시 기존 흐름 유지,
+> 3) 프론트에서 라벨 표시 가능.


### PR DESCRIPTION
### Motivation
- Make the existing diarization writeup actionable by converting it from an explanatory note into a Phase-based execution checklist with concrete DoD and rollback guidance. 
- Ensure the diarization plan is aligned with repository conventions and reference docs (`README.md`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`).
- Surface the minimal, backward-compatible extension points (`/process` contract, `segments[].speaker`, progress/error semantics) so implementers can start Phase 1 work without breaking existing flows.

### Description
- Rewrote `TODO/화자분리_로드맵.md` into an execution-oriented roadmap (Phases 0–4) that enumerates TODO items, DoD (completion criteria), risk/rollback, and a regression-test checklist. 
- Added a P1 master-backlog entry in `TODO/TODO.md` linking to the new roadmap via the line: "화자 분리(Speaker Diarization) 도입 설계/구현". 
- Documented concrete contract suggestions (e.g. adding a `diarize` step, `model_settings` options, `segments[].speaker`) and operational items (observability, long-audio policy, nullable storage). 
- Committed the two modified files with message `docs: refine diarization roadmap with execution checklist` and created the PR draft.

### Testing
- No automated unit/integration tests were executed because this is a documentation-only change; therefore no test failures occurred. 
- Performed content validation by inspecting diffs and file contents using `git diff -- TODO/TODO.md 'TODO/화자분리_로드맵.md'`, `nl -ba TODO/화자분리_로드맵.md`, and `nl -ba TODO/TODO.md`, and confirmed the expected edits were present and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699552f7eab8832e9ebac9f8974b3606)