### PR TITLE
docs: translate .env.example descriptions to Korean

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,130 +1,130 @@
-# RecordRoute Environment Configuration Sample
-# Copy this file to .env and modify the values as needed.
+# RecordRoute 환경 변수 설정 예시
+# 이 파일을 `.env`로 복사한 뒤 필요한 값만 수정해서 사용하세요.
 
-# --- Database Paths ---
-# Custom path for the database folder.
-# If not set, defaults to the 'DB' folder in the project root.
+# --- 데이터베이스 경로 ---
+# 데이터베이스 폴더를 사용자 지정 경로로 설정합니다.
+# 지정하지 않으면 프로젝트 루트의 `DB` 폴더를 기본값으로 사용합니다.
 # DB_FOLDER_PATH=d:/path/to/your/custom/db
 
-# --- LLM/Provider Settings ---
-# Provider for correction/summarization models.
+# --- LLM/Provider 설정 ---
+# 교정/요약 모델에 사용할 Provider를 지정합니다.
 # Supported: ollama, llamacpp (llama_cpp alias 지원)
 # LLM_PROVIDER=ollama
 
-# Legacy external endpoint URL (kept for backward compatibility).
+# 레거시 외부 엔드포인트 URL(하위 호환 목적).
 # llama-cpp-python in-process 모드에서는 무시됩니다.
 # LLM_BASE_URL=http://localhost:8081
 
-# Embedding provider selection (unset 시 LLM_PROVIDER 상속).
+# 임베딩 Provider 선택(미설정 시 LLM_PROVIDER 값을 상속).
 # EMBEDDING_PROVIDER=ollama
 
-# Legacy Ollama endpoint (deprecated: provider별 설정으로 전환 권장)
+# 레거시 Ollama 엔드포인트(권장하지 않음: Provider별 설정 사용 권장)
 # OLLAMA_BASE_URL=http://localhost:11434
 
-# llama.cpp in-process settings
-# Default model path: ./models/default_model.gguf
+# llama.cpp in-process 설정
+# 기본 모델 경로: ./models/default_model.gguf
 # LLAMA_CPP_MODEL_PATH=./models/default_model.gguf
-# Optional tuning
+# 선택 튜닝 옵션
 # LLAMA_CPP_N_CTX=8192
 # LLAMA_CPP_N_THREADS=8
 # LLAMA_CPP_N_BATCH=512
 # LLAMA_CPP_N_GPU_LAYERS=35
 # LLAMA_CPP_CHAT_FORMAT=chatml
-# Local cache directory for llama.cpp GGUF models (recommended for persistent volume mounts)
+# llama.cpp GGUF 모델의 로컬 캐시 디렉터리(지속 볼륨 마운트 환경에서 권장)
 # LLAMA_CPP_MODEL_CACHE_DIR=./models
-# Optional Hugging Face fallback download source when LLAMA_CPP_MODEL_PATH file is missing
+# LLAMA_CPP_MODEL_PATH 파일이 없을 때 사용할 Hugging Face 자동 다운로드 소스(선택)
 # HF_MODEL_REPO_ID=Qwen/Qwen2.5-7B-Instruct-GGUF
 # HF_MODEL_FILENAME=qwen2.5-7b-instruct-q4_k_m.gguf
 # HF_MODEL_REVISION=main
-# Hugging Face API token (do not hardcode in code)
+# Hugging Face API 토큰(코드에 하드코딩 금지)
 # HF_TOKEN=hf_xxx
-# Legacy variable (ignored in in-process mode)
+# 레거시 변수(in-process 모드에서는 무시)
 # LLAMA_CPP_COMMAND=llama-cli
-# Legacy timeout variable (ignored in in-process mode)
+# 레거시 타임아웃 변수(in-process 모드에서는 무시)
 # LLAMA_CPP_TIMEOUT=300
 
-# Common LLM timeout seconds (미설정 시 OLLAMA_TIMEOUT fallback)
+# 공통 LLM 타임아웃(초, 미설정 시 OLLAMA_TIMEOUT으로 대체)
 # llama-cpp-python in-process 모드에서는 provider timeout 인자를 사용하지 않아 사실상 무시됩니다.
 # LLM_TIMEOUT=300
 
-# --- Model Configuration (Windows) ---
-# Models to use on Windows systems.
+# --- 모델 설정 (Windows) ---
+# Windows 환경에서 사용할 모델을 지정합니다.
 # TRANSCRIBE_MODEL_WINDOWS=large-v3-turbo
 # SUMMARY_MODEL_WINDOWS=gemma3:4b
 # EMBEDDING_MODEL_WINDOWS=bge-m3:latest
 
-# --- Model Configuration (macOS/Linux) ---
-# Models to use on Unix-based systems.
+# --- 모델 설정 (macOS/Linux) ---
+# macOS/Linux 환경에서 사용할 모델을 지정합니다.
 # TRANSCRIBE_MODEL_UNIX=large-v3-turbo
 # SUMMARY_MODEL_UNIX=gpt-oss:20b
 # EMBEDDING_MODEL_UNIX=bge-m3:latest
 
-# --- Embedding Settings ---
-# Maximum characters for embedding prompts.
+# --- 임베딩 설정 ---
+# 임베딩 프롬프트의 최대 문자 수를 지정합니다.
 # EMBEDDING_MAX_PROMPT_CHARS=7500
-# Fallback embedding model if platform specific one isn't found
+# 플랫폼별 모델을 찾지 못했을 때 사용할 임베딩 fallback 모델
 # EMBEDDING_MODEL=bge-m3:latest
-# Legacy embedding endpoint base URL (in-process 모드에서는 무시됨)
+# 레거시 임베딩 엔드포인트 기본 URL(in-process 모드에서는 무시)
 # EMBEDDING_BASE_URL=http://localhost:8081
-# Legacy embedding timeout (in-process 모드에서는 무시됨)
+# 레거시 임베딩 타임아웃(in-process 모드에서는 무시)
 # EMBEDDING_TIMEOUT=300
 
-# --- Cloudflare Tunnel Configuration ---
-# Enable/disable Cloudflare Tunnel integration.
-# Set to 'true' to automatically start cloudflared tunnel on server startup.
-# Requires cloudflared to be installed and CLOUDFLARE_TUNNEL_TOKEN to be set.
+# --- Cloudflare Tunnel 설정 ---
+# Cloudflare Tunnel 연동 사용 여부를 설정합니다.
+# `true`로 설정하면 서버 시작 시 cloudflared 터널을 자동으로 실행합니다.
+# cloudflared 설치 및 CLOUDFLARE_TUNNEL_TOKEN 설정이 필요합니다.
 TUNNEL_ENABLED=false
 
-# Cloudflare Tunnel token for authentication.
-# Generate this token from your Cloudflare Zero Trust dashboard:
-# 1. Go to https://one.dash.cloudflare.com/
-# 2. Navigate to Networks > Tunnels
-# 3. Create a new tunnel or select existing one
-# 4. Copy the tunnel token from the configuration
+# Cloudflare Tunnel 인증 토큰입니다.
+# 아래 순서로 Cloudflare Zero Trust 대시보드에서 발급하세요.
+# 1. https://one.dash.cloudflare.com/ 접속
+# 2. Networks > Tunnels 이동
+# 3. 새 터널 생성 또는 기존 터널 선택
+# 4. 설정 화면의 tunnel token 복사
 # CLOUDFLARE_TUNNEL_TOKEN=your_tunnel_token_here
 
-# --- Obsidian MCP Integration ---
-# Enable/disable automatic sync to Obsidian via MCP (Model Context Protocol).
-# Set to 'true' to automatically send STT and summary results to Obsidian Vault.
+# --- Obsidian MCP 연동 ---
+# MCP(Model Context Protocol)를 통한 Obsidian 자동 동기화 사용 여부를 설정합니다.
+# `true`로 설정하면 STT/요약 결과를 Obsidian Vault로 자동 전송합니다.
 OBSIDIAN_MCP_ENABLED=false
 
-# Path to the Obsidian MCP server executable.
-# Example for macOS/Linux: /usr/local/bin/obsidian-mcp-server
-# Example for Windows: C:\path\to\obsidian-mcp-server.exe
-# You can install it via npm: npm install -g @john33/obsidian-mcp-server
+# Obsidian MCP 서버 실행 파일 경로입니다.
+# macOS/Linux 예시: /usr/local/bin/obsidian-mcp-server
+# Windows 예시: C:\path\to\obsidian-mcp-server.exe
+# npm 설치: npm install -g @john33/obsidian-mcp-server
 # OBSIDIAN_MCP_SERVER_PATH=/usr/local/bin/obsidian-mcp-server
 
-# Obsidian API Key for authentication.
-# Generate this from Obsidian settings or MCP server configuration.
+# 인증용 Obsidian API Key입니다.
+# Obsidian 설정 또는 MCP 서버 설정에서 발급/확인하세요.
 # OBSIDIAN_API_KEY=your_obsidian_api_key_here
 
-# Target folder in Obsidian Vault where files will be created.
-# Default: RecordRoute
-# Example: 위키/RecordRoute or Notes/Meetings
+# Obsidian Vault에서 파일을 생성할 대상 폴더입니다.
+# 기본값: RecordRoute
+# 예시: 위키/RecordRoute 또는 Notes/Meetings
 # OBSIDIAN_VAULT_FOLDER=RecordRoute
 
 
-# --- Destructive API Protection ---
-# Safe mode for destructive endpoints (/shutdown, /delete, /delete_records, /reset,
-# /reset_all_tasks, /reset_summary_embedding). Default is true (deny by default).
+# --- 파괴적 API 보호 ---
+# 파괴적 엔드포인트(/shutdown, /delete, /delete_records, /reset,
+# /reset_all_tasks, /reset_summary_embedding)의 안전 모드입니다. 기본값은 true(기본 거부)입니다.
 # RECORDROUTE_DESTRUCTIVE_API_SAFE_MODE=true
 
-# Option A) Shared admin token
+# 옵션 A) 공용 관리자 토큰
 # RECORDROUTE_DESTRUCTIVE_API_TOKEN=change-me
 
-# Option B) Session credentials (both required)
+# 옵션 B) 세션 자격 증명(둘 다 필수)
 # RECORDROUTE_DESTRUCTIVE_API_SESSION_ID=session-1
 # RECORDROUTE_DESTRUCTIVE_API_SESSION_TOKEN=session-secret
 
-# --- Similarity Graph Cache Policy ---
-# Similarity graph response cache TTL in seconds. 0 disables TTL expiration.
+# --- 유사도 그래프 캐시 정책 ---
+# 유사도 그래프 응답 캐시 TTL(초)입니다. 0이면 TTL 만료를 비활성화합니다.
 # RECORDROUTE_SIMILARITY_GRAPH_CACHE_TTL_SECONDS=300
 
-# Maximum number of similarity graph cache entries to keep.
+# 유지할 유사도 그래프 캐시 엔트리의 최대 개수입니다.
 # RECORDROUTE_SIMILARITY_GRAPH_CACHE_MAX_ENTRIES=24
 
-# Incremental similarity matrix state TTL in seconds. 0 disables TTL expiration.
+# 증분 유사도 행렬 상태 TTL(초)입니다. 0이면 TTL 만료를 비활성화합니다.
 # RECORDROUTE_SIMILARITY_INCREMENTAL_STATE_TTL_SECONDS=900
 
-# Maximum number of incremental matrix states to keep.
+# 유지할 증분 행렬 상태의 최대 개수입니다.
 # RECORDROUTE_SIMILARITY_INCREMENTAL_STATE_MAX_ENTRIES=8


### PR DESCRIPTION
### Motivation
- Improve onboarding and readability for Korean-speaking users by translating the explanatory comments in the environment sample file to Korean.
- This is a documentation-only change and does not modify any runtime configuration keys or behavior.

### Description
- Updated the explanatory comments and section headers in ` .env.example` to natural Korean while preserving all variable names and example values unchanged.
- Localized sections include database paths, LLM/provider settings, llama.cpp options, embedding settings, Cloudflare Tunnel, Obsidian MCP integration, destructive API protection, and similarity graph cache policy.
- No code or configuration logic was altered; only human-facing comments were rewritten.

### Testing
- No automated tests were run because this change is documentation-only and has no runtime impact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a59c6acb4832e9a100ec1a7a9efcc)