### PR TITLE
Fix .env loading for quoted paths in run/setup scripts

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,10 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 # .env 파일이 있으면 환경변수 로드
 if [ -f "$SCRIPT_DIR/.env" ]; then
     echo ".env 파일에서 환경변수를 로드합니다."
-    export $(grep -v '^#' "$SCRIPT_DIR/.env" | xargs)
+    set -a
+    # shellcheck disable=SC1090
+    . "$SCRIPT_DIR/.env"
+    set +a
     echo "[DEBUG] PYANNOTE_TOKEN이 로드되었습니다."
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -27,7 +27,10 @@ echo
 
 # Provider 설정 정규화(.env가 있으면 반영)
 if [ -f "$SCRIPT_DIR/.env" ]; then
-    export $(grep -v '^#' "$SCRIPT_DIR/.env" | xargs)
+    set -a
+    # shellcheck disable=SC1090
+    . "$SCRIPT_DIR/.env"
+    set +a
 fi
 LLM_PROVIDER_VALUE="${LLM_PROVIDER:-ollama}"
 EMBEDDING_PROVIDER_VALUE="${EMBEDDING_PROVIDER:-$LLM_PROVIDER_VALUE}"


### PR DESCRIPTION
### Motivation
- The previous `.env` parsing used `export $(grep -v '^#' .env | xargs)`, which breaks when values contain spaces or non-ASCII characters and can produce invalid shell identifiers during startup. 
- Loading user paths such as `DB_FOLDER_PATH` or localized folder names must preserve quoting and whitespace to avoid startup failures on macOS/Linux.

### Description
- Replaced fragile parsing in `run.sh` and `setup.sh` with `set -a; . "$SCRIPT_DIR/.env"; set +a` to source the file and export variables while preserving quoted values. 
- Added a `# shellcheck disable=SC1090` comment where the `.env` is sourced to acknowledge intentional dynamic sourcing. 
- No functional changes to runtime behavior beyond correct environment-variable loading.

### Testing
- Ran `bash -n run.sh && bash -n setup.sh` to verify shell syntax, which succeeded. 
- Performed an env-load verification by creating a sample env with spaces/non-ASCII and sourcing it via `set -a; . /tmp/rr_test.env; set +a`, which preserved the values as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a5fea444c832ebed64a05bbe8814d)