### PR TITLE
docs: remove deprecated baseline docs and align root guidance with repository state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,11 @@
 
 - `frontend/`: 운영 중인 프론트엔드 코드
 - `docs/`: Rust 전환/설계 문서
-- `deprecated/`: Python 기반 레거시 코드베이스(참조 및 안정성 기준선)
+- (현재 없음) `deprecated/`: 과거 Python 레거시 코드베이스 경로였으며, 현 저장소에는 포함되지 않습니다.
 
 원칙:
 - 신규 구현/문서화는 Rust 전환 목표를 기준으로 작성합니다.
-- 레거시 수정이 아닌 경우 `deprecated/`를 기본 실행 타깃으로 가정하지 않습니다.
+- 현재 저장소에는 `deprecated/` 디렉터리가 없으므로 레거시 실행 경로를 기본 타깃으로 가정하지 않습니다.
 
 ## 2) Rust 전환 기본 방향
 
@@ -21,6 +21,7 @@
 - 오디오 전처리: `ffmpeg` 외부 프로세스 대신 Rust `symphonia` 크레이트 기반 변환을 기본값으로 사용
 
 세부 정책은 `docs/rust-cpp-backend-rewrite-plan.md`를 단일 기준으로 따르며, 아키텍처 기준선은 `docs/architecture.md`를 참조합니다.
+배포/자산 세부 운영 기준은 `docs/deployment-asset-policy.md`를 참조합니다.
 실행 단위/의존성 추적은 `TODO/TODO.md`를 함께 참조합니다.
 
 ## 3) 문서 동기화 규칙
@@ -51,14 +52,13 @@
 
 코드 변경이 포함되면 해당 스택 검증 필수:
 - 프론트: `cd frontend && npm run build`
-- 레거시 Python: `cd deprecated && pytest` 또는 영향 범위 테스트
+- 레거시 Python(외부/별도 저장소에서만): 해당 저장소 테스트 규칙에 따라 `pytest` 또는 영향 범위 테스트
 - Rust 코드 도입 시: `cargo test`, `cargo clippy`(도입 이후 필수)
 
 ## 6) 레거시 스코프 주의
 
-`deprecated/` 하위 파일을 수정할 경우:
-- 반드시 `deprecated/AGENTS.md`를 추가로 준수합니다.
-- 루트 규칙보다 더 구체적인(더 깊은) 지침이 있으면 해당 지침을 우선합니다.
+- 현재 저장소 기준 `deprecated/`는 비어 있거나 존재하지 않을 수 있습니다.
+- 향후 `deprecated/`가 재도입되어 하위 파일을 수정할 경우, 해당 경로의 `AGENTS.md`가 있으면 우선 준수합니다.
 
 ## 7) 금지/권장
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,14 @@
 2. `README.md`
 3. `docs/architecture.md`
 4. `docs/rust-cpp-backend-rewrite-plan.md`
-5. `TODO/TODO.md`
-6. (레거시 작업 시) `deprecated/AGENTS.md`
+5. `docs/deployment-asset-policy.md`
+6. `TODO/TODO.md`
+7. 레거시는 별도 보관소/브랜치에서만 취급 (현 저장소 `deprecated/` 없음)
 
 ## 현재 프로젝트 전제
 
-- Rust 백엔드는 전환 계획 단계이며 루트에 `Cargo.toml`이 아직 없습니다.
-- 운영 중 코드 기준은 `frontend/`(현행) + `deprecated/`(레거시 참조)입니다.
+- 루트에 Rust 실행 코드(`Cargo.toml`)가 존재하며, 백엔드 전환 구현이 진행 중입니다.
+- 운영 중 코드 기준은 `frontend/`(현행) + 루트 Rust 코드입니다.
 - 오디오 변환 기본 전략은 외부 `ffmpeg` 호출이 아니라 Rust `symphonia` 크레이트 사용입니다.
 
 ## 작업 체크리스트

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,8 +4,8 @@
 
 ## 핵심 컨텍스트
 
-- 저장소는 Rust 전환 진행 중이며, 레거시 Python 코드는 `deprecated/`에 보관됩니다.
-- 현재 루트에는 Rust 실행 코드가 아직 없으므로, 문서/프론트/전환 설계 중심으로 작업합니다.
+- 저장소는 Rust 전환 진행 중이며, 레거시 Python 코드는 현 저장소에 포함되어 있지 않습니다.
+- 루트에는 Rust 실행 코드가 존재하며, 문서/프론트와 함께 Rust 구현 변경도 작업 대상입니다.
 - 오디오 전처리/변환 기본안은 Rust `symphonia` 크레이트 기반입니다.
 
 ## 우선 참조
@@ -14,14 +14,15 @@
 - 사용자 개요: `README.md`
 - 아키텍처 기준선: `docs/architecture.md`
 - 전환 설계: `docs/rust-cpp-backend-rewrite-plan.md`
+- 배포/자산 정책: `docs/deployment-asset-policy.md`
 - 전환 실행 WBS: `TODO/TODO.md`
-- 레거시 지침(필요 시): `deprecated/AGENTS.md`
+- 레거시 지침(필요 시): 별도 레거시 보관소/브랜치의 AGENTS 문서
 
 ## 에이전트 작업 규칙 (요약)
 
 1. 상세 규칙은 `AGENTS.md` 단일 기준으로 유지
 2. 문서 변경 시 `README.md`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` 동시 반영
-3. 레거시 경로 수정 시 `deprecated/` 스코프 문서 우선 적용
+3. 레거시 코드는 별도 보관소 기준 문서를 우선 적용
 4. Rust 전환 상태를 과장하지 않고 현재/목표를 분리해 기술
 
 ## 검증 가이드

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ RecordRoute는 음성/문서 처리 파이프라인을 **Rust 중심 아키텍�
 
 현재 저장소는 아래 두 영역으로 나뉩니다.
 
-- `deprecated/`: 기존 Python 기반 백엔드/워크플로우(레거시 기준선)
 - `frontend/`: 현재 유지 중인 웹 프론트엔드
+- `docs/`: Rust 전환/설계 문서
 
 Rust 백엔드는 아직 본 저장소에 구현되지 않았고, 설계 및 전환 계획을 기준으로 단계적으로 이전합니다.
 
@@ -17,13 +17,13 @@ Rust 백엔드는 아직 본 저장소에 구현되지 않았고, 설계 및 전
 2. 사용자/운영 개요: `README.md` (이 문서)
 3. 아키텍처 기준선: `docs/architecture.md`
 4. 전환 설계: `docs/rust-cpp-backend-rewrite-plan.md`
-5. 전환 실행 WBS: `TODO/TODO.md`
-6. 레거시 코드 참고: `deprecated/current-codebase-overview.md`
+5. 배포/자산 정책: `docs/deployment-asset-policy.md`
+6. 전환 실행 WBS: `TODO/TODO.md`
 7. 에이전트 요약: `CLAUDE.md`, `GEMINI.md`
 
 ## 현재 상태 (2026-02 기준)
 
-- Python 기반 구 구현은 `deprecated/`로 이동되어 유지보수 기준선으로 사용합니다.
+- Python 기반 구 구현은 현재 저장소에 포함되어 있지 않으며, 필요 시 별도 레거시 보관소를 참조합니다.
 - Rust 오케스트레이터 + C++(llama.cpp/whisper.cpp) 엔진 분리 아키텍처를 목표로 합니다.
 - 프론트엔드는 유지하되, 향후 Rust API 계약에 맞춰 점진적으로 연결합니다.
 
@@ -54,10 +54,10 @@ npm run build
 
 ## 레거시 코드 다룰 때
 
-- `deprecated/` 내부 문서(`deprecated/AGENTS.md`, `deprecated/CLAUDE.md`, `deprecated/GEMINI.md`)는 레거시 코드 수정 시에만 적용합니다.
-- 루트 문서와 레거시 문서가 충돌하면, 수정 대상 디렉터리의 문서 스코프를 우선합니다.
+- 현재 저장소에는 `deprecated/` 디렉터리가 없으므로 레거시 코드는 기본 작업 범위가 아닙니다.
+- 레거시 이슈 재현이 필요하면 별도 레거시 보관소/브랜치에서 수행하고, 결과만 본 저장소 문서에 반영합니다.
 
 ## 주의
 
-- 이 저장소 루트에는 아직 Rust 실행 코드(`Cargo.toml`)가 없습니다.
-- 따라서 현재 CI/로컬 검증은 프론트엔드 중심이며, 백엔드 검증은 레거시(`deprecated/`) 또는 별도 Rust 저장소/브랜치에서 수행해야 합니다.
+- 이 저장소 루트에는 Rust 실행 코드(`Cargo.toml`)가 존재합니다.
+- 따라서 Rust 코드 변경 시 `cargo test`, `cargo clippy`를 포함한 검증을 수행해야 합니다.

--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -7,6 +7,11 @@
   - `docs/rust-cpp-backend-rewrite-plan.md`에 기준 문서 링크 추가
   - 다음 우선 작업: WBS 1.2.x ~ 2.2.x 산출물(배포/자산 정책) 구체화
 
+- 2026-02-22: WBS 1.2.x ~ 2.2.x 구체화 문서 초안 추가
+  - `docs/deployment-asset-policy.md` 신규 작성 (배포 단위/API-Swagger 분리, 모델/벤더 자산 정책, 완료 판정 체크포인트)
+  - `docs/rust-cpp-backend-rewrite-plan.md`에 보조 정책 문서 링크 추가
+  - 다음 우선 작업: `.gitignore` 정책 초안 및 manifest 템플릿 정의
+
 ## WBS 1.0 전략/기반 정합성
 
 ### 1.1 아키텍처 기준 수립

--- a/docs/deployment-asset-policy.md
+++ b/docs/deployment-asset-policy.md
@@ -1,0 +1,91 @@
+# Deployment & Asset Policy (WBS 1.2.x ~ 2.2.x)
+
+이 문서는 `docs/rust-cpp-backend-rewrite-plan.md`의 WBS 1.2.x(구성요소 분리), 2.2.x(폴더/자산 정책)를 실행 가능한 기준으로 구체화한 산출물입니다.
+
+## 1) 배포 단위 분리 기준 (WBS 1.2.2)
+
+### API 서버 (Rust orchestrator)
+- 포트: `:18000`
+- 책임:
+  - 외부 요청 진입점 (`/jobs`, `/healthz`, `/readyz`)
+  - 엔진별 큐 라우팅 및 backpressure
+  - 엔진 헬스체크/재시작/타임아웃 감독
+- 비책임:
+  - Swagger UI 정적 자산 제공
+
+### Swagger 서버 (문서 전용 프로세스)
+- 포트: `:14000`
+- 책임:
+  - Swagger UI 제공
+  - OpenAPI 원본은 `http://localhost:18000/openapi.json` 참조
+- 비책임:
+  - API 트래픽 처리
+  - 엔진 상태 판단
+
+### 운영 분리 원칙
+- API와 Swagger는 **서로 다른 프로세스/서비스 단위**로 배포한다.
+- Swagger 장애가 API readiness에 영향을 주지 않아야 한다.
+- API 배포 롤백 시 Swagger 배포를 강제하지 않는다(역도 동일).
+
+## 2) 엔진 역할 분리 기준 (WBS 1.2.1)
+
+- `llama-text` (`127.0.0.1:18101`)
+  - `/models/text/*.gguf`
+  - 요약/교정 계열 요청 전용
+- `llama-embed` (`127.0.0.1:18102`)
+  - `/models/embed/*.gguf`
+  - 임베딩 요청 전용
+  - pooling 정책 명시 (`mean` 또는 `cls`)
+- `whisper-server` (`127.0.0.1:18103`)
+  - `/models/stt/*`
+  - STT 추론 전용
+
+요약/임베딩을 동일 엔진 프로세스에서 혼합 처리하지 않는다.
+
+## 3) 저장소 구조 기준 (WBS 2.2.1)
+
+```text
+/
+├── Cargo.toml
+├── /src
+├── /vendor
+│   ├── /llama.cpp
+│   └── /whisper.cpp
+├── /models
+│   ├── /text
+│   ├── /embed
+│   └── /stt
+└── /target 또는 /build (gitignore)
+```
+
+규칙:
+- `/vendor/*`는 소스만 관리하고 빌드 산출물/실행파일은 커밋하지 않는다.
+- `/models/**`의 원본 모델 파일은 커밋하지 않는다.
+- 모델 추적은 `manifest.yml` 또는 `manifest.json`으로 대체한다.
+
+## 4) Git 추적 정책 (WBS 2.2.2)
+
+### 필수 ignore 항목
+- `/build`
+- `/target`
+- `/models/**/*` (원본)
+- 엔진 바이너리/오브젝트/캐시
+
+### 버전관리 허용 항목
+- `/vendor/llama.cpp/**` 소스
+- `/vendor/whisper.cpp/**` 소스
+- `/models/**/manifest.yml` 또는 `manifest.json`
+- 배포/실행 스크립트, 설정 템플릿
+
+## 5) WBS 완료 판정 체크포인트
+
+- [ ] API(`:18000`)와 Swagger(`:14000`)를 독립 프로세스로 실행 가능한 배포 정의가 준비되었는가?
+- [ ] `llama-text`/`llama-embed`가 모델 경로와 요청 타입 기준으로 완전히 분리되었는가?
+- [ ] 저장소에 `/vendor`, `/models`, 빌드 산출물 정책이 `.gitignore`와 함께 반영되었는가?
+- [ ] 모델 원본 없이 manifest만으로 버전/체크섬 추적이 가능한가?
+
+## 6) 관련 문서
+
+- 기준 계획: `docs/rust-cpp-backend-rewrite-plan.md`
+- 아키텍처 기준선: `docs/architecture.md`
+- 실행 단위 추적: `TODO/TODO.md`

--- a/docs/rust-cpp-backend-rewrite-plan.md
+++ b/docs/rust-cpp-backend-rewrite-plan.md
@@ -1,6 +1,7 @@
 # Rust/C++ 기반 백엔드 재작성 실행 계획 (보강안)
 
 > 아키텍처 기준선: `docs/architecture.md`
+> 보조 정책(배포/자산): `docs/deployment-asset-policy.md`
 
 이 문서는 Rust 오케스트레이터 + C++ AI 엔진(`llama.cpp`, `whisper.cpp`) 분리 구조를 **운영 가능한 단일 방향성**으로 구체화한 실행 계획입니다. 핵심은 FFI를 피하고 내부 HTTP 계약으로 결합하되, 실제 운영에서 흔들리는 지점을 선제적으로 막는 것입니다.
 


### PR DESCRIPTION
### Motivation
- Correct root documentation to reflect that this repository does not contain an in-repo `deprecated/` baseline and avoid implying legacy files exist here. 
- Keep the agent/doc guidance accurate for ongoing Rust/C++ transition work and prevent confusion about where legacy code should be handled.

### Description
- Updated `AGENTS.md`, `README.md`, `CLAUDE.md`, and `GEMINI.md` to state that `deprecated/` is not present in this repository and that legacy work is handled in separate/archived locations. 
- Removed the previously added placeholder baseline docs under `deprecated/` (`deprecated/AGENTS.md`, `deprecated/CLAUDE.md`, `deprecated/GEMINI.md`, `deprecated/current-codebase-overview.md`). 
- Added `docs/deployment-asset-policy.md` and linked it from `docs/rust-cpp-backend-rewrite-plan.md`, and updated `TODO/TODO.md` to reference the new deployment/asset policy. 
- Adjusted validation guidance to reflect external legacy testing expectations and clarified that Rust runtime artifacts (`Cargo.toml`) exist in the repo root so Rust tests (`cargo test`, `cargo clippy`) apply when modifying Rust code. 

### Testing
- Ran a markdown reference check script that scans backtick-marked `*.md` links in the updated root docs and confirmed there were no unresolved references (succeeded). 
- Verified repository working-tree status with `git status --short` to ensure the intended files were present/removed (succeeded). 
- Performed local content inspections of the touched files to validate wording and link updates (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a98821d64832e9d1e60c205bcc2c4)