### PR TITLE
Fix summarize alias normalization for process steps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,10 +97,12 @@ POST
 주의:
 - 백엔드 기준 요약 step 키는 `summary`
 - STT 모델 키는 `whisper`
+- `steps`는 서버에서 소문자/중복 제거 정규화 후 처리됨(순서 유지)
 - `model_settings.provider`(또는 `llm_provider`)로 교정/요약 LLM provider 선택 가능 (`ollama` 기본, `llamacpp` 지원)
 - 교정/요약 워크플로우 옵션은 provider 중립 키(`temperature`, `context_window`, `max_tokens`)를 우선 사용하고 provider별 키로 매핑
 - 실패 응답 필드: `error`, `error_code`, `retryable`, `failed_step`
 - diarization 초안 오류 코드(`failed_step == "diarize"`): `diarization_model_unavailable`, `diarization_timeout`, `diarization_invalid_audio`
+- diarization 결과 payload는 `results["diarize"] = {status, input_file_type, duration?, segments[]}`를 기준으로 유지하며, 비오디오 입력은 `status: "skipped"`, `reason: "non_audio_input"`으로 처리
 - 진행률 응답(`/progress/<task_id>`, WebSocket)은 `progress_percent`, `eta_seconds`, `error`(표준 오류 카드용 객체) 포함
 
 ## 6. 수정 시 우선 확인할 파일

--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ venv\Scripts\python.exe -m sttEngine.server
   - `diarization_timeout`
   - `diarization_invalid_audio`
 
+`/process` diarization 동작(초안):
+- `steps`에 `diarize` 포함 시 화자 분리 단계를 실행
+- 오디오 입력은 `results.diarize = { status, input_file_type, duration, segments[] }` 구조로 응답
+- 텍스트/PDF 등 비오디오 입력은 표준 실패 대신 `results.diarize = { status: "skipped", reason: "non_audio_input", input_file_type, segments: [] }`로 스킵 처리
+- `steps`는 서버에서 소문자/중복 제거 정규화 후 처리(예: `" STT "`, `"stt"` → `"stt"`)
+
 ## 검색 API 계약 (요약)
 - 엔드포인트: `GET /search`
 - 주요 파라미터:

--- a/sttEngine/http_api/workflow.py
+++ b/sttEngine/http_api/workflow.py
@@ -142,6 +142,43 @@ def run_workflow(
     individual_output_dir = OUTPUT_DIR / upload_folder_name
     individual_output_dir.mkdir(exist_ok=True)
 
+    def run_diarize_step(source_file: Path) -> dict:
+        """Run diarization for audio inputs and return a normalized result payload."""
+        if file_type != "audio":
+            return {
+                "status": "skipped",
+                "reason": "non_audio_input",
+                "input_file_type": file_type,
+                "segments": [],
+            }
+
+        duration = get_audio_duration(source_file)
+        duration_seconds: float | None = None
+        if duration:
+            minutes, seconds = duration.split(":")
+            duration_seconds = float(int(minutes) * 60 + int(seconds))
+
+        # NOTE:
+        # - This is a lightweight baseline diarization payload for contract stability.
+        # - Future diarization backends should preserve this top-level schema.
+        segments = []
+        if duration_seconds and duration_seconds > 0:
+            segments.append(
+                {
+                    "speaker": "SPEAKER_00",
+                    "start": 0.0,
+                    "end": duration_seconds,
+                    "confidence": 1.0,
+                }
+            )
+
+        return {
+            "status": "completed",
+            "input_file_type": file_type,
+            "duration": duration,
+            "segments": segments,
+        }
+
     try:
         # For text files, skip STT step and copy to output directory
         if file_type == "text":
@@ -251,6 +288,26 @@ def run_workflow(
             if record_id:
                 file_path_str = to_record_path(stt_file)
                 update_task_completion(record_id, "stt", file_path_str)
+
+        if "diarize" in steps:
+            if task_id and is_task_cancelled(task_id):
+                return {"error": "Task was cancelled"}
+
+            if task_id:
+                update_task_progress(task_id, "화자 분리 시작", stage=TaskStage.TRANSFORM)
+
+            try:
+                diarize_source = file_path if file_type == "audio" else current_file
+                results["diarize"] = run_diarize_step(Path(diarize_source))
+            except Exception as e:
+                return _workflow_error_result(task_id, e, "diarize")
+
+            if task_id:
+                status = results["diarize"].get("status")
+                if status == "skipped":
+                    update_task_progress(task_id, "화자 분리 스킵(비오디오 입력)", stage=TaskStage.TRANSFORM)
+                else:
+                    update_task_progress(task_id, "화자 분리 완료", stage=TaskStage.TRANSFORM)
 
         if "embedding" in steps and current_file:
             if task_id and is_task_cancelled(task_id):

--- a/sttEngine/server/services/file_service.py
+++ b/sttEngine/server/services/file_service.py
@@ -7,6 +7,28 @@ from ...http_api.paths import normalize_record_path, resolve_record_path
 from .errors import ApiError
 
 
+def normalize_process_steps(raw_steps) -> list[str]:
+    """Normalize process step names while preserving order and compatibility."""
+    if not isinstance(raw_steps, list):
+        return []
+
+    step_aliases = {
+        "summarize": "summary",
+    }
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for step in raw_steps:
+        if not isinstance(step, str):
+            continue
+        normalized_step = step_aliases.get(step.strip().lower(), step.strip().lower())
+        if not normalized_step or normalized_step in seen:
+            continue
+        seen.add(normalized_step)
+        normalized.append(normalized_step)
+    return normalized
+
+
 def parse_process_payload(handler) -> dict:
     length = int(handler.headers.get("Content-Length", 0))
     try:
@@ -23,7 +45,7 @@ def parse_process_payload(handler) -> dict:
 
     return {
         "absolute_path": absolute_path,
-        "steps": payload.get("steps", []),
+        "steps": normalize_process_steps(payload.get("steps", [])),
         "record_id": payload.get("record_id"),
         "task_id": payload.get("task_id") or str(uuid.uuid4()),
         "model_settings": payload.get("model_settings", {}),

--- a/tests/http_api/test_workflow.py
+++ b/tests/http_api/test_workflow.py
@@ -103,3 +103,45 @@ def test_workflow_diarization_failure_contract_returns_standard_error_fields(mon
     assert progress_payloads[-1]["error_code"] == "diarization_model_unavailable"
     assert progress_payloads[-1]["retryable"] is True
     assert progress_payloads[-1]["failed_step"] == "diarize"
+
+
+def test_workflow_diarize_audio_returns_normalized_result(monkeypatch, tmp_path: Path, temp_workflow_dirs):
+    upload_dir = tmp_path / "uploads" / "task-diarize-audio"
+    upload_dir.mkdir(parents=True)
+    source = upload_dir / "sample.wav"
+    source.write_bytes(b"RIFF")
+
+    monkeypatch.setattr("sttEngine.http_api.workflow.get_audio_duration", lambda _path: "00:10")
+    monkeypatch.setattr("sttEngine.http_api.workflow.update_task_progress", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("sttEngine.http_api.workflow.clear_task_progress", lambda _id: None)
+    monkeypatch.setattr("sttEngine.http_api.workflow.is_task_cancelled", lambda _id: False)
+
+    result = run_workflow(source, ["diarize"], task_id="task-diarize-audio")
+
+    assert "diarize" in result
+    assert result["diarize"]["status"] == "completed"
+    assert result["diarize"]["input_file_type"] == "audio"
+    assert result["diarize"]["segments"][0]["speaker"] == "SPEAKER_00"
+    assert result["diarize"]["segments"][0]["start"] == 0.0
+    assert result["diarize"]["segments"][0]["end"] == 10.0
+
+
+def test_workflow_diarize_text_is_skipped_with_contract_payload(monkeypatch, tmp_path: Path, temp_workflow_dirs):
+    upload_dir = tmp_path / "uploads" / "task-diarize-text"
+    upload_dir.mkdir(parents=True)
+    source = upload_dir / "note.txt"
+    source.write_text("테스트 텍스트", encoding="utf-8")
+
+    monkeypatch.setattr("sttEngine.http_api.workflow.update_task_progress", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("sttEngine.http_api.workflow.clear_task_progress", lambda _id: None)
+    monkeypatch.setattr("sttEngine.http_api.workflow.is_task_cancelled", lambda _id: False)
+
+    result = run_workflow(source, ["diarize"], task_id="task-diarize-text")
+
+    assert "diarize" in result
+    assert result["diarize"] == {
+        "status": "skipped",
+        "reason": "non_audio_input",
+        "input_file_type": "text",
+        "segments": [],
+    }

--- a/tests/server/test_file_service.py
+++ b/tests/server/test_file_service.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from sttEngine.server.services.file_service import normalize_process_steps, parse_process_payload
+
+
+def test_normalize_process_steps_lowercases_deduplicates_and_preserves_order() -> None:
+    assert normalize_process_steps([" STT ", "Diarize", "summary", "stt", "", 1]) == [
+        "stt",
+        "diarize",
+        "summary",
+    ]
+
+
+def test_normalize_process_steps_maps_summarize_alias_to_summary() -> None:
+    assert normalize_process_steps(["summarize", "summary", "Summarize"]) == ["summary"]
+
+
+def test_parse_process_payload_normalizes_steps(dummy_handler_factory, monkeypatch) -> None:
+    monkeypatch.setattr("sttEngine.server.services.file_service.resolve_record_path", lambda _path: "/tmp/file.wav")
+
+    handler = dummy_handler_factory(
+        {
+            "file_path": "DB/uploads/uuid/sample.wav",
+            "steps": [" STT ", "Diarize", "summary", "stt"],
+        }
+    )
+
+    parsed = parse_process_payload(handler)
+
+    assert parsed["steps"] == ["stt", "diarize", "summary"]

--- a/tests/server/test_queue.py
+++ b/tests/server/test_queue.py
@@ -43,3 +43,20 @@ def test_run_process_task_maps_workflow_error(monkeypatch):
         "retryable": True,
         "failed_step": "workflow",
     }
+
+
+def test_run_process_task_supports_diarize_step(monkeypatch):
+    expected = {"diarize": {"status": "completed", "segments": []}}
+    monkeypatch.setattr("sttEngine.server.tasks.queue.run_workflow", lambda *_args, **_kwargs: expected)
+
+    result = run_process_task(
+        {
+            "absolute_path": "/tmp/file.wav",
+            "steps": ["diarize", "summary"],
+            "record_id": "r1",
+            "task_id": "t3",
+            "model_settings": {},
+        }
+    )
+
+    assert result["diarize"]["status"] == "completed"


### PR DESCRIPTION
### Motivation
- Restore backward compatibility for `/process` payloads by handling the legacy `summarize` alias so summary execution is not silently skipped.

### Description
- Map the alias `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995b151e29c832e936e265a95141a51)