### PR TITLE
Refine llama.cpp Hugging Face download path handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,14 @@
 # LLAMA_CPP_N_BATCH=512
 # LLAMA_CPP_N_GPU_LAYERS=35
 # LLAMA_CPP_CHAT_FORMAT=chatml
+# Local cache directory for llama.cpp GGUF models (recommended for persistent volume mounts)
+# LLAMA_CPP_MODEL_CACHE_DIR=./models
+# Optional Hugging Face fallback download source when LLAMA_CPP_MODEL_PATH file is missing
+# HF_MODEL_REPO_ID=Qwen/Qwen2.5-7B-Instruct-GGUF
+# HF_MODEL_FILENAME=qwen2.5-7b-instruct-q4_k_m.gguf
+# HF_MODEL_REVISION=main
+# Hugging Face API token (do not hardcode in code)
+# HF_TOKEN=hf_xxx
 # Legacy variable (ignored in in-process mode)
 # LLAMA_CPP_COMMAND=llama-cli
 # Legacy timeout variable (ignored in in-process mode)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,8 @@
 - 백엔드: `venv/bin/python -m sttEngine.server` (Windows: `venv\\Scripts\\python.exe -m sttEngine.server`)
 - Ollama provider 사용 시 추가 의존성: `pip install -r requirements-ollama.txt`
 - llama.cpp provider는 `llama-cpp-python` in-process 모드를 사용하며, `LLAMA_CPP_MODEL_PATH` 기본값은 `./models/default_model.gguf`
+- 로컬 GGUF 파일이 없으면 `HF_MODEL_REPO_ID`/`HF_MODEL_FILENAME`(선택 `HF_MODEL_REVISION`) 기반으로 Hugging Face 자동 다운로드를 시도하며, `HF_TOKEN`이 필요
+- Hugging Face 캐시 경로는 `LLAMA_CPP_MODEL_CACHE_DIR`(기본 `./models`)로 제어
 - Whisper 모델 경로는 `WHISPER_MODEL_DIR` 환경변수로 오버라이드할 수 있으며, 미지정 시 프로젝트 루트 `./models`를 기본 사용
 - `LLM_BASE_URL`/`EMBEDDING_BASE_URL`/`LLAMA_CPP_COMMAND`는 하위 호환용으로 남아 있으나 in-process 모드에서 무시됨
 - `.env`의 `LLM_PROVIDER`/`EMBEDDING_PROVIDER`가 `ollama`가 아니면 setup/run 스크립트의 Ollama 점검 단계는 자동 skip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,4 +33,6 @@
 
 - llama.cpp provider는 `llama-cpp-python` in-process 모드가 기본입니다.
 - `LLAMA_CPP_MODEL_PATH` 기본값은 `./models/default_model.gguf`이며, `LLM_BASE_URL`/`EMBEDDING_BASE_URL`/`LLAMA_CPP_COMMAND`는 하위 호환용으로만 유지됩니다.
+- 로컬 GGUF 파일이 없으면 `HF_MODEL_REPO_ID`/`HF_MODEL_FILENAME`(선택 `HF_MODEL_REVISION`) 기반으로 Hugging Face 자동 다운로드를 시도하며 `HF_TOKEN`이 필요합니다.
+- Hugging Face 캐시 경로는 `LLAMA_CPP_MODEL_CACHE_DIR`(기본 `./models`)로 제어합니다.
 - Whisper 모델 경로는 `WHISPER_MODEL_DIR`로 오버라이드할 수 있고, 기본값은 프로젝트 루트 `./models`입니다.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -29,4 +29,6 @@
 
 - llama.cpp provider는 `llama-cpp-python` in-process 모드를 기본으로 사용합니다.
 - `LLAMA_CPP_MODEL_PATH` 기본값은 `./models/default_model.gguf`이며, 기존 HTTP/CLI 관련 환경 변수는 하위 호환용으로 유지됩니다.
+- 로컬 GGUF 파일이 없으면 `HF_MODEL_REPO_ID`/`HF_MODEL_FILENAME`(선택 `HF_MODEL_REVISION`) 기반으로 Hugging Face 자동 다운로드를 시도하며 `HF_TOKEN`이 필요합니다.
+- Hugging Face 캐시 경로는 `LLAMA_CPP_MODEL_CACHE_DIR`(기본 `./models`)로 제어합니다.
 - Whisper 모델 경로는 `WHISPER_MODEL_DIR`로 오버라이드할 수 있고, 기본값은 프로젝트 루트 `./models`입니다.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ venv\Scripts\python.exe -m sttEngine.server
 ### 3-3. llama.cpp(In-process / `llama-cpp-python`) 사용 시
 - `pip install -r requirements.txt`로 `llama-cpp-python`을 함께 설치합니다.
 - `LLAMA_CPP_MODEL_PATH` (`.gguf` 모델 경로, 기본값 `./models/default_model.gguf`)
+- 로컬 모델 파일이 없을 때는 `HF_MODEL_REPO_ID` + `HF_MODEL_FILENAME`(선택 `HF_MODEL_REVISION`)를 사용해 Hugging Face에서 자동 다운로드합니다(`HF_TOKEN` 필요).
+- Hugging Face 다운로드 캐시 경로는 `LLAMA_CPP_MODEL_CACHE_DIR`(기본 `./models`)로 지정할 수 있습니다. Docker 사용 시 해당 경로를 볼륨으로 마운트해 영속화하세요.
 - Whisper 모델 다운로드 경로: `WHISPER_MODEL_DIR` (미지정 시 프로젝트 루트 `./models` 사용)
 - 선택 성능 튜닝: `LLAMA_CPP_N_CTX`, `LLAMA_CPP_N_THREADS`, `LLAMA_CPP_N_BATCH`, `LLAMA_CPP_N_GPU_LAYERS`, `LLAMA_CPP_CHAT_FORMAT`
 - 하위 호환용으로 `LLM_BASE_URL`, `EMBEDDING_BASE_URL`, `LLAMA_CPP_COMMAND`를 남겨둘 수 있으나, in-process 모드에서는 무시되며 warning 로그가 남습니다.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,14 @@ services:
       OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://ollama:11434}
       LLM_BASE_URL: ${LLM_BASE_URL:-http://llamacpp:8081}
       EMBEDDING_BASE_URL: ${EMBEDDING_BASE_URL:-http://llamacpp:8081}
+      LLAMA_CPP_MODEL_CACHE_DIR: ${LLAMA_CPP_MODEL_CACHE_DIR:-./models}
+      HF_MODEL_REPO_ID: ${HF_MODEL_REPO_ID:-}
+      HF_MODEL_FILENAME: ${HF_MODEL_FILENAME:-}
+      HF_MODEL_REVISION: ${HF_MODEL_REVISION:-}
+      HF_TOKEN: ${HF_TOKEN:-}
     volumes:
       - ./DB:/data/DB
+      - ./models:/app/models
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       interval: 30s

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ mcp>=0.1.0
 #   pip install -r requirements-ollama.txt
 
 llama-cpp-python
+huggingface_hub>=0.24.0,<1.0.0

--- a/sttEngine/providers/llama_cpp_provider.py
+++ b/sttEngine/providers/llama_cpp_provider.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
 from threading import Lock
 from typing import Any, Dict, List, Optional, Sequence
 
 import numpy as np
+from huggingface_hub import hf_hub_download
+from huggingface_hub.utils import HfHubHTTPError
 
 from .base import ProviderConfigurationError, ProviderRequestError
 from .embedding_provider import BaseEmbeddingProvider
@@ -13,6 +16,7 @@ from .llm_provider import BaseLLMProvider
 
 LOGGER = logging.getLogger(__name__)
 _DEFAULT_MODEL_PATH = "./models/default_model.gguf"
+_DEFAULT_MODEL_CACHE_DIR = "./models"
 _HTTP_ENV_KEYS = (
     "LLM_BASE_URL",
     "EMBEDDING_BASE_URL",
@@ -24,6 +28,119 @@ _HTTP_ENV_KEYS = (
 _WARNED_HTTP_ENV = False
 
 
+def _resolve_hf_cache_dir() -> str:
+    cache_dir = os.getenv("LLAMA_CPP_MODEL_CACHE_DIR", _DEFAULT_MODEL_CACHE_DIR)
+    return os.path.abspath(cache_dir)
+
+
+def _parse_hf_model_source(model: str) -> tuple[str, str, Optional[str]]:
+    """Parse HF source from env or a model string.
+
+    Supported model string formats:
+    - hf://<repo_id>/<filename>.gguf
+    - hf:<repo_id>:<filename>.gguf
+    """
+    model_value = (model or "").strip()
+    revision = (os.getenv("HF_MODEL_REVISION") or "").strip() or None
+
+    if model_value.startswith("hf://"):
+        source = model_value[len("hf://") :]
+        try:
+            repo_id, filename = source.rsplit("/", 1)
+        except ValueError as exc:
+            raise ProviderConfigurationError(
+                "hf:// 모델 지정 형식이 올바르지 않습니다. 예: hf://repo/file.gguf"
+            ) from exc
+        return repo_id.strip(), filename.strip(), revision
+
+    if model_value.startswith("hf:"):
+        parts = [part.strip() for part in model_value.split(":", 2)]
+        if len(parts) != 3 or not parts[1] or not parts[2]:
+            raise ProviderConfigurationError(
+                "hf: 모델 지정 형식이 올바르지 않습니다. 예: hf:repo:file.gguf"
+            )
+        return parts[1], parts[2], revision
+
+    repo_id = (os.getenv("HF_MODEL_REPO_ID") or "").strip()
+    filename = (os.getenv("HF_MODEL_FILENAME") or "").strip()
+    return repo_id, filename, revision
+
+
+def _ensure_model_file(model_path: str, model: str) -> str:
+    """Return absolute path to local GGUF model, downloading from HF if needed."""
+    absolute_model_path = os.path.abspath(model_path)
+    if os.path.exists(absolute_model_path):
+        return absolute_model_path
+
+    repo_id, filename, revision = _parse_hf_model_source(model)
+    if not repo_id or not filename:
+        raise ProviderConfigurationError(
+            "llama.cpp 모델 파일을 찾을 수 없습니다. 로컬 파일을 준비하거나 "
+            "HF_MODEL_REPO_ID/HF_MODEL_FILENAME(또는 hf://... 형식 model)를 설정하세요. "
+            f"경로: {absolute_model_path}"
+        )
+
+    hf_token = os.environ.get("HF_TOKEN")
+    if not hf_token:
+        raise ProviderConfigurationError(
+            "HF_TOKEN 환경 변수가 설정되지 않았습니다. Hugging Face 다운로드에 필요한 토큰을 설정하세요."
+        )
+
+    cache_dir = _resolve_hf_cache_dir()
+    Path(cache_dir).mkdir(parents=True, exist_ok=True)
+    LOGGER.info(
+        "llama.cpp 모델이 없어 Hugging Face에서 다운로드를 시도합니다: repo=%s, file=%s, revision=%s, cache_dir=%s",
+        repo_id,
+        filename,
+        revision or "<default>",
+        cache_dir,
+    )
+
+    try:
+        downloaded_path = hf_hub_download(
+            repo_id=repo_id,
+            filename=filename,
+            revision=revision,
+            token=hf_token,
+            cache_dir=cache_dir,
+            local_dir=cache_dir,
+            local_dir_use_symlinks=False,
+        )
+    except HfHubHTTPError as exc:
+        status_code = getattr(getattr(exc, "response", None), "status_code", None)
+        if status_code == 403:
+            LOGGER.error(
+                "Hugging Face 모델 다운로드 403 Forbidden: 토큰 권한 부족 또는 gated 모델 라이선스 미동의 가능성이 큽니다. "
+                "repo=%s file=%s",
+                repo_id,
+                filename,
+            )
+            raise RuntimeError(
+                "Hugging Face 403 Forbidden: HF_TOKEN 권한 또는 모델 라이선스 동의를 확인하세요."
+            ) from exc
+
+        LOGGER.error(
+            "Hugging Face 모델 다운로드 실패(HTTP %s): repo=%s file=%s error=%s",
+            status_code,
+            repo_id,
+            filename,
+            exc,
+        )
+        raise RuntimeError("Hugging Face 모델 다운로드에 실패했습니다.") from exc
+    except Exception as exc:
+        LOGGER.error(
+            "Hugging Face 모델 다운로드 중 예외가 발생했습니다: repo=%s file=%s error=%s",
+            repo_id,
+            filename,
+            exc,
+        )
+        raise RuntimeError("Hugging Face 모델 다운로드 중 예외가 발생했습니다.") from exc
+
+    resolved_path = os.path.abspath(downloaded_path)
+    LOGGER.info("Hugging Face 모델 다운로드 완료: %s", resolved_path)
+    return resolved_path
+
+
 class _LlamaInstanceManager:
     """Process-wide llama.cpp model cache keyed by absolute model path."""
 
@@ -31,8 +148,8 @@ class _LlamaInstanceManager:
     _lock = Lock()
 
     @classmethod
-    def get_or_create(cls, model_path: str) -> Any:
-        normalized_path = os.path.abspath(model_path)
+    def get_or_create(cls, model_path: str, *, model: str = "") -> Any:
+        normalized_path = _ensure_model_file(model_path, model)
 
         with cls._lock:
             if normalized_path in cls._instances:
@@ -111,7 +228,16 @@ def _warn_if_http_env_is_ignored() -> None:
 
 class _LlamaCppProviderMixin:
     def _resolve_model_path(self, model: str) -> str:
-        if model and ("/" in model or "\\" in model or model.endswith(".gguf")):
+        normalized_model = (model or "").strip()
+        if normalized_model.startswith("hf://") or normalized_model.startswith("hf:"):
+            _, filename, _ = _parse_hf_model_source(normalized_model)
+            target_filename = filename or (os.getenv("HF_MODEL_FILENAME") or "model.gguf")
+            return os.path.join(_resolve_hf_cache_dir(), target_filename)
+        if normalized_model and (
+            "/" in normalized_model
+            or "\\" in normalized_model
+            or normalized_model.endswith(".gguf")
+        ):
             return model
         return os.getenv("LLAMA_CPP_MODEL_PATH", _DEFAULT_MODEL_PATH)
 
@@ -125,10 +251,8 @@ class _LlamaCppProviderMixin:
 
     def _get_llama_or_raise(self, model: str) -> Any:
         model_path = self._get_model_path_or_raise(model)
-        if not os.path.exists(model_path):
-            raise ProviderConfigurationError(f"llama.cpp 모델 파일을 찾을 수 없습니다: {model_path}")
         _warn_if_http_env_is_ignored()
-        return _LlamaInstanceManager.get_or_create(model_path)
+        return _LlamaInstanceManager.get_or_create(model_path, model=model)
 
 
 class LlamaCppLLMProvider(_LlamaCppProviderMixin, BaseLLMProvider):
@@ -205,6 +329,14 @@ class LlamaCppLLMProvider(_LlamaCppProviderMixin, BaseLLMProvider):
             return True, f"llama.cpp 모델 로드됨(in-process): {model_path}"
         if os.path.exists(model_path):
             return True, f"llama.cpp 모델 파일 확인됨: {model_path}"
+
+        repo_id, filename, _ = _parse_hf_model_source("")
+        if repo_id and filename:
+            return True, (
+                "llama.cpp 모델 로컬 파일이 없지만 Hugging Face 자동 다운로드 설정이 확인되었습니다: "
+                f"repo={repo_id}, file={filename}"
+            )
+
         return False, f"llama.cpp 모델 파일이 없습니다: {model_path}"
 
     @staticmethod
@@ -253,6 +385,14 @@ class LlamaCppEmbeddingProvider(_LlamaCppProviderMixin, BaseEmbeddingProvider):
             return True, f"llama.cpp embedding 모델 로드됨(in-process): {model_path}"
         if os.path.exists(model_path):
             return True, f"llama.cpp embedding 모델 파일 확인됨: {model_path}"
+
+        repo_id, filename, _ = _parse_hf_model_source("")
+        if repo_id and filename:
+            return True, (
+                "llama.cpp embedding 모델 로컬 파일이 없지만 Hugging Face 자동 다운로드 설정이 확인되었습니다: "
+                f"repo={repo_id}, file={filename}"
+            )
+
         return False, f"llama.cpp embedding 모델 파일이 없습니다: {model_path}"
 
     @staticmethod


### PR DESCRIPTION
### Motivation
- Address review feedback to remove import-time optional-wrapping for `huggingface_hub` and align provider import style with repo conventions.
- Improve robustness of the llama.cpp in-process provider when a local `.gguf` is missing by making HF auto-download path resolution correct and making readiness checks more informative.

### Description
- Replace the `try/except` import wrapper with direct imports for `hf_hub_download` and `HfHubHTTPError` in `sttEngine/providers/llama_cpp_provider.py` and add HF-related helpers `
_parse_hf_model_source` and `_resolve_hf_cache_dir`.
- Add `_ensure_model_file(...)` which downloads a GGUF from Hugging Face using `hf_hub_download` (honors `HF_TOKEN`, `HF_MODEL_REPO_ID`, `HF_MODEL_FILENAME`, `HF_MODEL_REVISION`, and `LLAMA_CPP_MODEL_CACHE_DIR`) and surface clear errors for missing token/403 cases.
- Change `_LlamaInstanceManager.get_or_create(...)` to accept a `model` argument and resolve/ensure the model file via `_ensure_model_file(...)` before loading; update `_resolve_model_path(...)` to parse filename from `hf://...` or `hf:repo:file.gguf` specs and map it into the cache dir.
- Update health checks for LLM and Embedding providers to report a healthy precondition when a local GGUF is absent but a valid HF auto-download configuration is present, and add related documentation and environment examples (`.env.example`, `README.md`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`), `docker-compose.yml` entries, and add `huggingface_hub` to `requirements.txt`.

### Testing
- Ran static compile check with `python -m py_compile sttEngine/providers/llama_cpp_provider.py`, which completed successfully.
- Executed unit tests `pytest tests/server/test_queue.py` and all collected tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699972bc1c5c832eb435d171f809df8f)