### PR TITLE
Improve dark-mode contrast for similarity graph selected document details

### DIFF
--- a/frontend/src/components/SimilarityGraphPanel.tsx
+++ b/frontend/src/components/SimilarityGraphPanel.tsx
@@ -78,6 +78,9 @@ export function SimilarityGraphPanel() {
     () => nodes.find((node) => node.id === selectedNodeId) ?? null,
     [nodes, selectedNodeId],
   );
+  const selectedInfoTextColor = theme === 'dark' ? '#e2e8f0' : '#0f172a';
+  const selectedInfoLabelClass = theme === 'dark' ? 'font-medium text-slate-200' : 'font-medium text-slate-700';
+  const selectedInfoValueClass = theme === 'dark' ? 'text-slate-100' : 'text-slate-900';
 
   const nodeMap = useMemo(() => {
     return new Map(nodes.map((node) => [node.id, node]));
@@ -523,13 +526,16 @@ export function SimilarityGraphPanel() {
           </svg>
 
           {selectedNode && (
-            <aside className={`rounded-xl border p-4 text-sm ${theme === 'dark' ? 'border-slate-800 bg-slate-900/70' : 'border-slate-200 bg-white'}`}>
-              <h3 className="font-semibold mb-2">선택 문서</h3>
+            <aside
+              className={`rounded-xl border p-4 text-sm ${theme === 'dark' ? 'border-slate-800 bg-slate-900/70 text-slate-100' : 'border-slate-200 bg-white text-slate-900'}`}
+              style={{ color: selectedInfoTextColor }}
+            >
+              <h3 className={`mb-2 font-semibold ${theme === 'dark' ? 'text-slate-100' : 'text-slate-900'}`}>선택 문서</h3>
               <div className="space-y-2 break-all">
-                <div><span className="font-medium">이름:</span> {selectedNode.label || selectedNode.id}</div>
-                <div><span className="font-medium">id:</span> {selectedNode.id}</div>
-                <div><span className="font-medium">record:</span> {selectedNode.record_id || '-'}</div>
-                <div><span className="font-medium">업로드:</span> {selectedNode.uploaded_at || '-'}</div>
+                <div className={selectedInfoValueClass}><span className={selectedInfoLabelClass}>이름:</span> {selectedNode.label || selectedNode.id}</div>
+                <div className={selectedInfoValueClass}><span className={selectedInfoLabelClass}>id:</span> {selectedNode.id}</div>
+                <div className={selectedInfoValueClass}><span className={selectedInfoLabelClass}>record:</span> {selectedNode.record_id || '-'}</div>
+                <div className={selectedInfoValueClass}><span className={selectedInfoLabelClass}>업로드:</span> {selectedNode.uploaded_at || '-'}</div>
               </div>
               <Button
                 className="mt-4 w-full gap-2"


### PR DESCRIPTION
### Motivation
- Fix unreadable metadata in the similarity graph's selected-document aside by ensuring explicit, theme-aware text colors so fields remain legible in dark mode.

### Description
- Add `selectedInfoTextColor`, `selectedInfoLabelClass`, and `selectedInfoValueClass` and use them in `frontend/src/components/SimilarityGraphPanel.tsx` to separate label/value tones per theme.
- Apply a fallback inline style `style={{ color: selectedInfoTextColor }}` and update the header and field markup to use the new theme-aware classes so both dark and light modes have sufficient contrast.

### Testing
- Ran `cd frontend && npm run build`, which completed successfully.
- Launched the dev server and attempted an automated Playwright screenshot for visual verification, but the Playwright run failed with `ERR_EMPTY_RESPONSE` when connecting to `http://localhost:4173`, so the screenshot could not be captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69969a9fd4c4832ebb135cbee65258ac)