### PR TITLE
Support configurable Whisper model dir (`WHISPER_MODEL_DIR`), docs sync and regression tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@
 - 백엔드: `venv/bin/python -m sttEngine.server` (Windows: `venv\\Scripts\\python.exe -m sttEngine.server`)
 - Ollama provider 사용 시 추가 의존성: `pip install -r requirements-ollama.txt`
 - llama.cpp provider는 `llama-cpp-python` in-process 모드를 사용하며, `LLAMA_CPP_MODEL_PATH` 기본값은 `./models/default_model.gguf`
+- Whisper 모델 경로는 `WHISPER_MODEL_DIR` 환경변수로 오버라이드할 수 있으며, 미지정 시 프로젝트 루트 `./models`를 기본 사용
 - `LLM_BASE_URL`/`EMBEDDING_BASE_URL`/`LLAMA_CPP_COMMAND`는 하위 호환용으로 남아 있으나 in-process 모드에서 무시됨
 - `.env`의 `LLM_PROVIDER`/`EMBEDDING_PROVIDER`가 `ollama`가 아니면 setup/run 스크립트의 Ollama 점검 단계는 자동 skip
 - 프론트 빌드: `cd frontend && npm install && npm run build`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,3 +33,4 @@
 
 - llama.cpp provider는 `llama-cpp-python` in-process 모드가 기본입니다.
 - `LLAMA_CPP_MODEL_PATH` 기본값은 `./models/default_model.gguf`이며, `LLM_BASE_URL`/`EMBEDDING_BASE_URL`/`LLAMA_CPP_COMMAND`는 하위 호환용으로만 유지됩니다.
+- Whisper 모델 경로는 `WHISPER_MODEL_DIR`로 오버라이드할 수 있고, 기본값은 프로젝트 루트 `./models`입니다.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -29,3 +29,4 @@
 
 - llama.cpp provider는 `llama-cpp-python` in-process 모드를 기본으로 사용합니다.
 - `LLAMA_CPP_MODEL_PATH` 기본값은 `./models/default_model.gguf`이며, 기존 HTTP/CLI 관련 환경 변수는 하위 호환용으로 유지됩니다.
+- Whisper 모델 경로는 `WHISPER_MODEL_DIR`로 오버라이드할 수 있고, 기본값은 프로젝트 루트 `./models`입니다.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ venv\Scripts\python.exe -m sttEngine.server
 ### 3-3. llama.cpp(In-process / `llama-cpp-python`) 사용 시
 - `pip install -r requirements.txt`로 `llama-cpp-python`을 함께 설치합니다.
 - `LLAMA_CPP_MODEL_PATH` (`.gguf` 모델 경로, 기본값 `./models/default_model.gguf`)
+- Whisper 모델 다운로드 경로: `WHISPER_MODEL_DIR` (미지정 시 프로젝트 루트 `./models` 사용)
 - 선택 성능 튜닝: `LLAMA_CPP_N_CTX`, `LLAMA_CPP_N_THREADS`, `LLAMA_CPP_N_BATCH`, `LLAMA_CPP_N_GPU_LAYERS`, `LLAMA_CPP_CHAT_FORMAT`
 - 하위 호환용으로 `LLM_BASE_URL`, `EMBEDDING_BASE_URL`, `LLAMA_CPP_COMMAND`를 남겨둘 수 있으나, in-process 모드에서는 무시되며 warning 로그가 남습니다.
 

--- a/sttEngine/workflow/transcribe.py
+++ b/sttEngine/workflow/transcribe.py
@@ -6,7 +6,6 @@ import argparse
 import json
 import logging
 import traceback
-import platform
 import subprocess
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -23,7 +22,12 @@ except ImportError:
     pass
 
 # 설정 모듈 임포트
-from sttEngine.config import get_db_base_path, get_default_model, get_model_for_task
+from sttEngine.config import (
+    get_db_base_path,
+    get_default_model,
+    get_model_for_task,
+    get_project_root,
+)
 from sttEngine.logger import setup_logging
 from sttEngine.vocabulary_manager import VocabularyManager
 from sttEngine.obsidian_mcp import send_stt_to_obsidian_sync
@@ -259,6 +263,18 @@ def get_unique_output_path(base_path: Path) -> Path:
         if not new_path.exists():
             return new_path
         counter += 1
+
+
+def get_whisper_model_download_root() -> Path:
+    """Whisper 모델 다운로드/로드 루트 경로를 반환합니다."""
+    configured_dir = os.getenv("WHISPER_MODEL_DIR")
+    download_root = (
+        Path(configured_dir).expanduser()
+        if configured_dir
+        else get_project_root() / "models"
+    )
+    download_root.mkdir(parents=True, exist_ok=True)
+    return download_root
 
 
 
@@ -655,13 +671,20 @@ def transcribe_audio_files(input_dir: str, output_dir: str, model_identifier: st
     if device_message:
         logging.info(device_message)
 
+    model_download_root = get_whisper_model_download_root()
+    logging.info("Whisper 모델 다운로드 경로: %s", model_download_root)
+
     # Whisper 모델 로드
     if progress_callback:
         progress_callback(f"Whisper 모델 ({os.path.basename(model_identifier)}) 로드 중...")
 
     logging.info("'%s' 모델을 로드하는 중...", os.path.basename(model_identifier))
     try:
-        model = whisper.load_model(model_identifier, device=device)
+        model = whisper.load_model(
+            model_identifier,
+            device=device,
+            download_root=str(model_download_root),
+        )
         logging.info("모델 로드 완료.")
         if progress_callback:
             progress_callback("모델 로드 완료")
@@ -841,23 +864,17 @@ def main():
 
     configure_cli_logging(args.verbose)
 
-    # 모델 경로 결정 (플랫폼별 캐시 경로 지원)
+    # 모델 경로 결정 (프로젝트 로컬 모델 경로 또는 환경변수 오버라이드)
     model_to_use = args.model_size
     if args.model_size == 'large-v3-turbo':
-        # 플랫폼별 캐시 경로 결정
-        if platform.system() == "Windows":
-            # Windows: %USERPROFILE%\.cache\whisper\
-            cache_dir = Path(os.environ.get("USERPROFILE", Path.home())) / ".cache" / "whisper"
-        else:
-            # macOS/Linux: ~/.cache/whisper/
-            cache_dir = Path.home() / ".cache" / "whisper"
-        
+        model_root = get_whisper_model_download_root()
+
         # turbo 모델 파일 검색 (다양한 파일명 패턴 지원)
         model_path = None
         turbo_patterns = ["large-v3-turbo.pt", "whisper-turbo.pt", "turbo.pt"]
-        
+
         for pattern in turbo_patterns:
-            candidate_path = cache_dir / pattern
+            candidate_path = model_root / pattern
             if candidate_path.exists():
                 model_path = candidate_path
                 break
@@ -866,10 +883,9 @@ def main():
             model_to_use = str(model_path)
             logging.info("turbo 모델 파일을 찾았습니다: %s", model_path)
         else:
-            logging.warning("turbo 모델 파일을 찾을 수 없습니다. 검색 경로: %s", cache_dir)
+            logging.warning("turbo 모델 파일을 찾을 수 없습니다. 검색 경로: %s", model_root)
             logging.warning("검색한 파일명: %s", ', '.join(turbo_patterns))
-            logging.warning("자동으로 'large' 모델을 사용합니다.")
-            model_to_use = "large"
+            logging.info("Whisper가 지정된 다운로드 경로에 모델을 자동 다운로드합니다.")
 
     # 입력 경로 검증
     input_path = Path(args.input_dir)

--- a/tests/workflow/test_transcribe_model_dir.py
+++ b/tests/workflow/test_transcribe_model_dir.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+from sttEngine.workflow import transcribe
+
+
+def test_get_whisper_model_download_root_prefers_env(monkeypatch, tmp_path):
+    env_dir = tmp_path / "custom_whisper_models"
+    monkeypatch.setenv("WHISPER_MODEL_DIR", str(env_dir))
+    monkeypatch.setattr(transcribe, "get_project_root", lambda: tmp_path / "project_root")
+
+    resolved = transcribe.get_whisper_model_download_root()
+
+    assert resolved == env_dir
+    assert resolved.exists()
+    assert resolved.is_dir()
+
+
+def test_get_whisper_model_download_root_defaults_to_project_models(monkeypatch, tmp_path):
+    project_root = tmp_path / "repo"
+    monkeypatch.delenv("WHISPER_MODEL_DIR", raising=False)
+    monkeypatch.setattr(transcribe, "get_project_root", lambda: project_root)
+
+    resolved = transcribe.get_whisper_model_download_root()
+
+    assert resolved == project_root / "models"
+    assert resolved.exists()
+    assert resolved.is_dir()
+
+
+def test_transcribe_audio_files_passes_download_root_to_whisper_load_model(
+    monkeypatch,
+    tmp_path,
+):
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    media_file = input_dir / "sample.wav"
+    media_file.write_bytes(b"RIFF")
+
+    expected_download_root = tmp_path / "whisper_models"
+    monkeypatch.setattr(
+        transcribe,
+        "get_whisper_model_download_root",
+        lambda: expected_download_root,
+    )
+    monkeypatch.setattr(transcribe, "list_media_files", lambda *_args, **_kwargs: [media_file])
+    monkeypatch.setattr(transcribe, "resolve_inference_device", lambda _requested: ("cpu", "ok"))
+
+    captured = {}
+
+    def fake_load_model(model_identifier, device=None, download_root=None):
+        captured["model_identifier"] = model_identifier
+        captured["device"] = device
+        captured["download_root"] = download_root
+        return object()
+
+    monkeypatch.setattr(transcribe.whisper, "load_model", fake_load_model)
+    monkeypatch.setattr(
+        transcribe,
+        "transcribe_single_file",
+        lambda file_path, output_dir, *_args, **_kwargs: output_dir / f"{file_path.stem}.md",
+    )
+
+    transcribe.transcribe_audio_files(
+        input_dir=str(input_dir),
+        output_dir=str(output_dir),
+        model_identifier="large-v3-turbo",
+        language="ko",
+        initial_prompt="",
+        workers=1,
+        recursive=False,
+        filter_fillers=False,
+        min_seg_length=2,
+        normalize_punct=False,
+        requested_device="cpu",
+    )
+
+    assert captured["model_identifier"] == "large-v3-turbo"
+    assert captured["device"] == "cpu"
+    assert captured["download_root"] == str(expected_download_root)


### PR DESCRIPTION
### Motivation
- Make Whisper model download/cache location configurable and deterministic across platforms by honoring `WHISPER_MODEL_DIR` and falling back to the project `models` folder. 
- Ensure the transcribe workflow actually passes the resolved download root to Whisper so local probing and automatic downloads behave consistently. 
- Add regression tests and operator-facing docs to prevent regressions and to document the new runtime behavior. 

### Description
- Add `get_whisper_model_download_root()` to `sttEngine/workflow/transcribe.py` which returns `WHISPER_MODEL_DIR` if set or `<project_root>/models` otherwise and ensures the directory exists. 
- Use the resolved download root in `transcribe_audio_files()` by passing `download_root=str(model_download_root)` to `whisper.load_model()` and log the resolved path. 
- Replace platform-specific cache probing with probing inside the resolved model root when searching for `large-v3-turbo` turbo files. 
- Synchronize documentation to mention `WHISPER_MODEL_DIR` in `README.md`, `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`, and add `tests/workflow/test_transcribe_model_dir.py` covering env override, default fallback, and `whisper.load_model()` invocation. 

### Testing
- Ran `pytest -q tests/workflow/test_transcribe_model_dir.py tests/workflow/test_transcribe_segments.py` and all tests passed (`5 passed`).
- Unit tests verify `get_whisper_model_download_root()` behavior (env override and default) and that `transcribe_audio_files()` forwards `download_root` to `whisper.load_model()` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69996fc2b9ac832eb6a9c398e5b121b6)