### PR TITLE
Populate settings popup defaults from backend model config

### DIFF
--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -23,17 +23,32 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   const [defaults, setDefaults] = useState<{ whisper: string; summarize: string; embedding: string; provider?: 'ollama' | 'llamacpp' } | null>(null);
 
   const selectedProvider = (localSettings?.provider || localSettings?.llm_provider || defaults?.provider || 'ollama') as 'ollama' | 'llamacpp';
+  const requestedProvider = (localSettings?.provider || localSettings?.llm_provider) as 'ollama' | 'llamacpp' | undefined;
 
   useEffect(() => {
     if (open) {
       setLocalSettings(modelSettings);
       setDarkMode(theme === 'dark');
-      api.getModels(selectedProvider).then(data => {
-        setAvailableModels(data.models || []);
-        setDefaults(data.default);
+      api.getModels(requestedProvider).then(data => {
+        const models = data.models || [];
+        const fetchedDefaults = data.default;
+        setAvailableModels(models);
+        setDefaults(fetchedDefaults);
+        setLocalSettings(prev => {
+          if (!prev) {
+            return prev;
+          }
+          return {
+            ...prev,
+            provider: prev.provider || prev.llm_provider || fetchedDefaults?.provider,
+            llm_provider: prev.llm_provider || prev.provider || fetchedDefaults?.provider,
+            summarize: prev.summarize || fetchedDefaults?.summarize || models[0] || '',
+            embedding: prev.embedding || fetchedDefaults?.embedding || models[0] || '',
+          };
+        });
       }).catch(() => { });
     }
-  }, [open, modelSettings, theme, selectedProvider]);
+  }, [open, modelSettings, theme, requestedProvider]);
 
   const handleSave = () => {
     setTheme(darkMode ? 'dark' : 'light');


### PR DESCRIPTION
### Motivation
- Ensure the settings dialog reflects backend-configured defaults so opening the popup no longer shows empty/uninitialized values after changing environment defaults.
- Preserve any explicit user-selected settings while filling only missing provider/summary/embedding fields from the backend defaults.

### Description
- Updated `frontend/src/components/SettingsDialog.tsx` to call `api.getModels` with a `requestedProvider` and to merge `data.default` into the form `localSettings` when the dialog opens.
- Added logic to initialize `provider`/`llm_provider` and to fill `summarize`/`embedding` from `data.default` (falling back to the first available model), while keeping existing user values intact.
- Changed the `useEffect` dependency to watch `requestedProvider` so backend-configured defaults are fetched when the user hasn't explicitly set a local provider.

### Testing
- Ran `pytest tests/http_api/test_admin_models.py`, which passed (2 passed).
- Built the frontend with `cd frontend && npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a61fb987c832e9f499d7493d4ae78)