### PR TITLE
Frontend Nginx /api & /ws proxy defaults and WS fallback; sync compose and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,9 @@
   - `ThreadingHTTPServer` + `UploadHandler`
   - WebSocket 서버는 별도 스레드에서 실행 (`sttEngine/http_api/ws.py`, 포트 `8765`)
 - 런처 래퍼: `sttEngine/server.py` (`python -m sttEngine.server`)
+- Docker 분리 이미지:
+  - 백엔드: `Dockerfile.backend`
+  - 프론트엔드: `Dockerfile.frontend`
 - 핵심 HTTP 라우팅: `sttEngine/http_api/handler.py` + 라우트 모듈(`sttEngine/http_api/routes/*`)
   - 파일/정적 서빙: `sttEngine/http_api/routes/file_routes.py`
   - 유사문서 응답 조합: `sttEngine/http_api/routes/similar_documents.py`
@@ -37,10 +40,12 @@
 - `.env`의 `LLM_PROVIDER`/`EMBEDDING_PROVIDER`가 `ollama`가 아니면 setup/run 스크립트의 Ollama 점검 단계는 자동 skip
 - 프론트 빌드: `cd frontend && npm install && npm run build`
 
-Docker Compose provider profile:
-- 앱 단독: `docker compose up -d --build`
+Docker Compose provider profile(분리 배포):
+- 기본(backend + frontend): `docker compose up -d --build`
 - Ollama 포함: `docker compose --profile ollama up -d --build`
 - llama.cpp 포함: `docker compose --profile llamacpp up -d --build`
+- 프론트 접속: `http://localhost:3000`, 백엔드 API: `http://localhost:8080`, WebSocket: `ws://localhost:8765`
+- 프론트 컨테이너(Nginx)는 `/api` -> backend(8080), `/ws` -> backend WebSocket(8765) 프록시를 기본 제공
 
 ## 3. 데이터/경로 규칙
 - DB 루트는 `DB_FOLDER_PATH` 환경변수 우선, 없으면 프로젝트 루트의 `DB/`
@@ -54,7 +59,7 @@ Docker Compose provider profile:
 ## 4. API 계약 (현재 코드 기준)
 
 GET
-- `/`, `/assets/*`, `/download/<uuid_or_path>`
+- `/`, `/assets/*`, `/download/<uuid_or_path>`, `/health`
 - `/history`, `/tasks`, `/progress/<task_id>` (진행률 %, ETA, 표준 오류 payload 포함)
 - `/segments/<file_identifier>` (STT 세그먼트 sidecar를 읽어 `[{start,end,text,speaker}]` 반환, 없으면 빈 배열)
 - `/file_search`, `/search`

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,28 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    curl \
+    ffmpeg \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY sttEngine/requirements.txt /tmp/stt-requirements.txt
+COPY requirements.txt /tmp/root-requirements.txt
+
+RUN python -m pip install --upgrade pip \
+    && pip install -r /tmp/stt-requirements.txt \
+    && if [ -s /tmp/root-requirements.txt ]; then pip install -r /tmp/root-requirements.txt; fi
+
+COPY . /app
+RUN chmod +x /app/docker/entrypoint.sh
+
+EXPOSE 8080 8765
+
+ENTRYPOINT ["/app/docker/entrypoint.sh"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,20 @@
+FROM node:20-alpine AS build
+WORKDIR /app/frontend
+
+COPY frontend/package*.json ./
+RUN npm ci
+
+COPY frontend/ ./
+
+ARG VITE_API_BASE_URL=
+ARG VITE_WS_URL=
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+ENV VITE_WS_URL=$VITE_WS_URL
+
+RUN npm run build
+
+FROM nginx:1.27-alpine
+COPY docker/frontend/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/frontend/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,38 @@ run.bat
 
 ## 2) 수동 설치
 
+## 2-A) Docker 분리 배포 (backend + frontend)
+
+```bash
+docker compose up -d --build
+```
+
+프로필 사용:
+```bash
+# Ollama 포함
+docker compose --profile ollama up -d --build
+
+# llama.cpp 포함
+docker compose --profile llamacpp up -d --build
+```
+
+기본 포트:
+- 프론트엔드: `http://localhost:3000`
+- 백엔드 API: `http://localhost:8080`
+- WebSocket: `ws://localhost:8765`
+
+프론트 빌드 변수(Compose build args):
+- `VITE_API_BASE_URL` (기본 `/api`, 프론트 Nginx가 backend:8080으로 프록시)
+- `VITE_WS_URL` (기본 비움. 비어 있으면 브라우저 origin 기준 `/ws` 사용)
+
+백엔드 헬스체크:
+- `GET /health` → `{ "status": "ok" }`
+
+프론트 Nginx 프록시 경로:
+- `/api/*` -> `backend:8080/*`
+- `/ws` -> `backend:8765` (WebSocket 업그레이드)
+
+
 ### Python 가상환경 + 의존성 설치
 macOS/Linux:
 ```bash
@@ -56,8 +88,9 @@ venv\Scripts\python.exe -m sttEngine.server
 ```
 
 기본 접속 주소:
-- HTTP: `http://localhost:8080`
+- HTTP(API): `http://localhost:8080`
 - WebSocket: `ws://localhost:8765`
+- (Docker 분리 배포) Frontend: `http://localhost:3000`
 - Windows `run.bat` 실행 시 `8080` 바인딩이 불가하면 자동으로 `18080`으로 대체됩니다.
 
 ## 3) 모델/Provider 설정 방법

--- a/TODO/DOCKER_OPENAPI_DEPLOY_PLAN.md
+++ b/TODO/DOCKER_OPENAPI_DEPLOY_PLAN.md
@@ -79,14 +79,14 @@
 ### RTD 기준 미완료 작업 요약 (즉시 실행 큐)
 
 #### P0 (즉시)
-- [ ] `openapi/openapi.yaml` 신규 작성 및 핵심 5개 API 명세 반영
-- [ ] `Dockerfile.backend` + `Dockerfile.frontend` 분리
-- [ ] `docker-compose.yml`을 `backend`/`frontend` 2서비스 구조로 전환
+- [x] `openapi/openapi.yaml` 신규 작성 및 핵심 5개 API 명세 반영
+- [x] `Dockerfile.backend` + `Dockerfile.frontend` 분리
+- [x] `docker-compose.yml`을 `backend`/`frontend` 2서비스 구조로 전환
 
 #### P1 (안정화)
-- [ ] `GET /health` 구현 및 compose healthcheck 연결
-- [ ] `frontend/src/api/client.ts`에 `VITE_API_BASE_URL` 적용
-- [ ] `frontend/src/hooks/useWebSocket.ts`에 `VITE_WS_URL` 적용
+- [x] `GET /health` 구현 및 compose healthcheck 연결
+- [x] `frontend/src/api/client.ts`에 `VITE_API_BASE_URL` 적용
+- [x] `frontend/src/hooks/useWebSocket.ts`에 `VITE_WS_URL` 적용
 
 #### P2 (운영 고도화)
 - [ ] OpenAPI 기반 타입 생성/Contract Test 도입 검토
@@ -105,7 +105,7 @@
   - Docker/Compose 실행 경로, provider profile(`ollama`, `llamacpp`), 볼륨(`./DB:/data/DB`)은 이미 존재.
 
 ### 산출물 체크리스트 (실구현 반영)
-- [ ] `openapi/openapi.yaml`
+- [x] `openapi/openapi.yaml`
 - [ ] `Dockerfile.backend` (현재는 통합 `Dockerfile`만 존재)
 - [ ] `Dockerfile.frontend`
 - [x] `docker-compose.yml` (단, 백엔드/프론트 분리 구조는 아님)
@@ -116,7 +116,7 @@
 ## 작업 방향 TODO (우선순위 체크박스)
 
 ### P0 — 계약/구조 분리 착수
-- [ ] `openapi/openapi.yaml` 초안 작성
+- [x] `openapi/openapi.yaml` 초안 작성
   - [ ] `POST /process`, `GET /progress/{task_id}`, `GET /history`, `GET /search`, `POST /delete_records`(현행 API 기준) 명세 반영
   - [ ] 공통 에러 스키마(`error`, `error_code`, `retryable`, `failed_step`) 반영
   - [ ] WebSocket(`ws://<host>:8765`)은 별도 섹션(또는 AsyncAPI 링크)으로 문서화
@@ -262,7 +262,7 @@
 ## 작업 방향 TODO (우선순위 체크박스)
 
 ### P0 — 계약 고정 + 서비스 분리 골격
-- [ ] `openapi/openapi.yaml` 초안 작성
+- [x] `openapi/openapi.yaml` 초안 작성
   - [ ] `POST /process`, `GET /progress/{task_id}`, `GET /history`, `GET /search`, `POST /delete_records` 명세
   - [ ] 공통 오류 필드(`error`, `error_code`, `retryable`, `failed_step`) 반영
   - [ ] WS(8765) 별도 문서(또는 AsyncAPI) 링크 추가
@@ -277,7 +277,7 @@
   - [ ] `frontend/src/api/client.ts` 상대 경로 호출 정리
 - [ ] 프론트 WS URL 환경변수화
   - [ ] `frontend/src/hooks/useWebSocket.ts`의 `:8765` 하드코딩 제거
-- [ ] Reverse proxy(`/api`, `/ws`) 운영 템플릿(Nginx 등) 문서화
+- [x] Reverse proxy(`/api`, `/ws`) 운영 템플릿(Nginx 등) 문서화
 
 ### P2 — 계약 검증/운영 고도화
 - [ ] OpenAPI 기반 타입/클라이언트 생성 도입 여부 결정 + PoC
@@ -298,7 +298,7 @@
   - 대응: CI에서 스펙 검증 + 샘플 응답 검증 추가
 
 ## 산출물 체크리스트 (최신 상태 반영)
-- [ ] `openapi/openapi.yaml`
+- [x] `openapi/openapi.yaml`
 - [ ] `Dockerfile.backend`
 - [ ] `Dockerfile.frontend`
 - [x] `docker-compose.yml` (현재는 단일 앱 서비스 구조)

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -1,5 +1,5 @@
 services:
-  recordroute:
+  backend:
     gpus: all
     environment:
       WORKFLOW_DEVICE: auto

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,13 @@
 services:
-  recordroute:
+  backend:
     build:
       context: .
-      dockerfile: Dockerfile
-    image: recordroute:latest
-    container_name: recordroute
+      dockerfile: Dockerfile.backend
+    image: recordroute-backend:latest
+    container_name: recordroute-backend
     ports:
       - "8080:8080"
+      - "8765:8765"
     environment:
       HOST: 0.0.0.0
       PORT: 8080
@@ -19,6 +20,27 @@ services:
       EMBEDDING_BASE_URL: ${EMBEDDING_BASE_URL:-http://llamacpp:8081}
     volumes:
       - ./DB:/data/DB
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+      args:
+        VITE_API_BASE_URL: ${VITE_API_BASE_URL:-/api}
+        VITE_WS_URL: ${VITE_WS_URL:-}
+    image: recordroute-frontend:latest
+    container_name: recordroute-frontend
+    ports:
+      - "3000:80"
+    depends_on:
+      backend:
+        condition: service_healthy
 
   ollama:
     image: ollama/ollama:latest

--- a/docker/frontend/nginx.conf
+++ b/docker/frontend/nginx.conf
@@ -1,0 +1,28 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location /api/ {
+    proxy_pass http://backend:8080/;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location /ws {
+    proxy_pass http://backend:8765;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+  }
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -22,6 +22,14 @@ interface ApiRequestOptions extends RequestInit {
 }
 
 
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined)?.trim().replace(/\/$/, '') ?? '';
+
+function withApiBase(path: string): string {
+  if (!path.startsWith('/')) return path;
+  return API_BASE_URL ? `${API_BASE_URL}${path}` : path;
+}
+
+
 function buildDestructiveApiAuthOptions(auth?: DestructiveApiAuth): { headers?: Record<string, string>; body?: Record<string, string> } {
   if (!auth) return {};
 
@@ -49,7 +57,8 @@ function buildDestructiveApiAuthOptions(auth?: DestructiveApiAuth): { headers?: 
 
 async function apiRequest<T>(input: RequestInfo | URL, init: ApiRequestOptions = {}): Promise<T> {
   const { skipJson, ...requestInit } = init;
-  const res = await fetch(input, requestInit);
+  const requestInput = typeof input === 'string' ? withApiBase(input) : input;
+  const res = await fetch(requestInput, requestInit);
   if (!res.ok) {
     const body = await res.text().catch(() => '');
     throw new Error(body || `API request failed (${res.status})`);
@@ -224,7 +233,7 @@ export async function deleteFile(fileIdentifier: string, fileType: ViewerFileTyp
   });
 }
 
-export const getDownloadUrl = (fileIdentifier: string): string => `/download/${encodeURIComponent(fileIdentifier)}`;
+export const getDownloadUrl = (fileIdentifier: string): string => withApiBase(`/download/${encodeURIComponent(fileIdentifier)}`);
 
 export const getModels = (provider?: 'ollama' | 'llamacpp') => {
   const query = provider ? `?provider=${encodeURIComponent(provider)}` : '';

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+  readonly VITE_WS_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -15,7 +15,10 @@ export function useWebSocket(onMessage: MessageHandler) {
   const connect = useCallback(() => {
     try {
       const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-      const wsUrl = `${protocol}//${window.location.hostname}:8765`;
+      const configuredWsUrl = (import.meta.env.VITE_WS_URL as string | undefined)?.trim();
+      const wsUrl = configuredWsUrl && configuredWsUrl.length > 0
+        ? configuredWsUrl
+        : `${protocol}//${window.location.host}/ws`;
       const ws = new WebSocket(wsUrl);
 
       ws.onopen = () => {

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,0 +1,304 @@
+openapi: 3.0.3
+info:
+  title: RecordRoute API
+  version: 0.1.0
+  description: |
+    RecordRoute 백엔드 API 계약 문서 초안입니다.
+servers:
+  - url: http://localhost:8080
+paths:
+  /health:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: Server is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+                required: [status]
+  /process:
+    post:
+      summary: Start workflow processing
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProcessRequest'
+      responses:
+        '200':
+          description: Workflow accepted/executed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProcessResponse'
+        '400':
+          $ref: '#/components/responses/Error400'
+        '500':
+          $ref: '#/components/responses/Error500'
+  /progress/{task_id}:
+    get:
+      summary: Get workflow progress for task
+      parameters:
+        - in: path
+          name: task_id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Task progress payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskProgress'
+        '404':
+          $ref: '#/components/responses/Error404'
+        '500':
+          $ref: '#/components/responses/Error500'
+  /history:
+    get:
+      summary: Get upload and workflow history
+      responses:
+        '200':
+          description: History list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HistoryItem'
+        '500':
+          $ref: '#/components/responses/Error500'
+  /search:
+    get:
+      summary: Search by keyword/vector
+      parameters:
+        - in: query
+          name: query
+          schema:
+            type: string
+        - in: query
+          name: sort_by
+          schema:
+            type: string
+            enum: [similarity, date, uploaded_at]
+        - in: query
+          name: sort_order
+          schema:
+            type: string
+            enum: [asc, desc]
+        - in: query
+          name: min_score
+          schema:
+            type: number
+            minimum: 0
+            maximum: 1
+      responses:
+        '200':
+          description: Search response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchResponse'
+        '500':
+          $ref: '#/components/responses/Error500'
+  /delete_records:
+    post:
+      summary: Delete records (destructive)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                record_ids:
+                  type: array
+                  items:
+                    type: string
+              required: [record_ids]
+      responses:
+        '200':
+          description: All records deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  results:
+                    type: array
+                    items:
+                      type: object
+                required: [success, results]
+        '207':
+          description: Partial deletion success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  results:
+                    type: array
+                    items:
+                      type: object
+                required: [success, results]
+        '400':
+          $ref: '#/components/responses/Error400'
+        '403':
+          $ref: '#/components/responses/Error403'
+        '500':
+          $ref: '#/components/responses/Error500'
+components:
+  schemas:
+    ProcessRequest:
+      type: object
+      properties:
+        file_path:
+          type: string
+          example: DB/uploads/uuid/sample.m4a
+        steps:
+          type: array
+          items:
+            type: string
+            enum: [stt, correct, summary, summarize, diarize]
+        record_id:
+          type: string
+        task_id:
+          type: string
+        model_settings:
+          type: object
+          additionalProperties: true
+      required: [file_path, steps]
+    ProcessResponse:
+      type: object
+      properties:
+        task_id:
+          type: string
+        retry_mode:
+          type: string
+        retry_of_task_id:
+          type: string
+          nullable: true
+        error:
+          type: string
+          nullable: true
+        error_code:
+          type: string
+          nullable: true
+        retryable:
+          type: boolean
+          nullable: true
+        failed_step:
+          type: string
+          nullable: true
+      additionalProperties: true
+    TaskProgress:
+      type: object
+      properties:
+        task_id:
+          type: string
+        message:
+          type: string
+        stage:
+          type: string
+          nullable: true
+        progress_percent:
+          type: number
+          nullable: true
+        eta_seconds:
+          type: number
+          nullable: true
+        error:
+          type: object
+          nullable: true
+          additionalProperties: true
+      additionalProperties: true
+    HistoryItem:
+      type: object
+      properties:
+        id:
+          type: string
+        filename:
+          type: string
+        uploaded_at:
+          type: string
+        status:
+          type: object
+          additionalProperties: true
+      additionalProperties: true
+    SearchResponse:
+      type: object
+      properties:
+        contract_version:
+          type: string
+          example: search-v2
+        query:
+          type: string
+        similarDocuments:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        keywordMatches:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        sort:
+          type: object
+          additionalProperties: true
+        filters:
+          type: object
+          additionalProperties: true
+      additionalProperties: true
+    ErrorResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: false
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+          required: [code, message]
+      required: [success, error]
+  responses:
+    Error400:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Error403:
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Error404:
+      description: Not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Error500:
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'

--- a/sttEngine/http_api/routes/management_routes.py
+++ b/sttEngine/http_api/routes/management_routes.py
@@ -29,6 +29,13 @@ def _serve_running_tasks(handler) -> None:
 
 
 def handle_get(handler) -> bool:
+    if handler.path == '/health':
+        handler.send_response(200)
+        handler.send_header('Content-Type', 'application/json')
+        handler.end_headers()
+        handler.wfile.write(json.dumps({'status': 'ok'}).encode())
+        return True
+
     if handler.path == '/tasks':
         _serve_running_tasks(handler)
         return True

--- a/tests/http_api/test_monitoring.py
+++ b/tests/http_api/test_monitoring.py
@@ -65,3 +65,14 @@ def test_workflow_metrics_route_returns_snapshot(dummy_handler_factory, monkeypa
     assert handled is True
     assert handler.status_code == 200
     assert _body(handler)["steps"]["stt"]["runs"] == 3
+
+
+def test_health_route_returns_ok(dummy_handler_factory):
+    handler = dummy_handler_factory({})
+    handler.path = '/health'
+
+    handled = management_routes.handle_get(handler)
+
+    assert handled is True
+    assert handler.status_code == 200
+    assert _body(handler) == {'status': 'ok'}


### PR DESCRIPTION
### Motivation
- Prevent the frontend from baking a container-internal backend host into the built assets by making `/api` and `/ws` the default runtime proxy targets. 
- Ensure browser runtime connects to the backend via the same-origin proxy when available so WebSocket connections work consistently across containerized and non-containerized deployments. 
- Keep documentation and deployment defaults consistent with the proxy strategy so Compose/Nginx behavior is clear to operators. 

### Description
- Added an Nginx proxy config at `docker/frontend/nginx.conf` that routes `/api/*` -> `backend:8080/*` and `/ws` -> `backend:8765` (with WebSocket upgrade headers) while preserving SPA fallback. 
- Changed `docker-compose.yml` to a two-service layout (`backend` + `frontend`), exposed backend WebSocket port `8765`, added a `healthcheck` for `backend`, and set frontend build args defaults `VITE_API_BASE_URL=/api` and `VITE_WS_URL=`. 
- Updated frontend runtime behavior by modifying `frontend/src/hooks/useWebSocket.ts` to use `VITE_WS_URL` when provided and otherwise fall back to `ws(s)://<current-host>/ws`, and added API base handling in `frontend/src/api/client.ts` with `VITE_API_BASE_URL` + `withApiBase()` so fetches are routed via the proxy when configured. 
- Added Type declarations `frontend/src/env.d.ts` and synchronized docs (`README.md`, `AGENTS.md`, `TODO/DOCKER_OPENAPI_DEPLOY_PLAN.md`) to reflect the proxy defaults and updated compose behavior. 

### Testing
- Ran `pytest tests/http_api/test_monitoring.py tests/http_api/test_search.py` and all collected tests passed (`7 passed`). 
- Built the frontend with `cd frontend && npm run build` and the production build completed successfully. 
- Verified the added health test `tests/http_api/test_monitoring.py::test_health_route_returns_ok` passes as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997cf48c3a0832ea8b549f146335e7a)