### PR TITLE
llama.cpp: in-process llama-cpp-python provider integration, runtime docs and env samples updated

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,8 @@
 # Supported: ollama, llamacpp (llama_cpp alias 지원)
 # LLM_PROVIDER=ollama
 
-# Optional OpenAI-compatible base URL for provider endpoints.
-# llama.cpp server 사용 시 지정하세요.
+# Legacy external endpoint URL (kept for backward compatibility).
+# llama-cpp-python in-process 모드에서는 무시됩니다.
 # LLM_BASE_URL=http://localhost:8081
 
 # Embedding provider selection (unset 시 LLM_PROVIDER 상속).
@@ -21,12 +21,22 @@
 # Legacy Ollama endpoint (deprecated: provider별 설정으로 전환 권장)
 # OLLAMA_BASE_URL=http://localhost:11434
 
-# llama.cpp CLI/server settings
+# llama.cpp in-process settings
+# Default model path: ./models/default_model.gguf
+# LLAMA_CPP_MODEL_PATH=./models/default_model.gguf
+# Optional tuning
+# LLAMA_CPP_N_CTX=8192
+# LLAMA_CPP_N_THREADS=8
+# LLAMA_CPP_N_BATCH=512
+# LLAMA_CPP_N_GPU_LAYERS=35
+# LLAMA_CPP_CHAT_FORMAT=chatml
+# Legacy variable (ignored in in-process mode)
 # LLAMA_CPP_COMMAND=llama-cli
-# LLAMA_CPP_MODEL_PATH=/models/your-model.gguf
+# Legacy timeout variable (ignored in in-process mode)
 # LLAMA_CPP_TIMEOUT=300
 
 # Common LLM timeout seconds (미설정 시 OLLAMA_TIMEOUT fallback)
+# llama-cpp-python in-process 모드에서는 provider timeout 인자를 사용하지 않아 사실상 무시됩니다.
 # LLM_TIMEOUT=300
 
 # --- Model Configuration (Windows) ---
@@ -46,9 +56,9 @@
 # EMBEDDING_MAX_PROMPT_CHARS=7500
 # Fallback embedding model if platform specific one isn't found
 # EMBEDDING_MODEL=bge-m3:latest
-# llama.cpp/OpenAI-compatible embedding endpoint base URL
+# Legacy embedding endpoint base URL (in-process 모드에서는 무시됨)
 # EMBEDDING_BASE_URL=http://localhost:8081
-# Embedding provider request timeout seconds
+# Legacy embedding timeout (in-process 모드에서는 무시됨)
 # EMBEDDING_TIMEOUT=300
 
 # --- Cloudflare Tunnel Configuration ---

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ DB
 frontend/node_modules/
 frontend/dist/
 frontend/tsconfig.tsbuildinfo
+# Local llama.cpp model assets
+models/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,8 @@
 개별 실행:
 - 백엔드: `venv/bin/python -m sttEngine.server` (Windows: `venv\\Scripts\\python.exe -m sttEngine.server`)
 - Ollama provider 사용 시 추가 의존성: `pip install -r requirements-ollama.txt`
+- llama.cpp provider는 `llama-cpp-python` in-process 모드를 사용하며, `LLAMA_CPP_MODEL_PATH` 기본값은 `./models/default_model.gguf`
+- `LLM_BASE_URL`/`EMBEDDING_BASE_URL`/`LLAMA_CPP_COMMAND`는 하위 호환용으로 남아 있으나 in-process 모드에서 무시됨
 - `.env`의 `LLM_PROVIDER`/`EMBEDDING_PROVIDER`가 `ollama`가 아니면 setup/run 스크립트의 Ollama 점검 단계는 자동 skip
 - 프론트 빌드: `cd frontend && npm install && npm run build`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,3 +30,6 @@
 - 서버 엔트리는 `sttEngine/http_api/app.py`이며, `sttEngine/server.py`는 래퍼입니다.
 - 프론트 주 코드베이스는 `frontend/src`입니다. `frontend/legacy`는 fallback 용도입니다.
 - API/스키마 변경 시 `AGENTS.md`도 함께 갱신해 문서와 코드 드리프트를 막습니다.
+
+- llama.cpp provider는 `llama-cpp-python` in-process 모드가 기본입니다.
+- `LLAMA_CPP_MODEL_PATH` 기본값은 `./models/default_model.gguf`이며, `LLM_BASE_URL`/`EMBEDDING_BASE_URL`/`LLAMA_CPP_COMMAND`는 하위 호환용으로만 유지됩니다.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -26,3 +26,6 @@
 
 - `pytest tests/http_api/test_workflow.py tests/http_api/test_search.py tests/server/test_queue.py tests/test_vocab_system.py`
 - UI 변경 시: `cd frontend && npm run build`
+
+- llama.cpp provider는 `llama-cpp-python` in-process 모드를 기본으로 사용합니다.
+- `LLAMA_CPP_MODEL_PATH` 기본값은 `./models/default_model.gguf`이며, 기존 HTTP/CLI 관련 환경 변수는 하위 호환용으로 유지됩니다.

--- a/README.md
+++ b/README.md
@@ -107,12 +107,11 @@ venv\Scripts\python.exe -m sttEngine.server
 2. 사용할 모델 pull (예: `gpt-oss:20b`)
 3. 필요 시 `.env`에 Ollama 주소/타임아웃 설정
 
-### 3-3. llama.cpp(OpenAI 호환 API) 사용 시
-- `LLM_BASE_URL` (기본 `http://localhost:8081`)
-- `EMBEDDING_BASE_URL` (기본 `http://localhost:8081`)
-- `LLAMA_CPP_MODEL_PATH` (`.gguf` 모델 경로)
-- `LLAMA_CPP_COMMAND` (기본 `llama-cli`)
-- `LLAMA_CPP_TIMEOUT`, `LLM_TIMEOUT`, `EMBEDDING_TIMEOUT`
+### 3-3. llama.cpp(In-process / `llama-cpp-python`) 사용 시
+- `pip install -r requirements.txt`로 `llama-cpp-python`을 함께 설치합니다.
+- `LLAMA_CPP_MODEL_PATH` (`.gguf` 모델 경로, 기본값 `./models/default_model.gguf`)
+- 선택 성능 튜닝: `LLAMA_CPP_N_CTX`, `LLAMA_CPP_N_THREADS`, `LLAMA_CPP_N_BATCH`, `LLAMA_CPP_N_GPU_LAYERS`, `LLAMA_CPP_CHAT_FORMAT`
+- 하위 호환용으로 `LLM_BASE_URL`, `EMBEDDING_BASE_URL`, `LLAMA_CPP_COMMAND`를 남겨둘 수 있으나, in-process 모드에서는 무시되며 warning 로그가 남습니다.
 
 ### 3-4. 워크플로우 모델 키(`model_settings`)
 `/process` 요청 시 주로 아래 키를 사용합니다.

--- a/docs/llama-guide.md
+++ b/docs/llama-guide.md
@@ -1,32 +1,33 @@
-# RecordRoute + llama.cpp 초간단 따라하기
+# RecordRoute + llama.cpp 모델 세팅 가이드 (In-process)
 
-> 목표: **"처음 하는 사람도 그대로 복붙해서"** llama.cpp로 RecordRoute를 실행하도록 안내합니다.
+> 목표: RecordRoute에서 `llama-cpp-python` 기반 **in-process llama.cpp**를 안정적으로 설정하고 검증합니다.
 
 이 가이드는 **로컬 실행(비 Docker)** 기준입니다.
-Docker로 하고 싶으면 맨 아래 "부록"만 보면 됩니다.
 
 ---
 
-## 0) 먼저 알아둘 것 (30초)
+## 0) 핵심 요약
 
-RecordRoute에서 llama.cpp는 보통 2가지를 씁니다.
+RecordRoute의 `llamacpp` provider는 외부 `llama-cli`/`llama-server` 호출이 아니라,
+백엔드 프로세스 내부에서 `llama_cpp.Llama`를 직접 호출합니다.
 
-- **교정/요약 LLM**
-- **임베딩(검색용)**
-
-둘 다 안정적으로 쓰려면, 가장 단순하게 아래처럼 맞추면 됩니다.
+필수 포인트:
 
 - `LLM_PROVIDER=llamacpp`
 - `EMBEDDING_PROVIDER=llamacpp`
-- llama.cpp 서버(`llama-server`)를 `8081`로 실행하고 `--embeddings` 옵션 켜기
+- `LLAMA_CPP_MODEL_PATH` 설정 (미설정 시 기본값 `./models/default_model.gguf`)
+- `pip install -r requirements.txt`로 `llama-cpp-python` 설치
+
+하위 호환용 환경 변수(`LLM_BASE_URL`, `EMBEDDING_BASE_URL`, `LLAMA_CPP_COMMAND`)는
+남겨둘 수 있지만 in-process 모드에서 실제 호출에는 사용되지 않으며 warning 로그만 출력됩니다.
 
 ---
 
 ## 1) 준비물
 
 - RecordRoute 프로젝트
-- `.gguf` 모델 파일 1개
-- `llama-cli`, `llama-server` 실행 가능 환경
+- `.gguf` 모델 파일
+- Python 가상환경 (`venv`) + `requirements.txt` 설치
 
 ### 1-1. 모델 파일 준비
 
@@ -38,25 +39,17 @@ mkdir -p models
 
 `models/` 안에 `.gguf` 파일을 넣으세요. 예:
 
-- `models/model.gguf`
+- `models/default_model.gguf`
 
 ---
 
-## 2) llama.cpp 서버 먼저 실행
-
-아래 명령에서 경로만 본인 환경으로 바꿔서 실행하세요.
+## 2) 의존성 설치
 
 ```bash
-llama-server --host 0.0.0.0 --port 8081 --model /절대경로/models/model.gguf --embeddings
+./venv/bin/python -m pip install -r requirements.txt
 ```
 
-정상 실행되면 다음 체크:
-
-```bash
-curl -s http://localhost:8081/health
-```
-
-응답이 나오면 OK입니다.
+> `llama-cpp-python` 빌드에 시간이 걸릴 수 있습니다.
 
 ---
 
@@ -68,20 +61,25 @@ curl -s http://localhost:8081/health
 LLM_PROVIDER=llamacpp
 EMBEDDING_PROVIDER=llamacpp
 
-LLAMA_CPP_COMMAND=llama-cli
-LLAMA_CPP_MODEL_PATH=/절대경로/models/model.gguf
-LLAMA_CPP_TIMEOUT=300
+# 미설정 시 기본값: ./models/default_model.gguf
+LLAMA_CPP_MODEL_PATH=./models/default_model.gguf
 
-LLM_BASE_URL=http://localhost:8081
-EMBEDDING_BASE_URL=http://localhost:8081
-EMBEDDING_TIMEOUT=300
+# 선택 튜닝
+# LLAMA_CPP_N_CTX=8192
+# LLAMA_CPP_N_THREADS=8
+# LLAMA_CPP_N_BATCH=512
+# LLAMA_CPP_N_GPU_LAYERS=35
+# LLAMA_CPP_CHAT_FORMAT=chatml
 ```
 
-핵심은 3개입니다.
+legacy 변수는 선택적으로 남겨둘 수 있으나 in-process 모드에서는 무시됩니다.
 
-1. provider 둘 다 `llamacpp`
-2. 모델 경로는 **절대경로**
-3. base url 둘 다 `http://localhost:8081`
+```env
+# 아래 값들은 하위 호환용(무시됨)
+# LLM_BASE_URL=http://localhost:8081
+# EMBEDDING_BASE_URL=http://localhost:8081
+# LLAMA_CPP_COMMAND=llama-cli
+```
 
 ---
 
@@ -91,19 +89,17 @@ EMBEDDING_TIMEOUT=300
 ./venv/bin/python -m sttEngine.server
 ```
 
-서버가 떴다면 모델 상태 확인:
+서버가 올라오면 모델 상태 확인:
 
 ```bash
 curl -s http://localhost:8080/models | jq
 ```
 
-여기서 `default.provider`가 `llamacpp`면 1차 성공입니다.
+`default.provider`가 `llamacpp`면 1차 설정 성공입니다.
 
 ---
 
 ## 5) 실제 처리 요청 (`/process`)
-
-아래 JSON을 기준으로 요청하세요.
 
 ```json
 {
@@ -112,8 +108,8 @@ curl -s http://localhost:8080/models | jq
   "model_settings": {
     "provider": "llamacpp",
     "whisper": "large-v3-turbo",
-    "correct": "/절대경로/models/model.gguf",
-    "summarize": "/절대경로/models/model.gguf",
+    "correct": "./models/default_model.gguf",
+    "summarize": "./models/default_model.gguf",
     "temperature": 0.2,
     "context_window": 8192,
     "max_tokens": 1024
@@ -121,7 +117,7 @@ curl -s http://localhost:8080/models | jq
 }
 ```
 
-진행률은:
+진행률 확인:
 
 ```bash
 curl -s http://localhost:8080/progress/<task_id> | jq
@@ -129,53 +125,46 @@ curl -s http://localhost:8080/progress/<task_id> | jq
 
 ---
 
-## 6) 막히는 지점 빠른 해결
+## 6) 트러블슈팅
 
-### A. "llama.cpp 실행 파일을 찾을 수 없습니다"
+### A. `llama-cpp-python` import 실패
 
-```bash
-command -v llama-cli
-command -v llama-server
-```
+- `./venv/bin/python -m pip install -r requirements.txt` 재실행
+- Python/컴파일러 환경 확인
 
-둘 중 하나라도 비어 있으면 설치/경로 문제입니다.
+### B. `llama.cpp 모델 파일을 찾을 수 없습니다`
 
-### B. "모델 경로가 필요합니다"
+- `LLAMA_CPP_MODEL_PATH` 값 확인
+- 상대경로 기준은 **프로젝트 루트**
 
-- `LLAMA_CPP_MODEL_PATH` 확인
-- `/process`의 `correct`, `summarize`에 `.gguf` 절대경로 넣었는지 확인
+### C. 응답이 느림 / 메모리 사용량 큼
 
-### C. "임베딩 실패"
+- 큰 모델일수록 첫 로딩이 오래 걸립니다(이후는 캐시 재사용)
+- `LLAMA_CPP_N_THREADS`, `LLAMA_CPP_N_GPU_LAYERS`, `LLAMA_CPP_N_BATCH` 튜닝
 
-- `EMBEDDING_BASE_URL=http://localhost:8081` 확인
-- `llama-server` 실행 시 `--embeddings` 넣었는지 확인
+### D. 임베딩/검색 결과가 비정상
 
-### D. `/search` 결과가 이상함
-
-- 임베딩 차원 불일치가 있으면 문서가 제외될 수 있습니다(로그 확인)
+- 임베딩 차원 불일치 문서는 검색에서 제외될 수 있음(서버 로그 확인)
 
 ---
 
-## 7) 진짜 최소 체크리스트 (이것만 하면 됨)
+## 7) 최소 체크리스트
 
-1. `.gguf` 파일 준비
-2. `llama-server ... --embeddings` 실행
-3. `.env`에서 provider 2개를 `llamacpp`로 설정
-4. RecordRoute 실행
-5. `GET /models`에서 `default.provider=llamacpp` 확인
-6. `/process` 1건 실행 후 `/progress/<task_id>` 확인
-
-여기까지 되면 **사용 가능한 상태**입니다.
+1. `.gguf` 파일 준비 (`models/default_model.gguf`)
+2. `.env`에서 provider 2개를 `llamacpp`로 설정
+3. `LLAMA_CPP_MODEL_PATH` 확인
+4. 서버 실행 후 `GET /models` 확인
+5. `/process` 1건 실행 + `/progress/<task_id>` 확인
 
 ---
 
-## 부록) Docker로 하고 싶다면
+## 부록) Docker
 
 ```bash
 docker compose --profile llamacpp up -d --build
 ```
 
-- llama.cpp 서버: `http://localhost:8081`
+- 프론트: `http://localhost:3000`
 - 백엔드 API: `http://localhost:8080`
 
-주의: Docker로 띄워도 `.env`에서 provider를 `llamacpp`로 바꿔야 실제로 llama.cpp를 사용합니다.
+주의: Docker 환경에서도 `.env`에서 provider를 `llamacpp`로 설정해야 llama.cpp 경로가 사용됩니다.

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ mcp>=0.1.0
 # Optional provider dependencies
 # - Ollama provider를 사용하려면 아래 파일을 추가 설치하세요.
 #   pip install -r requirements-ollama.txt
+
+llama-cpp-python

--- a/sttEngine/providers/llama_cpp_provider.py
+++ b/sttEngine/providers/llama_cpp_provider.py
@@ -1,66 +1,137 @@
 from __future__ import annotations
 
+import logging
 import os
-import subprocess
+from threading import Lock
 from typing import Any, Dict, List, Optional, Sequence
 
 import numpy as np
-import requests
 
 from .base import ProviderConfigurationError, ProviderRequestError
 from .embedding_provider import BaseEmbeddingProvider
 from .llm_provider import BaseLLMProvider
 
+LOGGER = logging.getLogger(__name__)
+_DEFAULT_MODEL_PATH = "./models/default_model.gguf"
+_HTTP_ENV_KEYS = (
+    "LLM_BASE_URL",
+    "EMBEDDING_BASE_URL",
+    "LLAMA_CPP_COMMAND",
+    "LLM_TIMEOUT",
+    "EMBEDDING_TIMEOUT",
+    "LLAMA_CPP_TIMEOUT",
+)
+_WARNED_HTTP_ENV = False
 
-class LlamaCppLLMProvider(BaseLLMProvider):
+
+class _LlamaInstanceManager:
+    """Process-wide llama.cpp model cache keyed by absolute model path."""
+
+    _instances: dict[str, Any] = {}
+    _lock = Lock()
+
+    @classmethod
+    def get_or_create(cls, model_path: str) -> Any:
+        normalized_path = os.path.abspath(model_path)
+
+        with cls._lock:
+            if normalized_path in cls._instances:
+                return cls._instances[normalized_path]
+
+            llama_cls = cls._resolve_llama_class()
+            kwargs = cls._build_llama_kwargs()
+            try:
+                instance = llama_cls(model_path=normalized_path, embedding=True, **kwargs)
+            except Exception as exc:  # pragma: no cover - runtime backend errors
+                raise ProviderRequestError(
+                    f"llama.cpp 모델 로드에 실패했습니다: {normalized_path} ({exc})"
+                ) from exc
+
+            cls._instances[normalized_path] = instance
+            LOGGER.info("llama.cpp 모델 로드 완료(in-process): %s", normalized_path)
+            return instance
+
+    @classmethod
+    def is_loaded(cls, model_path: str) -> bool:
+        normalized_path = os.path.abspath(model_path)
+        with cls._lock:
+            return normalized_path in cls._instances
+
+    @staticmethod
+    def _resolve_llama_class() -> Any:
+        try:
+            from llama_cpp import Llama
+        except ImportError as exc:
+            raise ProviderConfigurationError(
+                "llama-cpp-python 패키지가 설치되어 있지 않습니다. requirements.txt를 확인하세요."
+            ) from exc
+        return Llama
+
+    @staticmethod
+    def _build_llama_kwargs() -> Dict[str, Any]:
+        kwargs: Dict[str, Any] = {}
+
+        def _apply_int(env_key: str, target_key: str) -> None:
+            value = os.getenv(env_key)
+            if value in {None, ""}:
+                return
+            try:
+                kwargs[target_key] = int(value)
+            except ValueError as exc:
+                raise ProviderConfigurationError(
+                    f"환경 변수 {env_key}는 정수여야 합니다: {value}"
+                ) from exc
+
+        _apply_int("LLAMA_CPP_N_CTX", "n_ctx")
+        _apply_int("LLAMA_CPP_N_THREADS", "n_threads")
+        _apply_int("LLAMA_CPP_N_BATCH", "n_batch")
+        _apply_int("LLAMA_CPP_N_GPU_LAYERS", "n_gpu_layers")
+
+        chat_format = os.getenv("LLAMA_CPP_CHAT_FORMAT")
+        if chat_format:
+            kwargs["chat_format"] = chat_format
+
+        return kwargs
+
+
+def _warn_if_http_env_is_ignored() -> None:
+    global _WARNED_HTTP_ENV
+    if _WARNED_HTTP_ENV:
+        return
+
+    configured_keys = [key for key in _HTTP_ENV_KEYS if os.getenv(key)]
+    if configured_keys:
+        LOGGER.warning(
+            "llama.cpp in-process 모드에서는 HTTP 환경 변수를 무시합니다: %s",
+            ", ".join(configured_keys),
+        )
+
+    _WARNED_HTTP_ENV = True
+
+
+class _LlamaCppProviderMixin:
     def _resolve_model_path(self, model: str) -> str:
         if model and ("/" in model or "\\" in model or model.endswith(".gguf")):
             return model
-        return os.getenv("LLAMA_CPP_MODEL_PATH", "")
+        return os.getenv("LLAMA_CPP_MODEL_PATH", _DEFAULT_MODEL_PATH)
 
-    def _messages_to_prompt(self, messages: List[Dict[str, str]]) -> str:
-        ordered = []
-        for message in messages:
-            role = (message.get("role") or "user").upper()
-            content = message.get("content") or ""
-            ordered.append(f"[{role}]\n{content}")
-        return "\n\n".join(ordered).strip()
-
-    def _run_cli(self, *, model: str, prompt: str, options: Dict[str, Any], timeout: Optional[int]) -> str:
-        command = os.getenv("LLAMA_CPP_COMMAND", "llama-cli")
-        model_path = self._resolve_model_path(model)
+    def _get_model_path_or_raise(self, model: str) -> str:
+        model_path = (self._resolve_model_path(model) or "").strip()
         if not model_path:
             raise ProviderConfigurationError(
                 "llama.cpp provider는 모델 경로(LLAMA_CPP_MODEL_PATH 또는 model 경로)가 필요합니다."
             )
+        return model_path
 
-        args = [command, "-m", model_path, "-p", prompt, "--no-display-prompt"]
-        if options.get("num_ctx"):
-            args.extend(["--ctx-size", str(options["num_ctx"])])
-        if options.get("temperature") is not None:
-            args.extend(["--temp", str(options["temperature"])])
-        if options.get("num_predict"):
-            args.extend(["--n-predict", str(options["num_predict"])])
+    def _get_llama_or_raise(self, model: str) -> Any:
+        model_path = self._get_model_path_or_raise(model)
+        if not os.path.exists(model_path):
+            raise ProviderConfigurationError(f"llama.cpp 모델 파일을 찾을 수 없습니다: {model_path}")
+        _warn_if_http_env_is_ignored()
+        return _LlamaInstanceManager.get_or_create(model_path)
 
-        timeout_seconds = timeout if timeout is not None else int(os.getenv("LLAMA_CPP_TIMEOUT", "300"))
 
-        try:
-            result = subprocess.run(args, capture_output=True, text=True, check=False, timeout=timeout_seconds)
-        except FileNotFoundError as exc:
-            raise ProviderRequestError(f"llama.cpp 실행 파일을 찾을 수 없습니다: {command}") from exc
-        except subprocess.TimeoutExpired as exc:
-            raise ProviderRequestError(f"llama.cpp 호출 타임아웃 ({timeout_seconds}초)") from exc
-
-        if result.returncode != 0:
-            raise ProviderRequestError(
-                f"llama.cpp 호출 실패(returncode={result.returncode}): {(result.stderr or '').strip()}"
-            )
-
-        content = (result.stdout or "").strip() or (result.stderr or "").strip()
-        if not content:
-            raise ProviderRequestError("llama.cpp 응답이 비어 있습니다.")
-        return content
-
+class LlamaCppLLMProvider(_LlamaCppProviderMixin, BaseLLMProvider):
     def chat(
         self,
         *,
@@ -69,10 +140,28 @@ class LlamaCppLLMProvider(BaseLLMProvider):
         options: Optional[Dict[str, Any]] = None,
         timeout: Optional[int] = None,
     ) -> Dict[str, Any]:
-        prompt = self._messages_to_prompt(messages)
-        if not prompt:
-            raise ProviderRequestError("llama.cpp 호출용 prompt가 비어 있습니다.")
-        content = self._run_cli(model=model, prompt=prompt, options=options or {}, timeout=timeout)
+        if not messages:
+            raise ProviderRequestError("llama.cpp 호출용 messages가 비어 있습니다.")
+
+        if timeout is not None:
+            LOGGER.warning("llama.cpp in-process 모드에서는 timeout 인자를 무시합니다.")
+
+        llama = self._get_llama_or_raise(model)
+        opts = options or {}
+
+        try:
+            response = llama.create_chat_completion(
+                messages=messages,
+                temperature=opts.get("temperature", 0.0),
+                max_tokens=opts.get("num_predict"),
+                top_p=opts.get("top_p"),
+            )
+        except Exception as exc:  # pragma: no cover - runtime backend errors
+            raise ProviderRequestError(f"llama.cpp chat 호출 실패: {exc}") from exc
+
+        content = self._extract_chat_content(response)
+        if not content:
+            raise ProviderRequestError("llama.cpp chat 응답이 비어 있습니다.")
         return {"message": {"content": content}}
 
     def generate(
@@ -85,94 +174,97 @@ class LlamaCppLLMProvider(BaseLLMProvider):
     ) -> Dict[str, Any]:
         if not prompt.strip():
             raise ProviderRequestError("llama.cpp 호출용 prompt가 비어 있습니다.")
-        content = self._run_cli(model=model, prompt=prompt, options=options or {}, timeout=timeout)
+
+        if timeout is not None:
+            LOGGER.warning("llama.cpp in-process 모드에서는 timeout 인자를 무시합니다.")
+
+        llama = self._get_llama_or_raise(model)
+        opts = options or {}
+
+        try:
+            response = llama(
+                prompt,
+                max_tokens=opts.get("num_predict"),
+                temperature=opts.get("temperature", 0.0),
+                top_p=opts.get("top_p"),
+            )
+        except Exception as exc:  # pragma: no cover - runtime backend errors
+            raise ProviderRequestError(f"llama.cpp generate 호출 실패: {exc}") from exc
+
+        content = self._extract_generate_content(response)
+        if not content:
+            raise ProviderRequestError("llama.cpp generate 응답이 비어 있습니다.")
         return {"response": content}
 
     def list_models(self) -> List[str]:
-        model_path = os.getenv("LLAMA_CPP_MODEL_PATH", "")
-        return [model_path] if model_path else []
+        return [self._get_model_path_or_raise("")]
 
     def healthcheck(self) -> tuple[bool, str]:
-        command = os.getenv("LLAMA_CPP_COMMAND", "llama-cli")
-        result = subprocess.run(["bash", "-lc", f"command -v {command}"], capture_output=True, text=True, check=False)
-        if result.returncode != 0:
-            return False, f"llama.cpp 실행 파일을 찾을 수 없습니다: {command}"
-        return True, f"llama.cpp 실행 파일 확인 완료: {command}"
+        model_path = self._get_model_path_or_raise("")
+        if _LlamaInstanceManager.is_loaded(model_path):
+            return True, f"llama.cpp 모델 로드됨(in-process): {model_path}"
+        if os.path.exists(model_path):
+            return True, f"llama.cpp 모델 파일 확인됨: {model_path}"
+        return False, f"llama.cpp 모델 파일이 없습니다: {model_path}"
+
+    @staticmethod
+    def _extract_chat_content(response: Any) -> str:
+        choices = response.get("choices") if isinstance(response, dict) else None
+        if not isinstance(choices, list) or not choices:
+            return ""
+        message = choices[0].get("message") if isinstance(choices[0], dict) else None
+        if isinstance(message, dict):
+            return str(message.get("content") or "").strip()
+        return ""
+
+    @staticmethod
+    def _extract_generate_content(response: Any) -> str:
+        choices = response.get("choices") if isinstance(response, dict) else None
+        if not isinstance(choices, list) or not choices:
+            return ""
+        text = choices[0].get("text") if isinstance(choices[0], dict) else None
+        return str(text or "").strip()
 
 
-class LlamaCppEmbeddingProvider(BaseEmbeddingProvider):
-    def _resolve_base_url(self) -> str:
-        return (
-            os.getenv("EMBEDDING_BASE_URL")
-            or os.getenv("LLM_BASE_URL")
-            or "http://localhost:8081"
-        ).rstrip("/")
-
-    def _resolve_timeout_seconds(self) -> int:
-        return int(os.getenv("EMBEDDING_TIMEOUT", os.getenv("LLAMA_CPP_TIMEOUT", "300")))
-
+class LlamaCppEmbeddingProvider(_LlamaCppProviderMixin, BaseEmbeddingProvider):
     def embed(self, text: str, *, model: str) -> np.ndarray:
         prompt = (text or "").strip()
         if not prompt:
             raise ProviderRequestError("llama.cpp embedding 호출용 텍스트가 비어 있습니다.")
 
-        model_name = (model or "").strip() or os.getenv("EMBEDDING_MODEL", "")
-        if not model_name:
-            raise ProviderConfigurationError("llama.cpp embedding provider는 model 이름이 필요합니다.")
-
-        base_url = self._resolve_base_url()
-        timeout_seconds = self._resolve_timeout_seconds()
+        llama = self._get_llama_or_raise(model)
 
         try:
-            response = requests.post(
-                f"{base_url}/v1/embeddings",
-                json={"model": model_name, "input": prompt},
-                timeout=timeout_seconds,
-            )
-        except requests.RequestException as exc:
-            raise ProviderRequestError(f"llama.cpp embedding 요청 실패: {exc}") from exc
+            response = llama.create_embedding(prompt)
+        except Exception as exc:  # pragma: no cover - runtime backend errors
+            raise ProviderRequestError(f"llama.cpp embedding 호출 실패: {exc}") from exc
 
-        try:
-            response.raise_for_status()
-        except requests.HTTPError as exc:
-            detail = response.text.strip()
-            raise ProviderRequestError(
-                f"llama.cpp embedding 응답 오류 {response.status_code}: {detail or 'no details'}"
-            ) from exc
-
-        payload = response.json() if response.content else {}
-        data = payload.get("data") if isinstance(payload, dict) else None
-        if not isinstance(data, list) or not data:
-            raise ProviderRequestError("llama.cpp embedding 응답(data)이 비어 있습니다.")
-
-        first = data[0] if isinstance(data[0], dict) else {}
-        embedding = first.get("embedding") if isinstance(first, dict) else None
-        if not isinstance(embedding, list) or not embedding:
+        vector = self._extract_embedding(response)
+        if vector.size == 0:
             raise ProviderRequestError("llama.cpp embedding 벡터가 비어 있습니다.")
-        return np.array(embedding, dtype=np.float32)
+        return vector
 
     def embed_batch(self, texts: Sequence[str], *, model: str) -> list[np.ndarray]:
         return [self.embed(text, model=model) for text in texts]
 
     def healthcheck(self) -> tuple[bool, str]:
-        base_url = self._resolve_base_url()
-        timeout_seconds = self._resolve_timeout_seconds()
-        try:
-            response = requests.get(f"{base_url}/health", timeout=min(timeout_seconds, 5))
-            if response.status_code < 500:
-                return True, f"llama.cpp embedding endpoint 확인 완료: {base_url}"
-        except requests.RequestException:
-            pass
+        model_path = self._get_model_path_or_raise("")
+        if _LlamaInstanceManager.is_loaded(model_path):
+            return True, f"llama.cpp embedding 모델 로드됨(in-process): {model_path}"
+        if os.path.exists(model_path):
+            return True, f"llama.cpp embedding 모델 파일 확인됨: {model_path}"
+        return False, f"llama.cpp embedding 모델 파일이 없습니다: {model_path}"
 
-        # /health 미구현 서버를 위해 embeddings endpoint에 probe
-        try:
-            response = requests.post(
-                f"{base_url}/v1/embeddings",
-                json={"model": os.getenv("EMBEDDING_MODEL", "__healthcheck__"), "input": "ping"},
-                timeout=min(timeout_seconds, 8),
-            )
-            if response.status_code in {200, 400, 404, 422}:
-                return True, f"llama.cpp embedding endpoint 확인 완료: {base_url}"
-            return False, f"llama.cpp embedding endpoint 응답 이상({response.status_code}): {base_url}"
-        except requests.RequestException as exc:
-            return False, f"llama.cpp embedding endpoint 접근 실패: {base_url} ({exc})"
+    @staticmethod
+    def _extract_embedding(response: Any) -> np.ndarray:
+        if isinstance(response, dict):
+            data = response.get("data")
+            if isinstance(data, list) and data and isinstance(data[0], dict):
+                embedding = data[0].get("embedding")
+                if isinstance(embedding, list):
+                    return np.array(embedding, dtype=np.float32)
+
+        if isinstance(response, list):
+            return np.array(response, dtype=np.float32)
+
+        return np.array([], dtype=np.float32)


### PR DESCRIPTION
### Motivation
- Migrate the `llamacpp` provider to use in-process `llama-cpp-python` for direct, faster integration and to avoid external CLI/HTTP dependencies.  
- Make runtime behavior explicit by warning when legacy HTTP/CLI/timeout environment variables are set but ignored in in-process mode.  
- Refresh documentation and environment samples so setup instructions (model path, tuning vars, requirements) match the new in-process provider behavior.

### Description
- Reworked provider implementation to use `llama_cpp.Llama` with a process-wide model cache via `_LlamaInstanceManager` and removed the old `subprocess`/HTTP call paths for in-process mode.  
- Added `_LlamaCppProviderMixin`, helpers to build `Llama` kwargs from env vars (`LLAMA_CPP_N_CTX`, `LLAMA_CPP_N_THREADS`, `LLAMA_CPP_N_BATCH`, `LLAMA_CPP_N_GPU_LAYERS`, `LLAMA_CPP_CHAT_FORMAT`), and `_warn_if_http_env_is_ignored()` to surface ignored legacy env keys.  
- Implemented robust model-path resolution/validation, runtime helpers to extract chat/generate/embedding outputs, and provider methods (`chat`, `generate`, `embed`, `embed_batch`, `healthcheck`, `list_models`) that call the in-process API and raise informative `ProviderRequestError`/`ProviderConfigurationError`.  
- Documentation and packaging updates: added `llama-cpp-python` to `requirements.txt`, added `models/` to `.gitignore`, refreshed `docs/llama-guide.md`, and updated `README.md`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and `.env.example` to reflect default model path `./models/default_model.gguf`, optional tuning vars, and legacy env behavior.

### Testing
- Ran a syntax check with `python -m py_compile sttEngine/providers/llama_cpp_provider.py`, which succeeded.  
- Attempted provider tests (`pytest tests/providers/test_llama_cpp_embedding_provider.py tests/providers/test_provider_factory.py`) but collection failed due to missing test dependency (`ModuleNotFoundError: No module named 'numpy'`), so full provider tests were not executed.  
- Performed repository consistency checks (`rg`/grep for key llama.cpp settings) to verify docs and `.env.example` updates and committed the documentation changes successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69996b634dec832eaf08717a2bf0aa9e)