### PR TITLE
docs: mark OpenAPI alignment done in WBS and sync guide docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,9 @@
 
 ## 4) 변경 우선순위
 
+
+정렬 상태 메모:
+- OpenAPI 계약(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)은 Rust 목표 엔드포인트 기준으로 유지합니다.
 1. 계약 안정성(API 응답 필드/에러 규약)
 2. 운영 안전성(타임아웃, 큐 포화, 헬스체크)
 3. 성능 최적화(검색/벡터/read-heavy 경로)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@
 
 ## 현재 프로젝트 전제
 
+- OpenAPI 계약(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)은 Rust 목표 엔드포인트 기준으로 정렬되어 있습니다.
 - 루트에 Rust 실행 코드(`Cargo.toml`)가 존재하며, 백엔드 전환 구현이 진행 중입니다.
 - 운영 중 코드 기준은 `frontend/`(현행) + 루트 Rust 코드입니다.
 - 오디오 변환 기본 전략은 외부 `ffmpeg` 호출이 아니라 Rust `symphonia` 크레이트 사용입니다.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -7,6 +7,7 @@
 
 ## 핵심 컨텍스트
 
+- OpenAPI 계약(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)은 Rust 목표 엔드포인트 기준으로 정렬되어 있습니다.
 - 저장소는 Rust 전환 진행 중이며, 레거시 Python 코드는 현 저장소에 포함되어 있지 않습니다.
 - 루트에는 Rust 실행 코드가 존재하며, 문서/프론트와 함께 Rust 구현 변경도 작업 대상입니다.
 - 오디오 전처리/변환 기본안은 Rust `symphonia` 크레이트 기반입니다.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Rust 백엔드는 `/healthz`/`/readyz` + `POST /jobs`/`GET /jobs/{id}`와 엔진
 
 ## 운영 안정화 메모 (Phase B-2)
 
+- OpenAPI 계약은 Rust 목표 엔드포인트(`/healthz`, `/readyz`, `POST /jobs`, `GET /jobs/{job_id}`) 기준으로 정렬되어 있습니다.
 - 동시성 상한은 semaphore 대기 태스크 누적 대신 **고정 worker 개수**로 강제합니다.
 - bounded queue 백프레셔를 유지하여 과부하 시 `POST /jobs`가 `429(queue_full)`로 떨어지도록 합니다.
 - 엔진 HTTP 호출은 `connect_timeout` + read/write timeout을 적용해 connect 지연과 응답 지연 모두 시간 상한 내 실패합니다.

--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -5,6 +5,10 @@
 
 ## 작업 로그
 
+- 2026-02-23: OpenAPI/API 계약 Rust 목표 엔드포인트 정렬 상태 확인 및 WBS 반영
+  - `docs/openapi.yaml`, `docs/swagger/openapi.yaml` 기준 엔드포인트가 `/healthz`, `/readyz`, `POST /jobs`, `GET /jobs/{job_id}`로 정렬됨을 재검증
+  - 잡 상태/에러 코드(enum)가 Rust 오케스트레이터 구현 계약(`queued|running|completed|failed|timeout|canceled|rejected`, `invalid_job_id`, `queue_full` 등)과 일치함을 확인
+  - WBS `1.2 OpenAPI/API 계약 재정렬` 항목 완료 처리
 - 2026-02-22: Phase B-1 엔진별 큐 수용량/배압(429) 스켈레톤 도입
   - `POST /jobs?engine=<stt|summarize|embed>` 라우팅 추가(기본값 `stt`)
   - 엔진별 bounded capacity 기반 큐 포화 시 `429 + queue_full` 반환
@@ -44,8 +48,8 @@
 
 - [x] 1.1 Rust 단일 진입점/엔진 경계 문서 기준 확정
   - 근거 문서: `docs/architecture.md`, `docs/rust-cpp-backend-rewrite-plan.md`
-- [ ] 1.2 OpenAPI/API 계약을 Rust 목표 엔드포인트 기준으로 재정렬
-  - 비고: 현재 `docs/openapi.yaml`은 레거시 경로 중심
+- [x] 1.2 OpenAPI/API 계약을 Rust 목표 엔드포인트 기준으로 재정렬
+  - 근거 문서: `docs/openapi.yaml`, `docs/swagger/openapi.yaml`
 
 ## 2.0 런타임 스캐폴딩
 


### PR DESCRIPTION
### Motivation

- Document that the OpenAPI contract has been validated against the Rust orchestrator endpoints and record that WBS item 1.2 is complete so the next work item can proceed.

### Description

- Added a dated work log entry to `TODO/TODO.md` confirming `docs/openapi.yaml` and `docs/swagger/openapi.yaml` are aligned to the Rust endpoints and marked WBS item `1.2 OpenAPI/API 계약 재정렬` as completed.
- Synchronized top-level guidance by adding a short note to `README.md`, `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` stating that the OpenAPI contract is aligned to the Rust orchestrator endpoints (`/healthz`, `/readyz`, `POST /jobs`, `GET /jobs/{job_id}`).
- No runtime/code changes were made; this is a docs-only update to reflect current implementation/WBS state.

### Testing

- Ran a Markdown link existence check script across the updated docs and it passed (no broken relative links detected). 
- Ran formatting/patch checks via `git diff --check` to ensure no whitespace/patch issues and it passed. 
- Verified repository working-tree status with `git status --short` to confirm only the intended docs files were changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bcf5b50a4832eb1b513d42072083f)