### PR TITLE
Speaker-aware segment merge, write STT sidecar and diarization alignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ POST
 - 실패 응답 필드: `error`, `error_code`, `retryable`, `failed_step`
 - diarization 초안 오류 코드(`failed_step == "diarize"`): `diarization_model_unavailable`, `diarization_timeout`, `diarization_invalid_audio`
 - diarization 결과 payload는 `results["diarize"] = {status, input_file_type, duration?, segments[]}`를 기준으로 유지하며, 비오디오 입력은 `status: "skipped"`, `reason: "non_audio_input"`으로 처리
+- STT 세그먼트는 dict 구조(`start/end/text/speaker`)를 기준으로 저장하며 `*.segments.json` 및 `/process`의 `stt_segments`에서 동일 스키마를 사용합니다.
 - 진행률 응답(`/progress/<task_id>`, WebSocket)은 `progress_percent`, `eta_seconds`, `error`(표준 오류 카드용 객체) 포함
 
 ## 6. 수정 시 우선 확인할 파일

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ venv\Scripts\python.exe -m sttEngine.server
 `/process` diarization 동작(초안):
 - `steps`에 `diarize` 포함 시 화자 분리 단계를 실행
 - 오디오 입력은 `results.diarize = { status, input_file_type, duration, segments[] }` 구조로 응답
+- STT 출력은 `*.segments.json` 사이드카 파일로 `segments[].{start,end,text,speaker}`를 저장하며, `/process` 응답에 `stt_segments`로 노출됩니다. diarization 실행 시 overlap 기준으로 화자 라벨을 align하고 미할당 구간은 기본 `SPEAKER_00`을 사용합니다.
 - 텍스트/PDF 등 비오디오 입력은 표준 실패 대신 `results.diarize = { status: "skipped", reason: "non_audio_input", input_file_type, segments: [] }`로 스킵 처리
 - `steps`는 서버에서 소문자/중복 제거 정규화 후 처리(예: `" STT "`, `"stt"` → `"stt"`)
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -63,6 +63,22 @@ export type WorkflowErrorCode =
   | 'diarization_invalid_audio'
   | (string & {});
 
+
+export interface SegmentItem {
+  start: number;
+  end: number;
+  text?: string;
+  speaker: string | null;
+}
+
+export interface DiarizeResult {
+  status: 'completed' | 'skipped';
+  reason?: string;
+  input_file_type?: string;
+  duration?: string;
+  segments: SegmentItem[];
+}
+
 export interface ProcessResult {
   accepted?: boolean;
   task_id?: string;
@@ -71,6 +87,8 @@ export interface ProcessResult {
   stt?: string;
   summary?: string;
   correct?: string;
+  diarize?: DiarizeResult;
+  stt_segments?: SegmentItem[];
   error?: string;
   error_code?: WorkflowErrorCode;
   retryable?: boolean;

--- a/sttEngine/http_api/workflow.py
+++ b/sttEngine/http_api/workflow.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from ..obsidian_mcp import send_summary_to_obsidian_sync
 from ..workflow.transcribe import transcribe_audio_files
+from ..workflow.speaker_utils import align_diarization_to_stt_segments, format_speaker_label
 from ..workflow.correct import correct_text_file
 from ..workflow.summarize import (
     DEFAULT_CHUNK_SIZE,
@@ -179,6 +180,51 @@ def run_workflow(
     individual_output_dir = OUTPUT_DIR / upload_folder_name
     individual_output_dir.mkdir(exist_ok=True)
 
+
+    def load_stt_segments(stt_markdown_file: Path) -> list[dict]:
+        sidecar = stt_markdown_file.with_suffix(".segments.json")
+        if not sidecar.exists():
+            return []
+        try:
+            import json
+
+            payload = json.loads(sidecar.read_text(encoding="utf-8"))
+            segments = payload.get("segments", [])
+            return segments if isinstance(segments, list) else []
+        except Exception:
+            return []
+
+
+    def apply_diarization_alignment_if_available(stt_markdown_file: Path) -> list[dict]:
+        stt_segments = load_stt_segments(stt_markdown_file)
+        if not stt_segments:
+            return []
+
+        diarize_payload = results.get("diarize") if isinstance(results.get("diarize"), dict) else None
+        diarization_segments = diarize_payload.get("segments", []) if diarize_payload else []
+
+        aligned_segments = align_diarization_to_stt_segments(
+            stt_segments,
+            diarization_segments if isinstance(diarization_segments, list) else [],
+            default_speaker=format_speaker_label(0),
+            allow_null_speaker=False,
+        )
+
+        results["stt_segments"] = aligned_segments
+
+        if aligned_segments:
+            try:
+                import json
+
+                stt_markdown_file.with_suffix(".segments.json").write_text(
+                    json.dumps({"segments": aligned_segments}, ensure_ascii=False, indent=2),
+                    encoding="utf-8",
+                )
+            except Exception:
+                pass
+
+        return aligned_segments
+
     def run_diarize_step(source_file: Path) -> dict:
         """Run diarization for audio inputs and return a normalized result payload."""
         if file_type != "audio":
@@ -202,7 +248,7 @@ def run_workflow(
         if duration_seconds and duration_seconds > 0:
             segments.append(
                 {
-                    "speaker": "SPEAKER_00",
+                    "speaker": format_speaker_label(0),
                     "start": 0.0,
                     "end": duration_seconds,
                     "confidence": 1.0,
@@ -232,6 +278,7 @@ def run_workflow(
                 download_url = f"/download/{upload_folder_name}/{text_file.name}"
                 results["stt"] = download_url
                 current_file = text_file
+                apply_diarization_alignment_if_available(current_file)
 
                 if record_id:
                     file_path_str = to_record_path(text_file)
@@ -242,6 +289,7 @@ def run_workflow(
 
                 shutil.copy2(file_path, text_file)
                 current_file = text_file
+                apply_diarization_alignment_if_available(current_file)
 
         # For PDF files, extract text and treat as markdown
         elif file_type == "pdf":
@@ -268,6 +316,7 @@ def run_workflow(
                     update_task_completion(record_id, "stt", file_path_str)
 
             current_file = text_file
+            apply_diarization_alignment_if_available(current_file)
 
         # For audio files, run STT step
         elif file_type == "audio" and "stt" in steps:
@@ -321,6 +370,7 @@ def run_workflow(
             download_url = f"/download/{upload_folder_name}/{stt_file.name}"
             results["stt"] = download_url
             current_file = stt_file
+            apply_diarization_alignment_if_available(current_file)
 
             if record_id:
                 file_path_str = to_record_path(stt_file)
@@ -337,6 +387,8 @@ def run_workflow(
                 _parse_diarization_settings(model_settings)
                 diarize_source = file_path if file_type == "audio" else current_file
                 results["diarize"] = run_diarize_step(Path(diarize_source))
+                if current_file and Path(current_file).suffix.lower() == ".md":
+                    apply_diarization_alignment_if_available(Path(current_file))
             except Exception as e:
                 return _workflow_error_result(task_id, e, "diarize")
 
@@ -358,6 +410,7 @@ def run_workflow(
                     if task_id:
                         update_task_progress(task_id, f"기존 STT 결과 발견: {existing_stt.name}", stage=TaskStage.TRANSFORM)
                     current_file = existing_stt
+                    apply_diarization_alignment_if_available(current_file)
                     download_url = f"/download/{upload_folder_name}/{existing_stt.name}"
                     results["stt"] = download_url
 
@@ -413,6 +466,7 @@ def run_workflow(
                     download_url = f"/download/{upload_folder_name}/{stt_file.name}"
                     results["stt"] = download_url
                     current_file = stt_file
+                    apply_diarization_alignment_if_available(current_file)
 
                     if record_id:
                         file_path_str = to_record_path(current_file)
@@ -463,6 +517,7 @@ def run_workflow(
                     if task_id:
                         update_task_progress(task_id, f"기존 STT 결과 발견: {existing_stt.name}", stage=TaskStage.TRANSFORM)
                     current_file = existing_stt
+                    apply_diarization_alignment_if_available(current_file)
                     download_url = f"/download/{upload_folder_name}/{existing_stt.name}"
                     results["stt"] = download_url
 
@@ -518,6 +573,7 @@ def run_workflow(
                     download_url = f"/download/{upload_folder_name}/{stt_file.name}"
                     results["stt"] = download_url
                     current_file = stt_file
+                    apply_diarization_alignment_if_available(current_file)
 
                     if record_id:
                         file_path_str = to_record_path(current_file)

--- a/sttEngine/workflow/speaker_utils.py
+++ b/sttEngine/workflow/speaker_utils.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+def format_speaker_label(index: int) -> str:
+    """Return canonical speaker label format (e.g. SPEAKER_00)."""
+    safe_index = max(0, int(index))
+    return f"SPEAKER_{safe_index:02d}"
+
+
+def normalize_speaker_label(raw_speaker: Any, default_index: int = 0) -> str:
+    """Normalize various provider speaker formats into canonical SPEAKER_XX."""
+    if isinstance(raw_speaker, int):
+        return format_speaker_label(raw_speaker)
+
+    if isinstance(raw_speaker, str):
+        text = raw_speaker.strip()
+        if not text:
+            return format_speaker_label(default_index)
+
+        matched = re.search(r"(\d+)$", text)
+        if matched:
+            return format_speaker_label(int(matched.group(1)))
+
+        upper = text.upper()
+        if upper.startswith("SPEAKER_"):
+            suffix = upper.split("SPEAKER_", 1)[1]
+            if suffix.isdigit():
+                return format_speaker_label(int(suffix))
+
+    return format_speaker_label(default_index)
+
+
+def get_overlap_seconds(start_a: float, end_a: float, start_b: float, end_b: float) -> float:
+    """Calculate overlap length (seconds) for two timeline windows."""
+    return max(0.0, min(end_a, end_b) - max(start_a, start_b))
+
+
+def align_diarization_to_stt_segments(
+    stt_segments: list[dict[str, Any]],
+    diarization_segments: list[dict[str, Any]],
+    *,
+    default_speaker: str | None = None,
+    allow_null_speaker: bool = False,
+) -> list[dict[str, Any]]:
+    """Assign speaker labels to STT segments by maximum overlap with diarization segments."""
+    aligned: list[dict[str, Any]] = []
+    normalized_default = normalize_speaker_label(default_speaker) if default_speaker else format_speaker_label(0)
+
+    normalized_diarization: list[dict[str, Any]] = []
+    for diarization in diarization_segments:
+        try:
+            start = float(diarization.get("start", 0.0))
+            end = float(diarization.get("end", 0.0))
+        except (TypeError, ValueError):
+            continue
+        if end <= start:
+            continue
+        normalized_diarization.append(
+            {
+                "start": start,
+                "end": end,
+                "speaker": normalize_speaker_label(diarization.get("speaker"), default_index=0),
+            }
+        )
+
+    for segment in stt_segments:
+        mapped = dict(segment)
+        try:
+            start = float(mapped.get("start", 0.0))
+            end = float(mapped.get("end", 0.0))
+        except (TypeError, ValueError):
+            start, end = 0.0, 0.0
+
+        speaker: str | None = None
+        best_overlap = 0.0
+
+        for diarization in normalized_diarization:
+            overlap = get_overlap_seconds(start, end, diarization["start"], diarization["end"])
+            if overlap > best_overlap:
+                best_overlap = overlap
+                speaker = diarization["speaker"]
+
+        if speaker is None:
+            speaker = None if allow_null_speaker else normalized_default
+
+        mapped["speaker"] = speaker
+        aligned.append(mapped)
+
+    return aligned

--- a/sttEngine/workflow/transcribe.py
+++ b/sttEngine/workflow/transcribe.py
@@ -3,6 +3,7 @@
 import whisper
 import os
 import argparse
+import json
 import logging
 import traceback
 import platform
@@ -28,6 +29,7 @@ from sttEngine.vocabulary_manager import VocabularyManager
 from sttEngine.obsidian_mcp import send_stt_to_obsidian_sync
 from sttEngine.workflow.cli_utils import add_verbose_argument, configure_cli_logging
 from sttEngine.server.services.errors import map_workflow_exception
+from sttEngine.workflow.speaker_utils import normalize_speaker_label
 
 DB_BASE_PATH = get_db_base_path()
 DEFAULT_OUTPUT_DIR = DB_BASE_PATH / "whisper_output"
@@ -54,6 +56,12 @@ def write_atomic(path: Path, data: str):
     with open(tmp_path, "w", encoding="utf-8") as f:
         f.write(data)
     tmp_path.replace(path)
+
+
+def write_segments_sidecar(markdown_path: Path, segments: list[dict]) -> None:
+    """Write STT segments to sidecar JSON file for downstream consumers."""
+    sidecar_path = markdown_path.with_suffix(".segments.json")
+    write_atomic(sidecar_path, json.dumps({"segments": segments}, ensure_ascii=False, indent=2))
 
 def remove_word_repetitions(text: str) -> str:
     """한 줄 내에서 반복되는 단어 제거 (첫 번째만 유지)"""
@@ -153,9 +161,10 @@ def merge_segments(segments, max_gap: float = 0.2):
     for segment in safe_segments[1:]:
         current = merged[-1]
         same_text = segment["text"].strip() == current["text"].strip()
+        same_speaker = segment.get("speaker") == current.get("speaker")
         time_continuous = segment["start"] <= current["end"] + max_gap
-        
-        if same_text and time_continuous:
+
+        if same_text and same_speaker and time_continuous:
             # 병합: 종료 시간을 더 늦은 것으로 업데이트
             current["end"] = max(current["end"], segment["end"])
         else:
@@ -476,26 +485,32 @@ def transcribe_single_file(file_path: Path, output_dir: Path, model,
         segments = merge_segments(segments, max_gap=0.2)
 
         # 필터링 및 정규화
-        processed_segments = []
+        processed_segments: list[dict] = []
         for segment in segments:
             text = segment.get("text", "").strip()
             if not should_keep_segment(text, filter_fillers, min_seg_length):
                 continue
             text = normalize_text(text, normalize_punct or True)  # 반복 단어 제거는 항상 활성화
             processed_segments.append(
-                (
-                    segment.get("start", 0.0),
-                    segment.get("end", 0.0),
-                    text,
-                )
+                {
+                    "start": float(segment.get("start", 0.0) or 0.0),
+                    "end": float(segment.get("end", 0.0) or 0.0),
+                    "text": text,
+                    "speaker": normalize_speaker_label(segment.get("speaker"), default_index=0),
+                }
             )
 
         # 마크다운 생성 (원본 파일명 기준)
         markdown_content = f"# {file_path.stem}\n\n"
         if processed_segments:
             lines = []
-            for start, end, text in processed_segments:
+            for segment in processed_segments:
+                start = segment.get("start", 0.0)
+                end = segment.get("end", 0.0)
+                text = segment.get("text", "")
                 ts = f"{format_timestamp(start)} - {format_timestamp(end)}"
+                # NOTE: markdown 본문은 기존 포맷을 유지하고,
+                # 화자 정보는 *.segments.json 사이드카/API(stt_segments)로 제공합니다.
                 lines.append(f"[{ts}] {text}")
             markdown_content += "\n".join(lines)
         else:
@@ -513,6 +528,7 @@ def transcribe_single_file(file_path: Path, output_dir: Path, model,
             progress_callback(f"'{file_path.name}' 파일 저장 중...")
 
         write_atomic(output_file_path, markdown_content)
+        write_segments_sidecar(output_file_path, processed_segments)
 
         # Obsidian MCP 자동 전송
         try:
@@ -525,7 +541,7 @@ def transcribe_single_file(file_path: Path, output_dir: Path, model,
             created_at = datetime.now()
 
             # STT 텍스트 추출 (타임스탬프 제거한 순수 텍스트)
-            stt_text_only = "\n".join([text for _, _, text in processed_segments]) if processed_segments else result.get("text", "").strip()
+            stt_text_only = "\n".join([segment["text"] for segment in processed_segments]) if processed_segments else result.get("text", "").strip()
 
             if progress_callback:
                 progress_callback(f"'{file_path.name}' Obsidian 전송 중...")

--- a/tests/http_api/test_workflow.py
+++ b/tests/http_api/test_workflow.py
@@ -166,3 +166,36 @@ def test_workflow_diarize_rejects_invalid_speaker_constraints(monkeypatch, tmp_p
 
     assert result["failed_step"] == "diarize"
     assert result["error_code"] == "diarization_invalid_audio"
+
+
+def test_workflow_exposes_stt_segments_with_speaker_after_diarize(monkeypatch, tmp_path: Path, temp_workflow_dirs):
+    upload_dir = tmp_path / "uploads" / "task-stt-diarize"
+    upload_dir.mkdir(parents=True)
+    source = upload_dir / "sample.wav"
+    source.write_bytes(b"RIFF")
+
+    def fake_transcribe_audio_files(**kwargs):
+        import json
+
+        output_dir = Path(kwargs["output_dir"])
+        output_dir.mkdir(parents=True, exist_ok=True)
+        markdown_file = output_dir / "sample.md"
+        markdown_file.write_text("# sample\n\n[00:00:00 - 00:00:02] hello", encoding="utf-8")
+        segments_payload = {
+            "segments": [
+                {"start": 0.0, "end": 2.0, "text": "hello", "speaker": "SPEAKER_00"}
+            ]
+        }
+        markdown_file.with_suffix(".segments.json").write_text(json.dumps(segments_payload), encoding="utf-8")
+
+    monkeypatch.setattr("sttEngine.http_api.workflow.transcribe_audio_files", fake_transcribe_audio_files)
+    monkeypatch.setattr("sttEngine.http_api.workflow.get_audio_duration", lambda _path: "00:02")
+    monkeypatch.setattr("sttEngine.http_api.workflow.update_task_progress", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("sttEngine.http_api.workflow.clear_task_progress", lambda _id: None)
+    monkeypatch.setattr("sttEngine.http_api.workflow.is_task_cancelled", lambda _id: False)
+
+    result = run_workflow(source, ["stt", "diarize"], task_id="task-stt-diarize")
+
+    assert "stt_segments" in result
+    assert result["stt_segments"][0]["speaker"] == "SPEAKER_00"
+    assert result["diarize"]["segments"][0]["speaker"] == "SPEAKER_00"

--- a/tests/workflow/test_speaker_utils.py
+++ b/tests/workflow/test_speaker_utils.py
@@ -1,0 +1,38 @@
+from sttEngine.workflow.speaker_utils import (
+    align_diarization_to_stt_segments,
+    format_speaker_label,
+    normalize_speaker_label,
+)
+
+
+def test_format_and_normalize_speaker_label():
+    assert format_speaker_label(0) == "SPEAKER_00"
+    assert normalize_speaker_label("speaker_1") == "SPEAKER_01"
+    assert normalize_speaker_label("SPEAKER_09") == "SPEAKER_09"
+    assert normalize_speaker_label("spk2") == "SPEAKER_02"
+
+
+def test_align_diarization_to_stt_segments_assigns_by_overlap():
+    stt_segments = [
+        {"start": 0.0, "end": 1.0, "text": "a"},
+        {"start": 1.0, "end": 2.0, "text": "b"},
+    ]
+    diarization_segments = [
+        {"start": 0.0, "end": 1.4, "speaker": "speaker_0"},
+        {"start": 1.4, "end": 2.0, "speaker": "1"},
+    ]
+
+    aligned = align_diarization_to_stt_segments(stt_segments, diarization_segments)
+
+    assert aligned[0]["speaker"] == "SPEAKER_00"
+    assert aligned[1]["speaker"] == "SPEAKER_01"
+
+
+def test_align_diarization_to_stt_segments_default_speaker_policy():
+    stt_segments = [{"start": 4.0, "end": 5.0, "text": "x"}]
+
+    aligned = align_diarization_to_stt_segments(stt_segments, [], allow_null_speaker=False)
+    assert aligned[0]["speaker"] == "SPEAKER_00"
+
+    aligned_null = align_diarization_to_stt_segments(stt_segments, [], allow_null_speaker=True)
+    assert aligned_null[0]["speaker"] is None

--- a/tests/workflow/test_transcribe_segments.py
+++ b/tests/workflow/test_transcribe_segments.py
@@ -1,0 +1,26 @@
+from sttEngine.workflow.transcribe import merge_segments
+
+
+def test_merge_segments_does_not_merge_different_speakers():
+    segments = [
+        {"start": 0.0, "end": 1.0, "text": "안녕하세요", "speaker": "SPEAKER_00"},
+        {"start": 1.0, "end": 2.0, "text": "안녕하세요", "speaker": "SPEAKER_01"},
+    ]
+
+    merged = merge_segments(segments, max_gap=0.2)
+
+    assert len(merged) == 2
+    assert merged[0]["speaker"] == "SPEAKER_00"
+    assert merged[1]["speaker"] == "SPEAKER_01"
+
+
+def test_merge_segments_merges_same_text_same_speaker_contiguous():
+    segments = [
+        {"start": 0.0, "end": 1.0, "text": "테스트", "speaker": "SPEAKER_00"},
+        {"start": 1.1, "end": 2.0, "text": "테스트", "speaker": "SPEAKER_00"},
+    ]
+
+    merged = merge_segments(segments, max_gap=0.2)
+
+    assert len(merged) == 1
+    assert merged[0]["end"] == 2.0


### PR DESCRIPTION
### Motivation
- Prevent incorrect merging of identical-text STT segments when they belong to different speakers and keep downstream contracts stable.
- Preserve the legacy markdown STT output format to avoid breaking consumers while exposing structured speaker metadata separately.
- Provide a canonical speaker labeling/normalization and align diarization output to STT timeline so `stt_segments` carry speaker labels for API consumers.

### Description
- Updated `sttEngine/workflow/transcribe.py` to make `merge_segments` respect speaker equality, to normalize speaker labels, to write a `*.segments.json` sidecar via `write_segments_sidecar`, and to keep markdown lines in the legacy `[timestamp] text` format (speaker info moved to sidecar). 
- Added `sttEngine/workflow/speaker_utils.py` implementing `format_speaker_label`, `normalize_speaker_label`, `get_overlap_seconds`, and `align_diarization_to_stt_segments` for canonical speaker handling and overlap-based alignment.
- Extended `sttEngine/http_api/workflow.py` to load STT sidecars, run diarization (baseline), align diarization segments to STT segments with `align_diarization_to_stt_segments`, expose `results['stt_segments']`, and persist aligned sidecars when available.
- Updated frontend types in `frontend/src/api/types.ts` to include `SegmentItem`, `DiarizeResult`, and `ProcessResult.stt_segments`/`diarize`, and updated `README.md`/`AGENTS.md` to document the sidecar and `stt_segments` contract.
- Added unit tests `tests/workflow/test_transcribe_segments.py` and `tests/workflow/test_speaker_utils.py` and a workflow integration assertion in `tests/http_api/test_workflow.py` to validate the new behavior.

### Testing
- Ran targeted pytest suite: `pytest tests/workflow/test_transcribe_segments.py tests/workflow/test_speaker_utils.py tests/http_api/test_workflow.py tests/server/test_queue.py tests/test_vocab_system.py`, all tests passed (`18 passed`).
- Built frontend production bundle with `npm run build` in `frontend/`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995b72ab820832ebf823da358f6ec3a)