### PR TITLE
Refine diarization failure fallback and update API types/docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ POST
 - 실패 응답 필드: `error`, `error_code`, `retryable`, `failed_step`
 - diarization 초안 오류 코드(`failed_step == "diarize"`): `diarization_model_unavailable`, `diarization_timeout`, `diarization_invalid_audio`
 - diarization 결과 payload는 `results["diarize"] = {status, input_file_type, duration?, segments[]}`를 기준으로 유지하며, 비오디오 입력은 `status: "skipped"`, `reason: "non_audio_input"`으로 처리
+- diarization이 STT 이후 실패하면 워크플로우는 STT 텍스트를 유지하고, `results["diarize"]`는 `status: "failed"` + 표준 오류 필드(`error/error_code/retryable/failed_step`)를 포함하며 `stt_segments[].speaker`는 `null`로 비활성화됩니다.
 - STT 세그먼트는 dict 구조(`start/end/text/speaker`)를 기준으로 저장하며 `*.segments.json` 및 `/process`의 `stt_segments`에서 동일 스키마를 사용합니다.
 - 진행률 응답(`/progress/<task_id>`, WebSocket)은 `progress_percent`, `eta_seconds`, `error`(표준 오류 카드용 객체) 포함
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ venv\Scripts\python.exe -m sttEngine.server
 - 오디오 입력은 `results.diarize = { status, input_file_type, duration, segments[] }` 구조로 응답
 - STT 출력은 `*.segments.json` 사이드카 파일로 `segments[].{start,end,text,speaker}`를 저장하며, `/process` 응답에 `stt_segments`로 노출됩니다. diarization 실행 시 overlap 기준으로 화자 라벨을 align하고 미할당 구간은 기본 `SPEAKER_00`을 사용합니다.
 - 텍스트/PDF 등 비오디오 입력은 표준 실패 대신 `results.diarize = { status: "skipped", reason: "non_audio_input", input_file_type, segments: [] }`로 스킵 처리
+- diarization이 STT 이후 실패하면 워크플로우는 STT 텍스트를 유지하고, `results.diarize = { status: "failed", input_file_type, segments: [], error, error_code, retryable, failed_step }`를 반환하며 `stt_segments[].speaker`는 `null`로 비활성화됩니다.
 - `steps`는 서버에서 소문자/중복 제거 정규화 후 처리(예: `" STT "`, `"stt"` → `"stt"`)
 
 ## 검색 API 계약 (요약)

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -72,10 +72,14 @@ export interface SegmentItem {
 }
 
 export interface DiarizeResult {
-  status: 'completed' | 'skipped';
+  status: 'completed' | 'skipped' | 'failed';
   reason?: string;
   input_file_type?: string;
   duration?: string;
+  error?: string;
+  error_code?: WorkflowErrorCode;
+  retryable?: boolean;
+  failed_step?: string;
   segments: SegmentItem[];
 }
 

--- a/sttEngine/http_api/workflow.py
+++ b/sttEngine/http_api/workflow.py
@@ -195,7 +195,11 @@ def run_workflow(
             return []
 
 
-    def apply_diarization_alignment_if_available(stt_markdown_file: Path) -> list[dict]:
+    def apply_diarization_alignment_if_available(
+        stt_markdown_file: Path,
+        *,
+        allow_null_speaker: bool = False,
+    ) -> list[dict]:
         stt_segments = load_stt_segments(stt_markdown_file)
         if not stt_segments:
             return []
@@ -207,7 +211,7 @@ def run_workflow(
             stt_segments,
             diarization_segments if isinstance(diarization_segments, list) else [],
             default_speaker=format_speaker_label(0),
-            allow_null_speaker=False,
+            allow_null_speaker=allow_null_speaker,
         )
 
         results["stt_segments"] = aligned_segments
@@ -390,12 +394,29 @@ def run_workflow(
                 if current_file and Path(current_file).suffix.lower() == ".md":
                     apply_diarization_alignment_if_available(Path(current_file))
             except Exception as e:
-                return _workflow_error_result(task_id, e, "diarize")
+                mapped_error = _workflow_error_result(task_id, e, "diarize")
+                has_stt_result = "stt" in results and current_file and Path(current_file).suffix.lower() == ".md"
+                if has_stt_result:
+                    results["diarize"] = {
+                        "status": "failed",
+                        "input_file_type": file_type,
+                        "segments": [],
+                        "error": mapped_error["error"],
+                        "error_code": mapped_error["error_code"],
+                        "retryable": mapped_error["retryable"],
+                        "failed_step": mapped_error["failed_step"],
+                    }
+                    results.update(mapped_error)
+                    apply_diarization_alignment_if_available(Path(current_file), allow_null_speaker=True)
+                else:
+                    return mapped_error
 
             if task_id:
                 status = results["diarize"].get("status")
                 if status == "skipped":
                     update_task_progress(task_id, "화자 분리 스킵(비오디오 입력)", stage=TaskStage.TRANSFORM)
+                elif status == "failed":
+                    update_task_progress(task_id, "화자 분리 실패(화자 라벨 비활성화)", stage=TaskStage.TRANSFORM)
                 else:
                     update_task_progress(task_id, "화자 분리 완료", stage=TaskStage.TRANSFORM)
 

--- a/tests/http_api/test_workflow.py
+++ b/tests/http_api/test_workflow.py
@@ -199,3 +199,43 @@ def test_workflow_exposes_stt_segments_with_speaker_after_diarize(monkeypatch, t
     assert "stt_segments" in result
     assert result["stt_segments"][0]["speaker"] == "SPEAKER_00"
     assert result["diarize"]["segments"][0]["speaker"] == "SPEAKER_00"
+
+
+def test_workflow_diarization_failure_fallback_keeps_stt_and_disables_speaker(monkeypatch, tmp_path: Path, temp_workflow_dirs):
+    upload_dir = tmp_path / "uploads" / "task-stt-diarize-fallback"
+    upload_dir.mkdir(parents=True)
+    source = upload_dir / "sample.wav"
+    source.write_bytes(b"RIFF")
+
+    def fake_transcribe_audio_files(**kwargs):
+        import json
+
+        output_dir = Path(kwargs["output_dir"])
+        output_dir.mkdir(parents=True, exist_ok=True)
+        markdown_file = output_dir / "sample.md"
+        markdown_file.write_text("# sample\n\n[00:00:00 - 00:00:02] hello", encoding="utf-8")
+        segments_payload = {
+            "segments": [
+                {"start": 0.0, "end": 2.0, "text": "hello", "speaker": "SPEAKER_00"}
+            ]
+        }
+        markdown_file.with_suffix(".segments.json").write_text(json.dumps(segments_payload), encoding="utf-8")
+
+    progress_messages: list[str] = []
+
+    monkeypatch.setattr("sttEngine.http_api.workflow.transcribe_audio_files", fake_transcribe_audio_files)
+    monkeypatch.setattr("sttEngine.http_api.workflow.get_audio_duration", lambda _path: (_ for _ in ()).throw(TimeoutError("diarization timeout after 30s")))
+    monkeypatch.setattr("sttEngine.http_api.workflow.update_task_progress", lambda _task_id, message, **_kwargs: progress_messages.append(message))
+    monkeypatch.setattr("sttEngine.http_api.workflow.clear_task_progress", lambda _id: None)
+    monkeypatch.setattr("sttEngine.http_api.workflow.is_task_cancelled", lambda _id: False)
+
+    result = run_workflow(source, ["stt", "diarize"], task_id="task-stt-diarize-fallback")
+
+    assert "stt" in result
+    assert result["diarize"]["status"] == "failed"
+    assert result["diarize"]["error_code"] == "diarization_timeout"
+    assert result["failed_step"] == "diarize"
+    assert result["error_code"] == "diarization_timeout"
+    assert result["stt_segments"][0]["speaker"] is None
+    assert "화자 분리 실패(화자 라벨 비활성화)" in progress_messages
+    assert "화자 분리 완료" not in progress_messages


### PR DESCRIPTION
### Motivation
- Fix incorrect progress semantics where a diarization fallback was reported as completion instead of failure. 
- Preserve STT output when diarization fails after STT has produced results so users retain transcriptions. 
- Make frontend/type contracts aware of diarization-level failures by exposing `failed` status and standard error fields.

### Description
- Update `sttEngine/http_api/workflow.py` to map diarization exceptions to a `results["diarize"]` payload with `status: "failed"` and include standard error fields (`error`, `error_code`, `retryable`, `failed_step`) while preserving top-level error metadata for UI error cards. 
- Add `allow_null_speaker` to `apply_diarization_alignment_if_available()` and call it on fallback to produce `stt_segments` where `speaker` is set to `null` when diarization fails. 
- Change progress reporting in `run_workflow` to emit `화자 분리 실패(화자 라벨 비활성화)` when diarization falls back and avoid emitting the completion message in that case. 
- Update frontend types in `frontend/src/api/types.ts` to allow `DiarizeResult.status` = `'failed'` and to include optional diarization-level fields `error`, `error_code`, `retryable`, and `failed_step`. 
- Add/extend tests in `tests/http_api/test_workflow.py` to verify STT preservation, `speaker: null` behavior, proper error metadata, and correct progress messages on diarization failure fallback. 
- Sync documentation in `README.md` and `AGENTS.md` to describe the diarization failure fallback contract and nullable speaker labels.

### Testing
- Ran the targeted Python test suite with `pytest tests/http_api/test_workflow.py tests/http_api/test_search.py tests/server/test_queue.py tests/test_vocab_system.py -q` and all tests passed (`18 passed`). 
- Built the frontend with `cd frontend && npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699668081e78832eaafe5ffe44ae3fa8)