### PR TITLE
fix: align rejected job error code with 429 capacity reason

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -387,14 +387,19 @@ impl JobStore {
         });
     }
 
-    fn mark_rejected_queue_full(&self, job_id: &JobId, engine: EngineKind) {
+    fn mark_rejected_capacity_exceeded(
+        &self,
+        job_id: &JobId,
+        engine: EngineKind,
+        code: &'static str,
+    ) {
         self.transition(job_id, |job| {
             if job.status == JobStatus::Queued {
                 job.status = JobStatus::Rejected;
                 job.finished_at_ms = Some(now_ms());
                 job.error = Some(JobError {
-                    code: "queue_full",
-                    message: format!("{} queue is full", engine.as_str()),
+                    code,
+                    message: format!("{} capacity exceeded ({code})", engine.as_str()),
                 });
             }
         });
@@ -709,7 +714,9 @@ fn route_request(request_line: &str, state: &AppState) -> String {
                     } else {
                         "engine_full"
                     };
-                    state.jobs.mark_rejected_queue_full(&job.job_id, engine);
+                    state
+                        .jobs
+                        .mark_rejected_capacity_exceeded(&job.job_id, engine, reason);
                     json_error_response(
                         429,
                         reason,
@@ -1239,6 +1246,8 @@ mod tests {
         assert!(second.starts_with("HTTP/1.1 429 Too Many Requests"));
         assert!(second.contains("\"code\":\"queue_full\""));
 
+        assert_eq!(find_first_rejected_error_code(&state), Some("queue_full"));
+
         let rejected = find_status_count(&state, JobStatus::Rejected);
         assert!(rejected >= 1);
     }
@@ -1446,6 +1455,17 @@ mod tests {
             .values()
             .filter(|job| job.status == target)
             .count()
+    }
+
+    fn find_first_rejected_error_code(state: &AppState) -> Option<&'static str> {
+        state
+            .jobs
+            .jobs
+            .lock()
+            .expect("job store mutex poisoned")
+            .values()
+            .find(|job| job.status == JobStatus::Rejected)
+            .and_then(|job| job.error.as_ref().map(|error| error.code))
     }
 
     fn extract_job_id(response: &str) -> String {


### PR DESCRIPTION
### Motivation
- Ensure API behavior and persisted job metadata are consistent by storing the same capacity reason used in the HTTP `429` response into the job record for rejected jobs.
- Remove the mismatch where rejected jobs were always recorded with `queue_full` even when the dispatch path returned `engine_full`.

### Description
- Replace the specialized helper with a generalized API `mark_rejected_capacity_exceeded(job_id, engine, code)` in `src/main.rs` so the chosen capacity reason is persisted into `JobError.code`.
- Call `mark_rejected_capacity_exceeded(..., reason)` from the dispatcher enqueue failure path where `reason` is either `"queue_full"` or `"engine_full"` depending on queue depth heuristics.
- Add a test helper `find_first_rejected_error_code` and a regression assertion in the queue-saturation test to verify the stored rejected job error code matches the API-level reason.
- Update rejection message formatting to include the chosen reason string for clearer logs and responses.

### Testing
- Ran `cargo fmt --all` which succeeded.
- Attempted `cargo test` but it was blocked by a crates.io index fetch failure in this environment (`CONNECT tunnel failed, response 403`) so test execution could not complete here.
- Attempted `cargo clippy --all-targets --all-features` but it was similarly blocked by the crates.io connectivity error and could not complete.
- Added a unit-level assertion to the existing tests that verifies rejected job `error.code` is set to the expected reason for the queue-full scenario.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bc9c0573c832ea53483ebe6c26137)