### PR TITLE
feat(orchestrator): add degraded readiness and JSON /metrics endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 이 문서는 저장소 루트(`./`) 기준 에이전트 작업 표준입니다.
 
-> 문서 동기화 메모: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리) 상태를 README/CLAUDE/GEMINI/TODO와 정렬.
+> 문서 동기화 메모: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리, readyz degraded + /metrics 노출) 상태를 README/CLAUDE/GEMINI/TODO와 정렬.
 
 ## 1) 프로젝트 구조 인식
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 이 문서는 요약본이며, 상세 기준은 `AGENTS.md`를 따릅니다.
 
 
-> 문서 동기화: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리) 반영 상태와 정렬됨.
+> 문서 동기화: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리, readyz degraded + /metrics 노출) 반영 상태와 정렬됨.
 
 ## 우선 확인 순서
 
@@ -24,6 +24,7 @@
 - 오디오 변환 기본 전략은 외부 `ffmpeg` 호출이 아니라 Rust `symphonia` 크레이트 사용입니다.
 - 잡 상태는 `queued|running|completed|failed|timeout|canceled|rejected`로 관리합니다.
 - `POST /jobs` 과부하 응답은 `429(queue_full|engine_full)` 규약으로 구분되며 엔진/사유별 리젝션 카운트를 기록합니다.
+- `/readyz`는 수용량 압박 시 `503 degraded`로 응답하며, `/metrics`에서 readiness/queue/rejection 스냅샷(JSON)을 노출합니다.
 
 ## 작업 체크리스트
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,6 +42,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,6 +59,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
 name = "itoa"
@@ -128,6 +161,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "symphonia",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -217,6 +251,178 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-flac",
+ "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
+ "symphonia-codec-adpcm",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-isomp4",
+ "symphonia-format-mkv",
+ "symphonia-format-ogg",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-adpcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-format-isomp4"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-mkv"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-ogg"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
+]
 
 [[package]]
 name = "syn"

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -3,7 +3,7 @@
 최신 원본 기준은 `AGENTS.md`입니다. 이 문서는 실행 요약만 제공합니다.
 
 
-> 문서 동기화: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리) 반영 상태와 정렬됨.
+> 문서 동기화: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리, readyz degraded + /metrics 노출) 반영 상태와 정렬됨.
 
 ## 핵심 컨텍스트
 
@@ -11,6 +11,7 @@
 - 저장소는 Rust 전환 진행 중이며, 레거시 Python 코드는 현 저장소에 포함되어 있지 않습니다.
 - 루트에는 Rust 실행 코드가 존재하며, 문서/프론트와 함께 Rust 구현 변경도 작업 대상입니다.
 - `POST /jobs` 과부하 응답은 `429(queue_full|engine_full)`로 구분되며, 리젝션은 엔진/사유 라벨 카운트로 관측합니다.
+- `/readyz`는 수용량 압박 시 `503 degraded`로 응답하며, `/metrics`에서 readiness/queue/rejection 스냅샷(JSON)을 노출합니다.
 - 오디오 전처리/변환 기본안은 Rust `symphonia` 크레이트 기반입니다.
 
 ## 우선 참조

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ RecordRoute는 음성/문서 처리 파이프라인을 **Rust 중심 아키텍�
 Rust 백엔드는 `/healthz`/`/readyz` + `POST /jobs`/`GET /jobs/{id}`와 엔진별 bounded queue/worker 기반 처리 흐름(queued→running→completed|failed|timeout|canceled|rejected)까지 반영되어 있으며, 엔진 슈퍼비전/전처리/Swagger 분리 배포 구성을 단계적으로 이전합니다.
 
 
-> 문서 동기화: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리) 반영 상태와 정렬됨.
+> 문서 동기화: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리, readyz degraded + /metrics 노출) 반영 상태와 정렬됨.
 
 ## 운영 안정화 메모 (Phase B-2)
 
@@ -18,6 +18,8 @@ Rust 백엔드는 `/healthz`/`/readyz` + `POST /jobs`/`GET /jobs/{id}`와 엔진
 - 동시성 상한은 semaphore 대기 태스크 누적 대신 **고정 worker 개수**로 강제합니다.
 - bounded queue 백프레셔를 유지하며, 과부하 시 `POST /jobs`는 `429(queue_full|engine_full)`로 원인을 구분해 응답합니다.
 - 리젝션 관측성은 엔진/사유 라벨(`engine`, `reason`) 단위 카운트로 기록합니다.
+- `/readyz`는 수용량 압박(큐 포화/디스패처 종료) 발생 시 `503 {"status":"degraded"}`로 응답해 운영 경보 신호를 제공합니다.
+- `/metrics`는 readiness(ready/degraded), 엔진별 큐/워커/러닝 수, 리젝션 카운트 스냅샷(JSON)를 제공합니다.
 - 엔진 HTTP 호출은 `connect_timeout` + read/write timeout을 적용해 connect 지연과 응답 지연 모두 시간 상한 내 실패합니다.
 - `job_id`는 `[a-zA-Z0-9_-]`, 1..64 규칙으로 검증되며 invalid 입력은 `400 invalid_job_id`로 응답합니다.
 - queue depth는 **근사 지표(accepted enqueue 기준)**로 정의하고 RAII guard Drop으로 감소 정합성을 보장합니다.

--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -5,6 +5,11 @@
 
 ## 작업 로그
 
+- 2026-02-23: Phase C-1 degraded readiness/운영 메트릭 노출 반영
+  - `/readyz`가 용량 리젝션/디스패처 종료 시 `degraded` 상태를 503으로 반환하도록 조정
+  - `/metrics` 엔드포인트에 readiness(ready/degraded), 엔진별 queue/running, 리젝션(engine/reason) 스냅샷 추가
+  - 라우팅 단위 테스트(`readyz degraded`, `metrics`) 추가 및 회귀 검증
+
 - 2026-02-23: Phase B-2 429 사유 분리/리젝션 메트릭 라벨 분리 반영
   - `POST /jobs` enqueue 실패(Full) 시 `engine_full`/`queue_full` reason을 worker 포화 기준으로 분리
   - 엔진/사유(`engine`, `reason`) 단위 리젝션 카운터를 오케스트레이터 메모리 지표로 추가
@@ -85,7 +90,7 @@
 
 - [x] 6.1 child 생명주기 감시 + backoff 재시작
 - [x] 6.2 graceful shutdown + 강제 종료 fallback
-- [ ] 6.3 degraded 상태/관측성 메트릭 반영
+- [x] 6.3 degraded 상태/관측성 메트릭 반영
 
 ## 7.0 배포/문서 분리
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::{
     net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs},
     pin::Pin,
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc, Mutex,
     },
     time::Duration,
@@ -29,6 +29,7 @@ use workers::build_dispatchers;
 #[derive(Clone)]
 struct AppState {
     ready: bool,
+    degraded: Arc<AtomicBool>,
     jobs: Arc<JobStore>,
     dispatchers: Arc<HashMap<EngineKind, EngineDispatcher>>,
     rejection_metrics: Arc<RejectionMetrics>,
@@ -44,6 +45,35 @@ pub(crate) struct EngineDispatcher {
 #[derive(Debug)]
 struct RejectionMetrics {
     counters: Mutex<HashMap<(EngineKind, &'static str), u64>>,
+}
+
+#[derive(Serialize)]
+struct MetricsResponse {
+    readiness: ReadinessMetrics,
+    engines: Vec<EngineMetrics>,
+    rejections: Vec<RejectionMetric>,
+}
+
+#[derive(Serialize)]
+struct ReadinessMetrics {
+    ready: bool,
+    degraded: bool,
+}
+
+#[derive(Serialize)]
+struct EngineMetrics {
+    engine: &'static str,
+    queue_depth: usize,
+    queue_capacity: usize,
+    worker_count: usize,
+    running: usize,
+}
+
+#[derive(Serialize)]
+struct RejectionMetric {
+    engine: &'static str,
+    reason: &'static str,
+    count: u64,
 }
 
 #[derive(Debug)]
@@ -242,6 +272,22 @@ impl RejectionMetrics {
         *counter
     }
 
+    fn snapshot(&self) -> Vec<RejectionMetric> {
+        let counters = self
+            .counters
+            .lock()
+            .expect("rejection metrics mutex poisoned");
+
+        counters
+            .iter()
+            .map(|((engine, reason), count)| RejectionMetric {
+                engine: engine.as_str(),
+                reason,
+                count: *count,
+            })
+            .collect()
+    }
+
     #[cfg(test)]
     fn count(&self, engine: EngineKind, reason: &'static str) -> u64 {
         *self
@@ -366,6 +412,7 @@ async fn run_server() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let state = AppState {
         ready: true,
+        degraded: Arc::new(AtomicBool::new(false)),
         jobs,
         dispatchers: Arc::new(dispatchers),
         rejection_metrics: Arc::new(RejectionMetrics::new()),
@@ -462,16 +509,40 @@ fn route_request(request_line: &str, state: &AppState) -> String {
     match (method, path) {
         ("GET", "/healthz") => json_response(200, &StatusBody { status: "ok" }),
         ("GET", "/readyz") => {
-            if state.ready {
+            if state.ready && !state.degraded.load(Ordering::Relaxed) {
                 json_response(200, &StatusBody { status: "ready" })
             } else {
-                json_response(
-                    503,
-                    &StatusBody {
-                        status: "not_ready",
-                    },
-                )
+                json_response(503, &StatusBody { status: "degraded" })
             }
+        }
+        ("GET", "/metrics") => {
+            let engines = [EngineKind::Stt, EngineKind::Summarize, EngineKind::Embed]
+                .iter()
+                .filter_map(|engine| {
+                    state
+                        .dispatchers
+                        .get(engine)
+                        .map(|dispatcher| EngineMetrics {
+                            engine: engine.as_str(),
+                            queue_depth: dispatcher.queue_depth(),
+                            queue_capacity: dispatcher.queue_capacity,
+                            worker_count: dispatcher.worker_count,
+                            running: state.jobs.running_count(*engine),
+                        })
+                })
+                .collect();
+
+            json_response(
+                200,
+                &MetricsResponse {
+                    readiness: ReadinessMetrics {
+                        ready: state.ready,
+                        degraded: state.degraded.load(Ordering::Relaxed),
+                    },
+                    engines,
+                    rejections: state.rejection_metrics.snapshot(),
+                },
+            )
         }
         ("POST", "/jobs") => {
             let engine = parse_engine_kind(query).unwrap_or(EngineKind::Stt);
@@ -495,13 +566,17 @@ fn route_request(request_line: &str, state: &AppState) -> String {
             };
 
             match dispatcher.enqueue(request) {
-                Ok(()) => json_response(
-                    202,
-                    &JobCreatedResponse {
-                        job_id: job.job_id.as_str(),
-                    },
-                ),
+                Ok(()) => {
+                    state.degraded.store(false, Ordering::Relaxed);
+                    json_response(
+                        202,
+                        &JobCreatedResponse {
+                            job_id: job.job_id.as_str(),
+                        },
+                    )
+                }
                 Err(QueueEnqueueError::Full) => {
+                    state.degraded.store(true, Ordering::Relaxed);
                     let reason = rejection_reason_for_full(engine, dispatcher, &state.jobs);
                     let rejection_count = state.rejection_metrics.increment(engine, reason);
                     state
@@ -524,6 +599,7 @@ fn route_request(request_line: &str, state: &AppState) -> String {
                     )
                 }
                 Err(QueueEnqueueError::Closed) => {
+                    state.degraded.store(true, Ordering::Relaxed);
                     let rejection_count = state
                         .rejection_metrics
                         .increment(engine, "engine_dispatcher_closed");
@@ -919,6 +995,7 @@ mod tests {
 
         AppState {
             ready: true,
+            degraded: Arc::new(AtomicBool::new(false)),
             jobs,
             dispatchers: Arc::new(dispatchers),
             rejection_metrics: Arc::new(RejectionMetrics::new()),
@@ -967,6 +1044,7 @@ mod tests {
 
         AppState {
             ready: true,
+            degraded: Arc::new(AtomicBool::new(false)),
             jobs,
             dispatchers: Arc::new(dispatchers),
             rejection_metrics: Arc::new(RejectionMetrics::new()),
@@ -984,6 +1062,43 @@ mod tests {
         let response = route_request("GET /healthz HTTP/1.1", &build_state(8, 1, client));
         assert!(response.starts_with("HTTP/1.1 200 OK"));
         assert!(response.contains("{\"status\":\"ok\"}"));
+    }
+
+    #[tokio::test]
+    async fn readyz_returns_degraded_when_flag_is_set() {
+        let client = Arc::new(MockEngineClient {
+            fail_with_5xx: Arc::new(AtomicBool::new(false)),
+            delay: Duration::ZERO,
+            inflight: Arc::new(AtomicUsize::new(0)),
+            max_inflight: Arc::new(AtomicUsize::new(0)),
+        });
+        let state = build_state(8, 1, client);
+        state.degraded.store(true, Ordering::Relaxed);
+
+        let response = route_request("GET /readyz HTTP/1.1", &state);
+        assert!(response.starts_with("HTTP/1.1 503 Service Unavailable"));
+        assert!(response.contains("{\"status\":\"degraded\"}"));
+    }
+
+    #[tokio::test]
+    async fn metrics_route_returns_queue_and_rejection_metrics() {
+        let client = Arc::new(MockEngineClient {
+            fail_with_5xx: Arc::new(AtomicBool::new(false)),
+            delay: Duration::from_millis(200),
+            inflight: Arc::new(AtomicUsize::new(0)),
+            max_inflight: Arc::new(AtomicUsize::new(0)),
+        });
+        let state = build_state(1, 1, client);
+
+        let _ = route_request("POST /jobs?engine=stt HTTP/1.1", &state);
+        let _ = route_request("POST /jobs?engine=stt HTTP/1.1", &state);
+
+        let response = route_request("GET /metrics HTTP/1.1", &state);
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(response.contains("\"readiness\""));
+        assert!(response.contains("\"engines\""));
+        assert!(response.contains("\"rejections\""));
+        assert!(response.contains("\"engine\":\"stt\""));
     }
 
     #[tokio::test]
@@ -1275,6 +1390,7 @@ mod tests {
         let completed = find_status_count(
             &AppState {
                 ready: true,
+                degraded: Arc::new(AtomicBool::new(false)),
                 jobs: store,
                 dispatchers: Arc::new(HashMap::new()),
                 rejection_metrics: Arc::new(RejectionMetrics::new()),


### PR DESCRIPTION
### Motivation
- Surface capacity pressure and basic runtime observability without adding external exporters by exposing a degraded readiness signal and an internal JSON `/metrics` snapshot. 
- Provide an operator-visible trigger when queues or dispatchers are under pressure so readiness probes can drive alerts and automated actions. 

### Description
- Added a `degraded` flag to `AppState` and logic to set/clear it on enqueue success/failure to reflect capacity pressure in the orchestrator (`src/main.rs`).
- Implemented a JSON `/metrics` route and related response models that snapshot readiness, per-engine queue/worker/running values, and rejection counters (`MetricsResponse`, `ReadinessMetrics`, `EngineMetrics`, `RejectionMetric`) in `src/main.rs`.
- Added `RejectionMetrics::snapshot()` to export engine/reason counters and wired rejection increments to record labeled metrics on capacity or dispatcher-closed events (`src/main.rs`).
- Updated documentation and tracking files to reflect the change: `README.md`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and `TODO/TODO.md`; the lockfile (`Cargo.lock`) was updated by dependency resolution.

### Testing
- Ran `cargo test` and unit tests (including new `readyz_returns_degraded_when_flag_is_set` and `metrics_route_returns_queue_and_rejection_metrics`) all passed (17 tests passed, 0 failed). 
- Ran `cargo fmt --all` and `cargo clippy --all-targets --all-features` (basic clippy run completed); both completed successfully under default warning settings. 
- Running `cargo clippy --all-targets --all-features -- -D warnings` fails due to pre-existing repository warnings (dead-code / clippy hints) unrelated to this change and not introduced by this PR. 
- All automated checks above were used as validation evidence for the RTD Step 5–18 pass decisions recorded during the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c6abfac74832e86d6b2663f1c1432)