### PR TITLE
fix: remove direct Ollama coupling from one-line summary

### DIFF
--- a/TODO/llama-migration.md
+++ b/TODO/llama-migration.md
@@ -43,6 +43,21 @@
 
 ---
 
+
+## 0-2. 코드베이스 재검토 결과 (2026-02-18)
+
+- 판정: **핵심 경로 완료 + 잔여 리스크 존재(완전 종료 아님)**
+- 확인 근거:
+  - 핵심 회귀(`workflow/search/queue/vocab`)는 통과하여 주요 사용자 플로우는 정상 동작.
+  - `tests/http_api/test_admin_models.py` 수집 단계에서 `sttEngine/one_line_summary.py`의 `import ollama`로 `ModuleNotFoundError: No module named 'ollama'` 재현.
+  - 즉, `requirements.txt`에서 Ollama를 optional로 분리한 상태에서 legacy direct import가 남아 **"Ollama 의존 제거 완료"는 100% 달성되지 않음**.
+- 액션 아이템(우선순위):
+  1. `sttEngine/one_line_summary.py`를 provider 인터페이스로 전환하거나, 모듈 import를 lazy/guard 처리해 optional dependency 환경에서도 테스트 수집이 가능하도록 정리
+  2. `tests/http_api/test_admin_models.py`가 ollama 미설치 환경에서도 독립 실행되도록 `one_line_summary` 결합부 의존 최소화
+  3. clean 환경 setup/run 실측 검증 및 결과를 본 문서 체크박스에 반영
+
+---
+
 ## 1. 현재 상태 진단 요약
 
 ### 1-1. Ollama 결합 지점 (2026-02-18 기준)

--- a/sttEngine/one_line_summary.py
+++ b/sttEngine/one_line_summary.py
@@ -1,28 +1,59 @@
-"""Utility for generating one-line summaries using Ollama."""
+"""Utility for generating one-line summaries via configured LLM provider."""
+
+from __future__ import annotations
 
 from pathlib import Path
-import ollama
-from .workflow.summarize import read_text_with_fallback, DEFAULT_MODEL
-from .ollama_utils import safe_ollama_call
+from typing import Any, Dict
+
+from .llm_provider import map_llm_options, normalize_provider_name
+from .providers.factory import get_llm_provider
+from .workflow.summarize import DEFAULT_MODEL, read_text_with_fallback
 
 
-def generate_one_line_summary(file_path: Path, model: str = None) -> str:
+def _extract_summary_line(response: Dict[str, Any]) -> str:
+    """Extract first non-empty summary line from provider response."""
+    if not isinstance(response, dict):
+        return ""
+
+    raw_text = response.get("response")
+    if not isinstance(raw_text, str):
+        message = response.get("message")
+        if isinstance(message, dict):
+            content = message.get("content")
+            if isinstance(content, str):
+                raw_text = content
+
+    if not isinstance(raw_text, str):
+        return ""
+
+    for line in raw_text.strip().splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def generate_one_line_summary(file_path: Path, model: str | None = None, provider_name: str | None = None) -> str:
     """Generate a single-line Korean summary for the given text file.
 
     Args:
         file_path: Path to the text file to summarize.
-        model: Optional Ollama model name to use. Defaults to the
-            structured summary model when not provided.
+        model: Optional model name to use. Defaults to the structured summary model.
+        provider_name: Optional provider override (`ollama`/`llamacpp`).
 
     Returns:
-        A one-line summary string.
+        A one-line summary string. Returns empty string when provider response is empty.
     """
     text = read_text_with_fallback(file_path)
     prompt = "다음 텍스트를 한 줄로 한국어로 요약해 주세요:\n" + text[:4000]
-    response = safe_ollama_call(
-        ollama.generate,
+
+    resolved_provider = normalize_provider_name(provider_name)
+    provider = get_llm_provider(resolved_provider)
+    options = map_llm_options({"temperature": 0}, provider_name=resolved_provider)
+
+    response = provider.generate(
         model=model or DEFAULT_MODEL,
         prompt=prompt,
-        options={"temperature": 0},
+        options=options,
     )
-    return response.get("response", "").strip().splitlines()[0]
+    return _extract_summary_line(response)

--- a/tests/http_api/test_admin_models.py
+++ b/tests/http_api/test_admin_models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from io import BytesIO
 
-from sttEngine.http_api.handler import UploadHandler
+from sttEngine.http_api.routes import admin_routes
 
 
 class _DummyModelsHandler:
@@ -44,9 +44,9 @@ def test_models_endpoint_uses_provider_contract(monkeypatch):
     }
 
     monkeypatch.setenv("LLM_PROVIDER", "llama_cpp")
-    monkeypatch.setattr("sttEngine.http_api.handler.get_llm_provider", lambda name: providers[name])
+    monkeypatch.setattr("sttEngine.http_api.routes.admin_routes.get_llm_provider", lambda name: providers[name])
 
-    UploadHandler._serve_available_models(handler)
+    admin_routes._serve_available_models(handler)
 
     assert handler.status_code == 200
     payload = json.loads(handler.wfile.getvalue().decode("utf-8"))
@@ -66,9 +66,9 @@ def test_models_endpoint_respects_explicit_provider_query(monkeypatch):
     }
 
     monkeypatch.setenv("LLM_PROVIDER", "llama_cpp")
-    monkeypatch.setattr("sttEngine.http_api.handler.get_llm_provider", lambda name: providers[name])
+    monkeypatch.setattr("sttEngine.http_api.routes.admin_routes.get_llm_provider", lambda name: providers[name])
 
-    UploadHandler._serve_available_models(handler, provider_name="ollama")
+    admin_routes._serve_available_models(handler, provider_name="ollama")
 
     assert handler.status_code == 200
     payload = json.loads(handler.wfile.getvalue().decode("utf-8"))

--- a/tests/test_one_line_summary.py
+++ b/tests/test_one_line_summary.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sttEngine.one_line_summary import _extract_summary_line, generate_one_line_summary
+
+
+class _DummyProvider:
+    def __init__(self, payload):
+        self.payload = payload
+        self.calls = []
+
+    def generate(self, *, model: str, prompt: str, options: dict):
+        self.calls.append({"model": model, "prompt": prompt, "options": options})
+        return self.payload
+
+
+def test_extract_summary_line_supports_generate_response() -> None:
+    assert _extract_summary_line({"response": "한 줄 요약\n두번째 줄"}) == "한 줄 요약"
+
+
+def test_extract_summary_line_supports_chat_shape() -> None:
+    assert _extract_summary_line({"message": {"content": "요약 결과"}}) == "요약 결과"
+
+
+def test_generate_one_line_summary_uses_provider_contract(monkeypatch, tmp_path: Path) -> None:
+    source = tmp_path / "sample.txt"
+    source.write_text("테스트 본문", encoding="utf-8")
+
+    provider = _DummyProvider({"response": "요약 한 줄"})
+    monkeypatch.setattr("sttEngine.one_line_summary.get_llm_provider", lambda *_args, **_kwargs: provider)
+
+    summary = generate_one_line_summary(source, model="demo", provider_name="llamacpp")
+
+    assert summary == "요약 한 줄"
+    assert provider.calls
+    assert provider.calls[0]["model"] == "demo"
+    assert provider.calls[0]["options"]["temperature"] == 0


### PR DESCRIPTION
### Motivation
- Tests failed to collect in environments where the optional `ollama` package is not installed because `sttEngine/one_line_summary.py` imported `ollama` at module import time. 
- The intent is to make the one-line-summary utility provider-neutral and follow the existing provider abstraction so optional dependencies do not break test collection or runtime import.

### Description
- Reworked `sttEngine/one_line_summary.py` to use the provider abstraction (`get_llm_provider` + `generate`) and `map_llm_options` instead of directly importing `ollama` at module import time.
- Added `_extract_summary_line()` to normalize different provider response shapes (supporting `response` and `message.content`).
- Added unit tests `tests/test_one_line_summary.py` covering extraction and provider-contract invocation behavior.
- Updated `tests/http_api/test_admin_models.py` to patch the current route module (`sttEngine.http_api.routes.admin_routes`) and call the route helper (`_serve_available_models`) instead of the old handler symbol location.

### Testing
- Ran `pytest tests/test_one_line_summary.py tests/providers/test_provider_factory.py tests/http_api/test_admin_models.py tests/server/test_error_mapping.py` and all tests passed (`22 passed`).
- Ran `pytest tests/http_api/test_workflow.py tests/http_api/test_search.py tests/server/test_queue.py tests/test_vocab_system.py` and all tests passed (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995b236793c832e9d7844837d7cc799)