### PR TITLE
Add per-engine worker module and engine process supervision (Phase C/D)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Rust 오케스트레이터 작업 환경 스캐폴딩"
 
 [dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time", "process"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"

--- a/src/engine_manager.rs
+++ b/src/engine_manager.rs
@@ -1,0 +1,257 @@
+use std::{
+    io::{Read, Write},
+    net::{TcpStream, ToSocketAddrs},
+    process::Stdio,
+    time::Duration,
+};
+
+use tokio::{
+    process::{Child, Command},
+    sync::watch,
+    task::JoinHandle,
+};
+
+#[derive(Clone, Debug)]
+pub struct EngineProcessSpec {
+    pub name: &'static str,
+    pub port: u16,
+    pub command: String,
+    pub args: Vec<String>,
+    pub health_path: &'static str,
+}
+
+#[derive(Debug)]
+pub struct EngineManager {
+    shutdown_tx: watch::Sender<bool>,
+    tasks: Vec<JoinHandle<()>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct EngineManagerConfig {
+    pub startup_timeout: Duration,
+    pub readiness_poll_interval: Duration,
+    pub shutdown_grace: Duration,
+    pub restart_backoff_base: Duration,
+    pub restart_backoff_max: Duration,
+}
+
+impl EngineManager {
+    pub fn spawn(specs: Vec<EngineProcessSpec>, config: EngineManagerConfig) -> Self {
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        let tasks = specs
+            .into_iter()
+            .map(|spec| {
+                let mut rx = shutdown_rx.clone();
+                let cfg = config.clone();
+                tokio::spawn(async move {
+                    supervise_engine(spec, cfg, &mut rx).await;
+                })
+            })
+            .collect();
+
+        Self { shutdown_tx, tasks }
+    }
+
+    pub async fn shutdown(mut self) {
+        let _ = self.shutdown_tx.send(true);
+        for task in self.tasks.drain(..) {
+            if let Err(error) = task.await {
+                tracing::warn!(error = %error, "engine supervisor join failed");
+            }
+        }
+    }
+}
+
+async fn supervise_engine(
+    spec: EngineProcessSpec,
+    config: EngineManagerConfig,
+    shutdown_rx: &mut watch::Receiver<bool>,
+) {
+    let mut restart_attempt = 0usize;
+
+    loop {
+        if *shutdown_rx.borrow() {
+            tracing::info!(engine = spec.name, "engine supervisor stopped before spawn");
+            return;
+        }
+
+        match spawn_engine(&spec) {
+            Ok(mut child) => {
+                tracing::info!(
+                    engine = spec.name,
+                    port = spec.port,
+                    "engine process spawned"
+                );
+
+                match wait_for_readiness(&spec, &config, shutdown_rx).await {
+                    Ok(true) => {
+                        tracing::info!(engine = spec.name, "engine readiness passed");
+                        restart_attempt = 0;
+                    }
+                    Ok(false) => {
+                        tracing::info!(
+                            engine = spec.name,
+                            "engine shutdown requested during startup"
+                        );
+                        let _ = graceful_shutdown(&spec, &mut child, config.shutdown_grace).await;
+                        return;
+                    }
+                    Err(error) => {
+                        tracing::warn!(engine = spec.name, error = %error, "engine readiness failed");
+                        let _ = graceful_shutdown(&spec, &mut child, config.shutdown_grace).await;
+                        backoff_sleep(&spec, &config, restart_attempt, shutdown_rx).await;
+                        restart_attempt = restart_attempt.saturating_add(1);
+                        continue;
+                    }
+                }
+
+                tokio::select! {
+                    _ = shutdown_rx.changed() => {
+                        tracing::info!(engine = spec.name, "engine shutdown signal received");
+                        let _ = graceful_shutdown(&spec, &mut child, config.shutdown_grace).await;
+                        return;
+                    }
+                    status = child.wait() => {
+                        match status {
+                            Ok(exit) => tracing::warn!(engine = spec.name, exit = %exit, "engine exited unexpectedly"),
+                            Err(error) => tracing::warn!(engine = spec.name, error = %error, "failed waiting engine process"),
+                        }
+                        backoff_sleep(&spec, &config, restart_attempt, shutdown_rx).await;
+                        restart_attempt = restart_attempt.saturating_add(1);
+                    }
+                }
+            }
+            Err(error) => {
+                tracing::error!(engine = spec.name, error = %error, "engine spawn failed");
+                backoff_sleep(&spec, &config, restart_attempt, shutdown_rx).await;
+                restart_attempt = restart_attempt.saturating_add(1);
+            }
+        }
+    }
+}
+
+fn spawn_engine(spec: &EngineProcessSpec) -> Result<Child, std::io::Error> {
+    let mut cmd = Command::new(&spec.command);
+    cmd.args(&spec.args)
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(spec.port.to_string())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    tracing::info!(engine = spec.name, command = %spec.command, args = ?spec.args, "spawning engine command");
+    cmd.spawn()
+}
+
+async fn wait_for_readiness(
+    spec: &EngineProcessSpec,
+    config: &EngineManagerConfig,
+    shutdown_rx: &mut watch::Receiver<bool>,
+) -> Result<bool, std::io::Error> {
+    let timeout = tokio::time::sleep(config.startup_timeout);
+    tokio::pin!(timeout);
+
+    loop {
+        tokio::select! {
+            _ = shutdown_rx.changed() => return Ok(false),
+            _ = &mut timeout => return Ok(false),
+            _ = tokio::time::sleep(config.readiness_poll_interval) => {
+                if readiness_probe(spec.port, spec.health_path, config.readiness_poll_interval).await? {
+                    return Ok(true);
+                }
+            }
+        }
+    }
+}
+
+async fn readiness_probe(
+    port: u16,
+    health_path: &str,
+    timeout: Duration,
+) -> Result<bool, std::io::Error> {
+    let health_path = health_path.to_string();
+    tokio::task::spawn_blocking(move || {
+        let addr = ("127.0.0.1", port)
+            .to_socket_addrs()?
+            .next()
+            .ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::AddrNotAvailable, "no address")
+            })?;
+
+        let mut stream = TcpStream::connect_timeout(&addr, timeout)?;
+        stream.set_read_timeout(Some(timeout))?;
+        stream.set_write_timeout(Some(timeout))?;
+        let request = format!(
+            "GET {} HTTP/1.1\r\nHost: 127.0.0.1:{}\r\nConnection: close\r\n\r\n",
+            health_path, port
+        );
+        stream.write_all(request.as_bytes())?;
+        let mut response = String::new();
+        stream.read_to_string(&mut response)?;
+        Ok(response.starts_with("HTTP/1.1 200") || response.starts_with("HTTP/1.0 200"))
+    })
+    .await
+    .map_err(|error| std::io::Error::other(format!("probe join error: {error}")))?
+}
+
+async fn graceful_shutdown(
+    spec: &EngineProcessSpec,
+    child: &mut Child,
+    grace: Duration,
+) -> Result<(), std::io::Error> {
+    #[cfg(unix)]
+    {
+        if let Some(pid) = child.id() {
+            let _ = Command::new("kill")
+                .arg("-TERM")
+                .arg(pid.to_string())
+                .status()
+                .await;
+            tracing::info!(engine = spec.name, pid, "sent SIGTERM to engine process");
+        }
+    }
+
+    match tokio::time::timeout(grace, child.wait()).await {
+        Ok(wait_result) => {
+            let status = wait_result?;
+            tracing::info!(engine = spec.name, exit = %status, "engine exited gracefully");
+            Ok(())
+        }
+        Err(_) => {
+            tracing::warn!(
+                engine = spec.name,
+                "engine graceful shutdown timed out; forcing kill"
+            );
+            child.start_kill()?;
+            let _ = child.wait().await;
+            Ok(())
+        }
+    }
+}
+
+async fn backoff_sleep(
+    spec: &EngineProcessSpec,
+    config: &EngineManagerConfig,
+    attempt: usize,
+    shutdown_rx: &mut watch::Receiver<bool>,
+) {
+    let exponent = attempt.min(6) as u32;
+    let mut delay = config
+        .restart_backoff_base
+        .mul_f32((2u32.saturating_pow(exponent)) as f32);
+    if delay > config.restart_backoff_max {
+        delay = config.restart_backoff_max;
+    }
+    tracing::info!(
+        engine = spec.name,
+        backoff_ms = delay.as_millis() as u64,
+        "waiting before engine restart"
+    );
+
+    tokio::select! {
+        _ = shutdown_rx.changed() => {}
+        _ = tokio::time::sleep(delay) => {}
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,14 @@ use std::{
 
 use serde::Serialize;
 use serde_json::{json, Value};
-use tokio::sync::{mpsc, Semaphore};
+use tokio::sync::mpsc;
 use tracing_subscriber::{fmt as tracing_fmt, EnvFilter};
+
+mod engine_manager;
+mod workers;
+
+use engine_manager::{EngineManager, EngineManagerConfig, EngineProcessSpec};
+use workers::build_dispatchers;
 
 #[derive(Clone)]
 struct AppState {
@@ -24,27 +30,27 @@ struct AppState {
     dispatchers: Arc<HashMap<EngineKind, EngineDispatcher>>,
 }
 
-struct EngineDispatcher {
-    sender: mpsc::Sender<JobRequest>,
-    queue_depth: Arc<AtomicUsize>,
+pub(crate) struct EngineDispatcher {
+    pub(crate) sender: mpsc::Sender<JobRequest>,
+    pub(crate) queue_depth: Arc<AtomicUsize>,
 }
 
 #[derive(Debug)]
-struct JobRequest {
-    job_id: JobId,
-    engine: EngineKind,
-    payload: Value,
-    queue_depth_guard: Option<QueueDepthGuard>,
+pub(crate) struct JobRequest {
+    pub(crate) job_id: JobId,
+    pub(crate) engine: EngineKind,
+    pub(crate) payload: Value,
+    pub(crate) queue_depth_guard: Option<QueueDepthGuard>,
 }
 
 #[derive(Debug)]
-struct JobStore {
+pub(crate) struct JobStore {
     next_id: AtomicU64,
     jobs: Mutex<HashMap<JobId, Job>>,
 }
 
 #[derive(Clone, Debug)]
-struct AppConfig {
+pub(crate) struct AppConfig {
     host: String,
     api_port: u16,
     stt_queue_capacity: usize,
@@ -60,6 +66,18 @@ struct AppConfig {
     stt_engine_url: String,
     summarize_engine_url: String,
     embed_engine_url: String,
+    engine_supervision_enabled: bool,
+    stt_engine_command: String,
+    stt_engine_args: Vec<String>,
+    summarize_engine_command: String,
+    summarize_engine_args: Vec<String>,
+    embed_engine_command: String,
+    embed_engine_args: Vec<String>,
+    engine_startup_timeout_secs: u64,
+    engine_readiness_poll_ms: u64,
+    engine_shutdown_grace_secs: u64,
+    engine_restart_backoff_base_ms: u64,
+    engine_restart_backoff_max_ms: u64,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -86,7 +104,7 @@ struct JobError {
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
-enum EngineKind {
+pub(crate) enum EngineKind {
     Stt,
     Summarize,
     Embed,
@@ -103,27 +121,27 @@ enum JobStatus {
 }
 
 #[derive(Debug)]
-enum QueueEnqueueError {
+pub(crate) enum QueueEnqueueError {
     Full,
     Closed,
 }
 
 #[derive(Debug)]
-struct EngineResult {
-    payload: Value,
+pub(crate) struct EngineResult {
+    pub(crate) payload: Value,
 }
 
 #[derive(Debug)]
-struct EngineError {
-    code: &'static str,
-    message: String,
-    retryable: bool,
+pub(crate) struct EngineError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+    pub(crate) retryable: bool,
 }
 
 type EngineFuture<'a> =
     Pin<Box<dyn Future<Output = Result<EngineResult, EngineError>> + Send + 'a>>;
 
-trait EngineClient: Send + Sync {
+pub(crate) trait EngineClient: Send + Sync {
     fn call(&self, engine: EngineKind, payload: Value) -> EngineFuture<'_>;
 }
 
@@ -137,12 +155,12 @@ struct HttpEngineClient {
 }
 
 #[derive(Debug)]
-struct QueueDepthGuard {
+pub(crate) struct QueueDepthGuard {
     queue_depth: Arc<AtomicUsize>,
 }
 
 impl QueueDepthGuard {
-    fn new(queue_depth: Arc<AtomicUsize>) -> Self {
+    pub(crate) fn new(queue_depth: Arc<AtomicUsize>) -> Self {
         queue_depth.fetch_add(1, Ordering::Relaxed);
         Self { queue_depth }
     }
@@ -182,7 +200,7 @@ impl JobId {
         &self.0
     }
 
-    fn safe_for_logs(&self) -> String {
+    pub(crate) fn safe_for_logs(&self) -> String {
         sanitize_for_logs(self.as_str(), 24)
     }
 }
@@ -213,7 +231,7 @@ impl JobIdValidationError {
 }
 
 impl AppConfig {
-    fn from_env() -> Self {
+    pub(crate) fn from_env() -> Self {
         let host = env::var("RECORDROUTE_API_HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
         let api_port = env::var("RECORDROUTE_API_PORT")
             .ok()
@@ -239,6 +257,33 @@ impl AppConfig {
                 .unwrap_or_else(|_| "http://127.0.0.1:18101/infer".to_string()),
             embed_engine_url: env::var("RECORDROUTE_EMBED_ENGINE_URL")
                 .unwrap_or_else(|_| "http://127.0.0.1:18102/infer".to_string()),
+            engine_supervision_enabled: env::var("RECORDROUTE_ENGINE_SUPERVISION_ENABLED")
+                .ok()
+                .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+                .unwrap_or(false),
+            stt_engine_command: env::var("RECORDROUTE_STT_ENGINE_COMMAND")
+                .unwrap_or_else(|_| "whisper-server".to_string()),
+            stt_engine_args: read_csv_env("RECORDROUTE_STT_ENGINE_ARGS"),
+            summarize_engine_command: env::var("RECORDROUTE_SUMMARIZE_ENGINE_COMMAND")
+                .unwrap_or_else(|_| "llama-text".to_string()),
+            summarize_engine_args: read_csv_env("RECORDROUTE_SUMMARIZE_ENGINE_ARGS"),
+            embed_engine_command: env::var("RECORDROUTE_EMBED_ENGINE_COMMAND")
+                .unwrap_or_else(|_| "llama-embed".to_string()),
+            embed_engine_args: read_csv_env("RECORDROUTE_EMBED_ENGINE_ARGS"),
+            engine_startup_timeout_secs: read_u64_env(
+                "RECORDROUTE_ENGINE_STARTUP_TIMEOUT_SECS",
+                20,
+            ),
+            engine_readiness_poll_ms: read_u64_env("RECORDROUTE_ENGINE_READINESS_POLL_MS", 500),
+            engine_shutdown_grace_secs: read_u64_env("RECORDROUTE_ENGINE_SHUTDOWN_GRACE_SECS", 5),
+            engine_restart_backoff_base_ms: read_u64_env(
+                "RECORDROUTE_ENGINE_RESTART_BACKOFF_BASE_MS",
+                500,
+            ),
+            engine_restart_backoff_max_ms: read_u64_env(
+                "RECORDROUTE_ENGINE_RESTART_BACKOFF_MAX_MS",
+                15_000,
+            ),
         }
     }
 
@@ -246,7 +291,7 @@ impl AppConfig {
         format!("{}:{}", self.host, self.api_port).parse()
     }
 
-    fn queue_capacity(&self, engine: EngineKind) -> usize {
+    pub(crate) fn queue_capacity(&self, engine: EngineKind) -> usize {
         match engine {
             EngineKind::Stt => self.stt_queue_capacity,
             EngineKind::Summarize => self.summarize_queue_capacity,
@@ -254,7 +299,7 @@ impl AppConfig {
         }
     }
 
-    fn concurrency(&self, engine: EngineKind) -> usize {
+    pub(crate) fn concurrency(&self, engine: EngineKind) -> usize {
         match engine {
             EngineKind::Stt => self.stt_concurrency,
             EngineKind::Summarize => self.summarize_concurrency,
@@ -264,7 +309,7 @@ impl AppConfig {
 }
 
 impl JobStore {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             next_id: AtomicU64::new(1),
             jobs: Mutex::new(HashMap::new()),
@@ -302,7 +347,7 @@ impl JobStore {
             .cloned()
     }
 
-    fn mark_running(&self, job_id: &JobId) {
+    pub(crate) fn mark_running(&self, job_id: &JobId) {
         self.transition(job_id, |job| {
             if job.status == JobStatus::Queued {
                 job.status = JobStatus::Running;
@@ -311,7 +356,7 @@ impl JobStore {
         });
     }
 
-    fn mark_succeeded(&self, job_id: &JobId, result: Value) {
+    pub(crate) fn mark_succeeded(&self, job_id: &JobId, result: Value) {
         self.transition(job_id, |job| {
             if job.status == JobStatus::Running {
                 job.status = JobStatus::Succeeded;
@@ -321,7 +366,7 @@ impl JobStore {
         });
     }
 
-    fn mark_failed(&self, job_id: &JobId, code: &'static str, message: String) {
+    pub(crate) fn mark_failed(&self, job_id: &JobId, code: &'static str, message: String) {
         self.transition(job_id, |job| {
             if matches!(job.status, JobStatus::Queued | JobStatus::Running) {
                 job.status = JobStatus::Failed;
@@ -366,24 +411,11 @@ impl JobStore {
 }
 
 impl EngineKind {
-    fn as_str(self) -> &'static str {
+    pub(crate) fn as_str(self) -> &'static str {
         match self {
             EngineKind::Stt => "stt",
             EngineKind::Summarize => "summarize",
             EngineKind::Embed => "embed",
-        }
-    }
-}
-
-impl EngineDispatcher {
-    // queue_depth is an approximation based on accepted enqueues. It is decremented via RAII
-    // guard drop, which makes decrement reliable across success/failure/panic paths.
-    fn enqueue(&self, mut request: JobRequest) -> Result<(), QueueEnqueueError> {
-        request.queue_depth_guard = Some(QueueDepthGuard::new(self.queue_depth.clone()));
-        match self.sender.try_send(request) {
-            Ok(()) => Ok(()),
-            Err(mpsc::error::TrySendError::Full(_)) => Err(QueueEnqueueError::Full),
-            Err(mpsc::error::TrySendError::Closed(_)) => Err(QueueEnqueueError::Closed),
         }
     }
 }
@@ -478,6 +510,17 @@ async fn run_server() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let dispatchers = build_dispatchers(&config, jobs.clone(), engine_client);
 
+    let _engine_manager = if config.engine_supervision_enabled {
+        tracing::info!("engine supervision enabled");
+        Some(EngineManager::spawn(
+            engine_specs_from_config(&config),
+            supervision_config(&config),
+        ))
+    } else {
+        tracing::info!("engine supervision disabled");
+        None
+    };
+
     let state = AppState {
         ready: true,
         jobs,
@@ -490,101 +533,40 @@ async fn run_server() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     Ok(())
 }
 
-fn build_dispatchers(
-    config: &AppConfig,
-    jobs: Arc<JobStore>,
-    engine_client: Arc<dyn EngineClient>,
-) -> HashMap<EngineKind, EngineDispatcher> {
-    let mut dispatchers = HashMap::new();
-
-    for engine in [EngineKind::Stt, EngineKind::Summarize, EngineKind::Embed] {
-        let (sender, receiver) = mpsc::channel(config.queue_capacity(engine));
-        let queue_depth = Arc::new(AtomicUsize::new(0));
-        let semaphore = Arc::new(Semaphore::new(config.concurrency(engine).max(1)));
-
-        spawn_worker_loop(
-            engine,
-            receiver,
-            semaphore,
-            jobs.clone(),
-            engine_client.clone(),
-        );
-
-        dispatchers.insert(
-            engine,
-            EngineDispatcher {
-                sender,
-                queue_depth,
-            },
-        );
-    }
-
-    dispatchers
+fn engine_specs_from_config(config: &AppConfig) -> Vec<EngineProcessSpec> {
+    vec![
+        EngineProcessSpec {
+            name: "llama-text",
+            port: 18101,
+            command: config.summarize_engine_command.clone(),
+            args: config.summarize_engine_args.clone(),
+            health_path: "/healthz",
+        },
+        EngineProcessSpec {
+            name: "llama-embed",
+            port: 18102,
+            command: config.embed_engine_command.clone(),
+            args: config.embed_engine_args.clone(),
+            health_path: "/healthz",
+        },
+        EngineProcessSpec {
+            name: "whisper-server",
+            port: 18103,
+            command: config.stt_engine_command.clone(),
+            args: config.stt_engine_args.clone(),
+            health_path: "/healthz",
+        },
+    ]
 }
 
-fn spawn_worker_loop(
-    engine: EngineKind,
-    mut receiver: mpsc::Receiver<JobRequest>,
-    semaphore: Arc<Semaphore>,
-    jobs: Arc<JobStore>,
-    engine_client: Arc<dyn EngineClient>,
-) {
-    tokio::spawn(async move {
-        while let Some(request) = receiver.recv().await {
-            // Acquire permit before spawning so recv loop cannot drain queue without available
-            // execution capacity. This preserves bounded-mpsc backpressure under load.
-            let permit = semaphore
-                .clone()
-                .acquire_owned()
-                .await
-                .expect("engine semaphore closed unexpectedly");
-
-            let jobs = jobs.clone();
-            let engine_client = engine_client.clone();
-
-            tokio::spawn(async move {
-                let _permit = permit;
-                let _queue_depth_guard = request.queue_depth_guard;
-
-                let start = std::time::Instant::now();
-                jobs.mark_running(&request.job_id);
-                tracing::info!(
-                    job_id = %request.job_id.safe_for_logs(),
-                    engine = engine.as_str(),
-                    status_transition = "queued->running",
-                    "job started"
-                );
-
-                match engine_client.call(request.engine, request.payload).await {
-                    Ok(result) => {
-                        let latency_ms = start.elapsed().as_millis() as u64;
-                        jobs.mark_succeeded(&request.job_id, result.payload);
-                        tracing::info!(
-                            job_id = %request.job_id.safe_for_logs(),
-                            engine = engine.as_str(),
-                            status_transition = "running->succeeded",
-                            latency_ms,
-                            "job completed"
-                        );
-                    }
-                    Err(error) => {
-                        let latency_ms = start.elapsed().as_millis() as u64;
-                        jobs.mark_failed(&request.job_id, error.code, error.message.clone());
-                        tracing::warn!(
-                            job_id = %request.job_id.safe_for_logs(),
-                            engine = engine.as_str(),
-                            status_transition = "running->failed",
-                            latency_ms,
-                            retryable = error.retryable,
-                            error_code = error.code,
-                            error_message = %sanitize_for_logs(&error.message, 120),
-                            "job failed"
-                        );
-                    }
-                }
-            });
-        }
-    });
+fn supervision_config(config: &AppConfig) -> EngineManagerConfig {
+    EngineManagerConfig {
+        startup_timeout: Duration::from_secs(config.engine_startup_timeout_secs),
+        readiness_poll_interval: Duration::from_millis(config.engine_readiness_poll_ms),
+        shutdown_grace: Duration::from_secs(config.engine_shutdown_grace_secs),
+        restart_backoff_base: Duration::from_millis(config.engine_restart_backoff_base_ms),
+        restart_backoff_max: Duration::from_millis(config.engine_restart_backoff_max_ms),
+    }
 }
 
 fn run_blocking_server(
@@ -676,11 +658,16 @@ fn route_request(request_line: &str, state: &AppState) -> String {
                     },
                 ),
                 Err(QueueEnqueueError::Full) => {
+                    let reason = if dispatcher.queue_depth() >= state.jobs.running_count(engine) {
+                        "queue_full"
+                    } else {
+                        "engine_full"
+                    };
                     state.jobs.mark_rejected_queue_full(&job.job_id, engine);
                     json_error_response(
                         429,
-                        "queue_full",
-                        &format!("{} queue is full", engine.as_str()),
+                        reason,
+                        &format!("{} capacity exceeded ({reason})", engine.as_str()),
                     )
                 }
                 Err(QueueEnqueueError::Closed) => {
@@ -733,7 +720,7 @@ struct JobCreatedResponse<'a> {
     job_id: &'a str,
 }
 
-fn sanitize_for_logs(input: &str, max_len: usize) -> String {
+pub(crate) fn sanitize_for_logs(input: &str, max_len: usize) -> String {
     let mut out = String::new();
     for ch in input.chars() {
         if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
@@ -813,6 +800,19 @@ fn read_u64_env(key: &str, default: u64) -> u64 {
         .ok()
         .and_then(|value| value.parse::<u64>().ok())
         .unwrap_or(default)
+}
+
+fn read_csv_env(key: &str) -> Vec<String> {
+    env::var(key)
+        .ok()
+        .map(|raw| {
+            raw.split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn now_ms() -> u64 {

--- a/src/workers.rs
+++ b/src/workers.rs
@@ -1,0 +1,127 @@
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
+
+use tokio::sync::{mpsc, Semaphore};
+
+use crate::{
+    AppConfig, EngineClient, EngineDispatcher, EngineKind, JobRequest, JobStore, QueueDepthGuard,
+};
+
+pub fn build_dispatchers(
+    config: &AppConfig,
+    jobs: Arc<JobStore>,
+    engine_client: Arc<dyn EngineClient>,
+) -> HashMap<EngineKind, EngineDispatcher> {
+    let mut dispatchers = HashMap::new();
+
+    for engine in [EngineKind::Stt, EngineKind::Summarize, EngineKind::Embed] {
+        let (sender, receiver) = mpsc::channel(config.queue_capacity(engine));
+        let queue_depth = Arc::new(AtomicUsize::new(0));
+        let semaphore = Arc::new(Semaphore::new(config.concurrency(engine).max(1)));
+
+        spawn_worker_loop(
+            engine,
+            receiver,
+            semaphore,
+            jobs.clone(),
+            engine_client.clone(),
+        );
+
+        dispatchers.insert(
+            engine,
+            EngineDispatcher {
+                sender,
+                queue_depth,
+            },
+        );
+    }
+
+    dispatchers
+}
+
+pub fn spawn_worker_loop(
+    engine: EngineKind,
+    mut receiver: mpsc::Receiver<JobRequest>,
+    semaphore: Arc<Semaphore>,
+    jobs: Arc<JobStore>,
+    engine_client: Arc<dyn EngineClient>,
+) {
+    tokio::spawn(async move {
+        while let Some(request) = receiver.recv().await {
+            // Acquire permit before spawning so recv loop cannot drain queue without available
+            // execution capacity. This preserves bounded-mpsc backpressure under load.
+            let permit = semaphore
+                .clone()
+                .acquire_owned()
+                .await
+                .expect("engine semaphore closed unexpectedly");
+
+            let jobs = jobs.clone();
+            let engine_client = engine_client.clone();
+
+            tokio::spawn(async move {
+                let _permit = permit;
+                let _queue_depth_guard: Option<QueueDepthGuard> = request.queue_depth_guard;
+
+                let start = std::time::Instant::now();
+                jobs.mark_running(&request.job_id);
+                tracing::info!(
+                    job_id = %request.job_id.safe_for_logs(),
+                    engine = engine.as_str(),
+                    status_transition = "queued->running",
+                    "job started"
+                );
+
+                match engine_client.call(request.engine, request.payload).await {
+                    Ok(result) => {
+                        let latency_ms = start.elapsed().as_millis() as u64;
+                        jobs.mark_succeeded(&request.job_id, result.payload);
+                        tracing::info!(
+                            job_id = %request.job_id.safe_for_logs(),
+                            engine = engine.as_str(),
+                            status_transition = "running->succeeded",
+                            latency_ms,
+                            "job completed"
+                        );
+                    }
+                    Err(error) => {
+                        let latency_ms = start.elapsed().as_millis() as u64;
+                        jobs.mark_failed(&request.job_id, error.code, error.message.clone());
+                        tracing::warn!(
+                            job_id = %request.job_id.safe_for_logs(),
+                            engine = engine.as_str(),
+                            status_transition = "running->failed",
+                            latency_ms,
+                            retryable = error.retryable,
+                            error_code = error.code,
+                            error_message = %crate::sanitize_for_logs(&error.message, 120),
+                            "job failed"
+                        );
+                    }
+                }
+            });
+        }
+    });
+}
+
+impl crate::EngineDispatcher {
+    // queue_depth is an approximation based on accepted enqueues. It is decremented via RAII
+    // guard drop, which makes decrement reliable across success/failure/panic paths.
+    pub fn enqueue(&self, mut request: JobRequest) -> Result<(), crate::QueueEnqueueError> {
+        request.queue_depth_guard = Some(QueueDepthGuard::new(self.queue_depth.clone()));
+        match self.sender.try_send(request) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_)) => Err(crate::QueueEnqueueError::Full),
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(crate::QueueEnqueueError::Closed),
+        }
+    }
+
+    pub fn queue_depth(&self) -> usize {
+        self.queue_depth.load(Ordering::Relaxed)
+    }
+}


### PR DESCRIPTION
### Motivation
- Finalize Phase C by implementing real per-engine bounded queues and worker concurrency control to enforce queue-level backpressure and fixed worker concurrency limits.
- Begin Phase D by adding a supervision layer to run and manage the three engine processes (`llama-text`, `llama-embed`, `whisper-server`) with readiness gating and restart/backoff semantics.
- Align runtime behavior with the Rust/C++ backend rewrite plan and `architecture.md` goals: Rust orchestrator as single entrypoint, HTTP engine contracts, engine isolation on `127.0.0.1` and clear operational controls.

### Description
- Introduced `src/workers.rs` which encapsulates per-engine bounded `mpsc` queues + `Semaphore`-based concurrency and a worker loop that acquires a permit before spawning work to preserve backpressure; exposes `build_dispatchers` and `spawn_worker_loop` and `EngineDispatcher::enqueue` / `queue_depth()` accessor.
- Added `src/engine_manager.rs` implementing an `EngineManager` supervision tree using `tokio::process::Command` to spawn engine child processes with enforced `--host 127.0.0.1 --port <fixed>` args, readiness polling, exponential backoff restarts, graceful shutdown (SIGTERM) and force-kill fallback.
- Updated `src/main.rs` to wire the new modules (`mod workers`, `mod engine_manager`), add supervision config and feature flag `RECORDROUTE_ENGINE_SUPERVISION_ENABLED`, and to classify `429` responses as either `queue_full` or `engine_full` using queue depth vs running count heuristics when enqueue fails.
- Exposed environment-driven engine command/args and supervision timing/backoff via `AppConfig` (`RECORDROUTE_*` vars) and added a small helper `read_csv_env` to parse args lists.
- Enabled `tokio` `process` feature in `Cargo.toml` so the project can spawn and manage child processes with `tokio::process`.
- Logging uses `tracing` throughout; all engine communication remains via HTTP/transport probes (no FFI), and engine bindings are forced to `127.0.0.1` to satisfy security requirements.

### Testing
- Ran `cargo fmt --all` : PASS (formatting applied).
- Ran `cargo test` : FAIL to complete due to environment network restrictions preventing crates.io index downloads (403); unit tests could not be executed in this environment.
- Ran `cargo clippy --all-targets --all-features -- -D warnings` : FAIL in this environment for the same reason (crates.io network access blocked).
- Verified `cd frontend && npm run build` : PASS (frontend build completed successfully), demonstrating no frontend breakage.

Note: All implemented runtime behaviors (worker backpressure, semaphore concurrency, engine spawn/readiness/backoff/shutdown) are unit- and integration-testable locally in a full-network environment; re-running `cargo test`/`clippy` in CI or a developer machine with crates.io access is recommended before production rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bb345e3f4832eaaac811e89aca4ab)