### PR TITLE
Fix embedding artifact deletion for unresolved path identifiers

### DIFF
--- a/sttEngine/http_api/records.py
+++ b/sttEngine/http_api/records.py
@@ -8,7 +8,6 @@ from typing import Any
 from ..embedding_pipeline import load_index, save_index
 from .history import load_upload_history, save_upload_history
 from .paths import (
-    BASE_DIR,
     DB_ALIAS,
     DELETED_OUTPUT_DIR,
     DELETED_UPLOAD_DIR,
@@ -87,59 +86,52 @@ def reset_upload_record(record_id: str) -> bool:
 
 
 def delete_file(file_identifier: str, file_type: str) -> tuple[bool, str]:
-    """Delete a specific file (STT or summary) and update history."""
+    """Delete a specific task artifact for a record and update metadata."""
     try:
-        # Get file info by UUID
-        file_info = get_file_by_uuid(file_identifier)
-        if not file_info:
+        normalized_task = str(file_type or "").strip().lower()
+        if normalized_task not in TASK_TYPES:
+            return False, "지원하지 않는 항목입니다."
+
+        file_path, record_id, resolved_task_type, _ = resolve_file_identifier(file_identifier)
+        if not file_path:
             return False, "파일을 찾을 수 없습니다."
 
-        # Get the actual file path
-        file_path = Path(BASE_DIR) / file_info["file_path"]
+        expected_task_type = resolved_task_type
+        if expected_task_type is None:
+            suffix = file_path.name
+            if suffix.endswith(".summary.md"):
+                expected_task_type = "summary"
 
-        if not file_path.exists():
-            return False, "파일이 존재하지 않습니다."
+        if expected_task_type and expected_task_type != normalized_task:
+            return False, "요청한 항목과 파일 유형이 일치하지 않습니다."
 
-        # Verify file type matches
-        if file_type == "stt" and not file_path.name.endswith(".md"):
-            return False, "STT 파일이 아닙니다."
-        if file_type == "summary" and not file_path.name.endswith(".summary.md"):
-            return False, "요약 파일이 아닙니다."
+        if not record_id:
+            return False, "연결된 기록을 찾을 수 없습니다."
 
-        # Delete the file
-        try:
-            file_path.unlink()
-        except Exception as e:
-            print(f"Failed to delete {file_path}: {e}")
-            return False, "파일 삭제에 실패했습니다."
-
-        # Update history record
         history = load_upload_history()
-        record_id = file_info["record_id"]
+        record = next((item for item in history if item.get("id") == record_id), None)
+        if not record:
+            return False, "기록을 찾을 수 없습니다."
+        if record.get("deleted"):
+            return False, "삭제된 항목입니다."
 
-        for record in history:
-            if record["id"] == record_id:
-                if record.get("deleted"):
-                    return False, "삭제된 항목입니다."
-                # Update completion status
-                record["completed_tasks"][file_type] = False
-
-                # Remove download link
-                if file_type in record["download_links"]:
-                    del record["download_links"][file_type]
-
-                # If deleting summary, also clear title_summary
-                if file_type == "summary":
-                    record["title_summary"] = ""
-                break
-
-        # Remove from file registry
         registry = load_file_registry()
-        if file_identifier in registry:
-            del registry[file_identifier]
-            save_file_registry(registry)
+        index = load_index()
 
-        # Save updated history
+        results, registry_changed, index_changed = reset_tasks_for_record(
+            record,
+            {normalized_task},
+            registry,
+            index,
+        )
+
+        if not results.get(normalized_task):
+            return False, "삭제할 항목이 없습니다."
+
+        if registry_changed:
+            save_file_registry(registry)
+        if index_changed:
+            save_index(index)
         save_upload_history(history)
 
         return True, ""

--- a/tests/http_api/test_records_reset.py
+++ b/tests/http_api/test_records_reset.py
@@ -35,3 +35,139 @@ def test_reset_upload_record_removes_speaker_outputs_and_clears_history(monkeypa
     assert saved['history'][0]['completed_tasks'] == {'stt': False, 'summary': False, 'embedding': False}
     assert saved['history'][0]['download_links'] == {}
     assert saved['history'][0]['title_summary'] == ''
+
+
+
+
+def test_delete_file_resets_embedding_and_cleans_index(monkeypatch, tmp_path: Path):
+    output_dir = tmp_path / 'whisper_output' / 'folder-1'
+    output_dir.mkdir(parents=True)
+    stt_path = output_dir / 'sample.md'
+    stt_path.write_text('hello', encoding='utf-8')
+
+    vector_dir = tmp_path / 'vector_store'
+    vector_dir.mkdir(parents=True)
+    vec_file = vector_dir / 'vec-1.npy'
+    vec_file.write_bytes(b'1')
+
+    history = [{
+        'id': 'record-1',
+        'file_path': 'DB/uploads/folder-1/sample.wav',
+        'folder_name': 'folder-1',
+        'completed_tasks': {'stt': True, 'summary': True, 'embedding': True},
+        'download_links': {'embedding': '/download/11111111-1111-1111-1111-111111111111'},
+        'title_summary': 'title',
+    }]
+    registry = {
+        '11111111-1111-1111-1111-111111111111': {
+            'file_path': 'DB/whisper_output/folder-1/sample.md',
+            'record_id': 'record-1',
+            'task_type': 'embedding',
+        }
+    }
+    index = {str(stt_path): {'vector': 'vec-1.npy'}}
+    saved: dict[str, object] = {}
+
+    monkeypatch.setattr(records, 'OUTPUT_DIR', tmp_path / 'whisper_output')
+    monkeypatch.setattr(records, 'VECTOR_DIR', vector_dir)
+    monkeypatch.setattr(records, 'resolve_file_identifier', lambda _x: (stt_path, 'record-1', 'embedding', '11111111-1111-1111-1111-111111111111'))
+    monkeypatch.setattr(records, 'load_upload_history', lambda: history)
+    monkeypatch.setattr(records, 'save_upload_history', lambda payload: saved.update({'history': payload}))
+    monkeypatch.setattr(records, 'load_file_registry', lambda: registry)
+    monkeypatch.setattr(records, 'save_file_registry', lambda payload: saved.update({'registry': payload.copy()}))
+    monkeypatch.setattr(records, 'load_index', lambda: index)
+    monkeypatch.setattr(records, 'save_index', lambda payload: saved.update({'index': payload.copy()}))
+
+    ok, message = records.delete_file('11111111-1111-1111-1111-111111111111', 'embedding')
+
+    assert ok is True
+    assert message == ''
+    assert saved['history'][0]['completed_tasks']['embedding'] is False
+    assert 'embedding' not in saved['history'][0]['download_links']
+    assert '11111111-1111-1111-1111-111111111111' not in saved['registry']
+    assert saved['index'] == {}
+    assert not vec_file.exists()
+
+
+def test_delete_file_resets_stt_and_removes_corrected_file(monkeypatch, tmp_path: Path):
+    output_dir = tmp_path / 'whisper_output' / 'folder-1'
+    output_dir.mkdir(parents=True)
+    stt_path = output_dir / 'sample.md'
+    stt_path.write_text('hello', encoding='utf-8')
+    corrected_path = output_dir / 'sample.corrected.md'
+    corrected_path.write_text('corrected', encoding='utf-8')
+
+    history = [{
+        'id': 'record-1',
+        'file_path': 'DB/uploads/folder-1/sample.wav',
+        'folder_name': 'folder-1',
+        'completed_tasks': {'stt': True, 'summary': False, 'embedding': False},
+        'download_links': {'stt': '/download/22222222-2222-2222-2222-222222222222'},
+        'title_summary': '',
+    }]
+    registry = {
+        '22222222-2222-2222-2222-222222222222': {
+            'file_path': 'DB/whisper_output/folder-1/sample.md',
+            'record_id': 'record-1',
+            'task_type': 'stt',
+        }
+    }
+    saved: dict[str, object] = {}
+
+    monkeypatch.setattr(records, 'OUTPUT_DIR', tmp_path / 'whisper_output')
+    monkeypatch.setattr(records, 'resolve_record_path', lambda _x: tmp_path / 'uploads' / 'folder-1' / 'sample.wav')
+    monkeypatch.setattr(records, 'resolve_file_identifier', lambda _x: (stt_path, 'record-1', 'stt', '22222222-2222-2222-2222-222222222222'))
+    monkeypatch.setattr(records, 'load_upload_history', lambda: history)
+    monkeypatch.setattr(records, 'save_upload_history', lambda payload: saved.update({'history': payload}))
+    monkeypatch.setattr(records, 'load_file_registry', lambda: registry)
+    monkeypatch.setattr(records, 'save_file_registry', lambda payload: saved.update({'registry': payload.copy()}))
+    monkeypatch.setattr(records, 'load_index', lambda: {})
+
+    ok, message = records.delete_file('22222222-2222-2222-2222-222222222222', 'stt')
+
+    assert ok is True
+    assert message == ''
+    assert not stt_path.exists()
+    assert not corrected_path.exists()
+    assert saved['history'][0]['completed_tasks']['stt'] is False
+    assert 'stt' not in saved['history'][0]['download_links']
+    assert '22222222-2222-2222-2222-222222222222' not in saved['registry']
+
+
+def test_delete_file_allows_embedding_when_task_type_is_not_resolved(monkeypatch, tmp_path: Path):
+    output_dir = tmp_path / 'whisper_output' / 'folder-1'
+    output_dir.mkdir(parents=True)
+    embedding_file = output_dir / 'sample.md'
+    embedding_file.write_text('embedding source text', encoding='utf-8')
+
+    history = [{
+        'id': 'record-1',
+        'file_path': 'DB/uploads/folder-1/sample.wav',
+        'folder_name': 'folder-1',
+        'completed_tasks': {'stt': True, 'summary': False, 'embedding': True},
+        'download_links': {'embedding': '/download/DB/whisper_output/folder-1/sample.md'},
+        'title_summary': '',
+    }]
+    registry = {
+        '33333333-3333-3333-3333-333333333333': {
+            'file_path': 'DB/whisper_output/folder-1/sample.md',
+            'record_id': 'record-1',
+            'task_type': 'embedding',
+        }
+    }
+    saved: dict[str, object] = {}
+
+    monkeypatch.setattr(records, 'OUTPUT_DIR', tmp_path / 'whisper_output')
+    monkeypatch.setattr(records, 'resolve_file_identifier', lambda _x: (embedding_file, 'record-1', None, 'DB/whisper_output/folder-1/sample.md'))
+    monkeypatch.setattr(records, 'load_upload_history', lambda: history)
+    monkeypatch.setattr(records, 'save_upload_history', lambda payload: saved.update({'history': payload}))
+    monkeypatch.setattr(records, 'load_file_registry', lambda: registry)
+    monkeypatch.setattr(records, 'save_file_registry', lambda payload: saved.update({'registry': payload.copy()}))
+    monkeypatch.setattr(records, 'load_index', lambda: {})
+
+    ok, message = records.delete_file('DB/whisper_output/folder-1/sample.md', 'embedding')
+
+    assert ok is True
+    assert message == ''
+    assert saved['history'][0]['completed_tasks']['embedding'] is False
+    assert 'embedding' not in saved['history'][0]['download_links']


### PR DESCRIPTION
### Motivation
- Deleting per-item artifacts could be blocked when a path/UUID resolved without a `task_type`, because `.md` filenames were being implicitly treated as `stt` and rejected for `embedding` deletes.
- Ensure per-artifact deletes succeed for embedding files when registry metadata is missing while keeping safety checks for mismatched types.

### Description
- Updated `delete_file()` in `sttEngine/http_api/records.py` to only infer `summary` from a `.summary.md` suffix and avoid treating generic `.md` as `stt` when `resolved_task_type` is `None`.
- Kept the unified cleanup flow that delegates to `reset_tasks_for_record()` and preserves history/registry/index save semantics.
- Added a regression test `test_delete_file_allows_embedding_when_task_type_is_not_resolved` in `tests/http_api/test_records_reset.py` to cover embedding deletion for unresolved identifier metadata.

### Testing
- Ran `python -m pytest tests/http_api/test_records_reset.py -q` and the file-level tests passed (`4 passed`).
- Ran the broader test suite `python -m pytest tests/http_api/test_records_reset.py tests/http_api/test_records_routes.py tests/http_api/test_destructive_guard.py tests/http_api/test_workflow.py tests/http_api/test_search.py tests/server/test_queue.py tests/test_vocab_system.py -q` and all tests passed (`31 passed`) with a single non-blocking thread-warning from an unrelated `shutdown_server` helper.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a61e3cf40832ebfe6a6fd730be282)