### PR TITLE
fix: handle encoded/decoded endpoint aliases for adjacent highlighting

### DIFF
--- a/frontend/src/components/SimilarityGraphPanel.tsx
+++ b/frontend/src/components/SimilarityGraphPanel.tsx
@@ -32,6 +32,11 @@ const INITIAL_ALPHA = 1;
 const ALPHA_DECAY = 0.985;
 const MIN_ALPHA = 0.03;
 const DRAG_CLICK_THRESHOLD = 4;
+const SELECTED_NODE_FILL = '#f59e0b';
+const SELECTED_NODE_STROKE = '#fde68a';
+const ADJACENT_NODE_FILL = '#fb923c';
+const ADJACENT_NODE_STROKE = '#ffedd5';
+const ADJACENT_EDGE_STROKE = '#f97316';
 
 type DocType = 'audio' | 'document' | 'other';
 
@@ -78,6 +83,51 @@ export function SimilarityGraphPanel() {
     () => nodes.find((node) => node.id === selectedNodeId) ?? null,
     [nodes, selectedNodeId],
   );
+  const resolveGraphNodeKeys = useCallback((node: Pick<SimNode, 'id' | 'record_id' | 'file'>) => {
+    const keys = new Set<string>();
+    const candidates = [node.id, node.record_id, node.file];
+    for (const raw of candidates) {
+      if (!raw) continue;
+      const value = String(raw).trim();
+      if (!value) continue;
+      keys.add(value);
+      keys.add(encodeURIComponent(value));
+      try {
+        const decoded = decodeURIComponent(value);
+        keys.add(decoded);
+        keys.add(encodeURIComponent(decoded));
+      } catch {
+        // noop: keep original/encoded values only.
+      }
+    }
+    return keys;
+  }, []);
+  const graphNodeIdByEndpoint = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const node of nodes) {
+      const keys = resolveGraphNodeKeys(node);
+      for (const key of keys) map.set(key, node.id);
+    }
+    return map;
+  }, [nodes, resolveGraphNodeKeys]);
+  const selectedGraphKeys = useMemo(() => {
+    if (!selectedNode) return new Set<string>();
+    return resolveGraphNodeKeys(selectedNode);
+  }, [resolveGraphNodeKeys, selectedNode]);
+  const adjacentNodeIds = useMemo(() => {
+    if (!selectedNodeId || selectedGraphKeys.size === 0) return new Set<string>();
+    const neighbors = new Set<string>();
+    for (const edge of graph?.edges ?? []) {
+      const sourceNodeId = graphNodeIdByEndpoint.get(edge.source) ?? edge.source;
+      const targetNodeId = graphNodeIdByEndpoint.get(edge.target) ?? edge.target;
+      const sourceMatched = selectedGraphKeys.has(edge.source) || sourceNodeId === selectedNodeId;
+      const targetMatched = selectedGraphKeys.has(edge.target) || targetNodeId === selectedNodeId;
+      if (sourceMatched) neighbors.add(targetNodeId);
+      if (targetMatched) neighbors.add(sourceNodeId);
+    }
+    neighbors.delete(selectedNodeId);
+    return neighbors;
+  }, [graph?.edges, graphNodeIdByEndpoint, selectedGraphKeys, selectedNodeId]);
   const selectedInfoTextColor = theme === 'dark' ? '#e2e8f0' : '#0f172a';
   const selectedInfoLabelClass = theme === 'dark' ? 'font-medium text-slate-200' : 'font-medium text-slate-700';
   const selectedInfoValueClass = theme === 'dark' ? 'text-slate-100' : 'text-slate-900';
@@ -443,6 +493,8 @@ export function SimilarityGraphPanel() {
               <span className="inline-flex items-center gap-1"><span className="size-2 rounded-full bg-sky-400" />audio</span>
               <span className="inline-flex items-center gap-1"><span className="size-2 rounded-full bg-emerald-400" />document</span>
               <span className="inline-flex items-center gap-1"><span className="size-2 rounded-full bg-violet-400" />other</span>
+              <span className="inline-flex items-center gap-1"><span className="size-2 rounded-full" style={{ backgroundColor: SELECTED_NODE_FILL }} />selected</span>
+              <span className="inline-flex items-center gap-1"><span className="size-2 rounded-full" style={{ backgroundColor: ADJACENT_NODE_FILL }} />adjacent</span>
             </div>
             <div className="flex items-center gap-2">
               <span className="font-medium">edge weight</span>
@@ -473,6 +525,17 @@ export function SimilarityGraphPanel() {
                 const source = nodeMap.get(edge.source);
                 const target = nodeMap.get(edge.target);
                 if (!source || !target) return null;
+                const sourceNodeId = graphNodeIdByEndpoint.get(edge.source) ?? edge.source;
+                const targetNodeId = graphNodeIdByEndpoint.get(edge.target) ?? edge.target;
+                const isAdjacentEdge = Boolean(
+                  selectedNodeId
+                  && (
+                    selectedGraphKeys.has(edge.source)
+                    || selectedGraphKeys.has(edge.target)
+                    || sourceNodeId === selectedNodeId
+                    || targetNodeId === selectedNodeId
+                  ),
+                );
                 return (
                   <line
                     key={`${edge.source}-${edge.target}`}
@@ -480,24 +543,25 @@ export function SimilarityGraphPanel() {
                     y1={source.y}
                     x2={target.x}
                     y2={target.y}
-                    stroke={theme === 'dark' ? '#334155' : '#94a3b8'}
-                    strokeOpacity={edgeOpacity(edge)}
-                    strokeWidth={edgeWidth(edge)}
+                    stroke={isAdjacentEdge ? ADJACENT_EDGE_STROKE : theme === 'dark' ? '#334155' : '#94a3b8'}
+                    strokeOpacity={isAdjacentEdge ? 0.95 : edgeOpacity(edge)}
+                    strokeWidth={isAdjacentEdge ? edgeWidth(edge) + 1.6 : edgeWidth(edge)}
                   />
                 );
               })}
               {nodes.map((node) => {
                 const selected = node.id === selectedNodeId;
+                const adjacent = adjacentNodeIds.has(node.id);
                 const style = getNodeStyle(node);
                 return (
                   <g key={node.id}>
                     <circle
                       cx={node.x}
                       cy={node.y}
-                      r={selected ? style.radius + 2 : style.radius}
-                      fill={selected ? '#f59e0b' : style.fill}
-                      stroke={selected ? '#fde68a' : style.stroke}
-                      strokeWidth={selected ? 2 : 1}
+                      r={selected ? style.radius + 2 : adjacent ? style.radius + 1.2 : style.radius}
+                      fill={selected ? SELECTED_NODE_FILL : adjacent ? ADJACENT_NODE_FILL : style.fill}
+                      stroke={selected ? SELECTED_NODE_STROKE : adjacent ? ADJACENT_NODE_STROKE : style.stroke}
+                      strokeWidth={selected ? 2 : adjacent ? 1.8 : 1}
                       onPointerDown={(event) => startNodeDrag(event, node.id)}
                       onClick={(event) => {
                         event.stopPropagation();


### PR DESCRIPTION
### Motivation
- Adjacent-node/edge highlighting could fail when an edge's `source`/`target` used a URL-encoded or decoded form that did not exactly match a node `id`, causing visual adjacency to be missed.
- The change aims to make endpoint-to-node matching resilient to common alternate representations (original, URL-encoded, and decoded(+re-encoded)) so adjacency highlights are reliable.

### Description
- Enhanced the endpoint alias key generation in `frontend/src/components/SimilarityGraphPanel.tsx` by expanding `resolveGraphNodeKeys` to register `value`, `encodeURIComponent(value)`, decoded `value`, and `encodeURIComponent(decoded)` for each candidate (`id`, `record_id`, `file`).
- Built a canonical lookup `graphNodeIdByEndpoint` from those keys and switched adjacency computations to use the alias-aware mapping (`graphNodeIdByEndpoint`) and `selectedGraphKeys` to derive `adjacentNodeIds`.
- Applied alias-aware adjacent styling to edges and nodes (added `ADJACENT_EDGE_STROKE`, `SELECTED_NODE_FILL`, `ADJACENT_NODE_FILL`, etc.) and added simple legend chips to indicate `selected` and `adjacent` states.

### Testing
- Ran a production frontend build with `cd frontend && npm run build` and the build completed successfully.
- Launched a local preview with `cd frontend && npm run preview -- --host 0.0.0.0 --port 4173` and the preview started successfully.
- Captured a full-page screenshot with a Playwright script against the preview to verify legend and adjacent highlighting behavior, and the capture completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996a22a36fc832e99b4501af12bbebc)