### PR TITLE
feat(orchestrator): length-based job timeout budgeting for STT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 이 문서는 저장소 루트(`./`) 기준 에이전트 작업 표준입니다.
 
-> 문서 동기화 메모: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리, readyz degraded + /metrics 노출) 상태를 README/CLAUDE/GEMINI/TODO와 정렬.
+> 문서 동기화 메모: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, 길이/예산 기반 job timeout 산정식, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리, readyz degraded + /metrics 노출) 상태를 README/CLAUDE/GEMINI/TODO와 정렬.
 
 ## 1) 프로젝트 구조 인식
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 이 문서는 요약본이며, 상세 기준은 `AGENTS.md`를 따릅니다.
 
 
-> 문서 동기화: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리, readyz degraded + /metrics 노출) 반영 상태와 정렬됨.
+> 문서 동기화: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, 길이/예산 기반 job timeout 산정식, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리, readyz degraded + /metrics 노출) 반영 상태와 정렬됨.
 
 ## 우선 확인 순서
 
@@ -25,6 +25,7 @@
 - 잡 상태는 `queued|running|completed|failed|timeout|canceled|rejected`로 관리합니다.
 - `POST /jobs` 과부하 응답은 `429(queue_full|engine_full)` 규약으로 구분되며 엔진/사유별 리젝션 카운트를 기록합니다.
 - `/readyz`는 수용량 압박 시 `503 degraded`로 응답하며, `/metrics`에서 readiness/queue/rejection 스냅샷(JSON)을 노출합니다.
+- STT는 `audio_ms` 길이 입력이 있을 때 처리율/버퍼/상하한 기반 timeout budget 산정식을 적용합니다.
 
 ## 작업 체크리스트
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -3,7 +3,7 @@
 최신 원본 기준은 `AGENTS.md`입니다. 이 문서는 실행 요약만 제공합니다.
 
 
-> 문서 동기화: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리, readyz degraded + /metrics 노출) 반영 상태와 정렬됨.
+> 문서 동기화: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, 길이/예산 기반 job timeout 산정식, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리, readyz degraded + /metrics 노출) 반영 상태와 정렬됨.
 
 ## 핵심 컨텍스트
 
@@ -12,6 +12,7 @@
 - 루트에는 Rust 실행 코드가 존재하며, 문서/프론트와 함께 Rust 구현 변경도 작업 대상입니다.
 - `POST /jobs` 과부하 응답은 `429(queue_full|engine_full)`로 구분되며, 리젝션은 엔진/사유 라벨 카운트로 관측합니다.
 - `/readyz`는 수용량 압박 시 `503 degraded`로 응답하며, `/metrics`에서 readiness/queue/rejection 스냅샷(JSON)을 노출합니다.
+- STT는 `audio_ms` 길이 입력이 있을 때 처리율/버퍼/상하한 기반 timeout budget 산정식을 적용합니다.
 - 오디오 전처리/변환 기본안은 Rust `symphonia` 크레이트 기반입니다.
 
 ## 우선 참조

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ RecordRoute는 음성/문서 처리 파이프라인을 **Rust 중심 아키텍�
 Rust 백엔드는 `/healthz`/`/readyz` + `POST /jobs`/`GET /jobs/{id}`와 엔진별 bounded queue/worker 기반 처리 흐름(queued→running→completed|failed|timeout|canceled|rejected)까지 반영되어 있으며, 엔진 슈퍼비전/전처리/Swagger 분리 배포 구성을 단계적으로 이전합니다.
 
 
-> 문서 동기화: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리, readyz degraded + /metrics 노출) 반영 상태와 정렬됨.
+> 문서 동기화: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, 길이/예산 기반 job timeout 산정식, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리, readyz degraded + /metrics 노출) 반영 상태와 정렬됨.
 
 ## 운영 안정화 메모 (Phase B-2)
 
@@ -19,6 +19,7 @@ Rust 백엔드는 `/healthz`/`/readyz` + `POST /jobs`/`GET /jobs/{id}`와 엔진
 - bounded queue 백프레셔를 유지하며, 과부하 시 `POST /jobs`는 `429(queue_full|engine_full)`로 원인을 구분해 응답합니다.
 - 리젝션 관측성은 엔진/사유 라벨(`engine`, `reason`) 단위 카운트로 기록합니다.
 - `/readyz`는 수용량 압박(큐 포화/디스패처 종료) 발생 시 `503 {"status":"degraded"}`로 응답해 운영 경보 신호를 제공합니다.
+- 길이(`audio_ms`) 기반으로 STT job timeout budget을 산정하며, 처리율/버퍼/상하한(min/max)은 환경변수로 조정합니다.
 - `/metrics`는 readiness(ready/degraded), 엔진별 큐/워커/러닝 수, 리젝션 카운트 스냅샷(JSON)를 제공합니다.
 - 엔진 HTTP 호출은 `connect_timeout` + read/write timeout을 적용해 connect 지연과 응답 지연 모두 시간 상한 내 실패합니다.
 - `job_id`는 `[a-zA-Z0-9_-]`, 1..64 규칙으로 검증되며 invalid 입력은 `400 invalid_job_id`로 응답합니다.

--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -5,6 +5,11 @@
 
 ## 작업 로그
 
+- 2026-02-23: Phase E-1 길이/예산 기반 job timeout 산정식 1차 반영
+  - `POST /jobs?engine=stt&audio_ms=<ms>` 입력 시 `job_timeout = clamp((audio_ms * per_audio_sec_ms / 1000) + buffer_ms, min, max)` 산식으로 timeout budget 계산
+  - timeout 파라미터는 환경변수(`RECORDROUTE_JOB_TIMEOUT_MIN_SECS`, `RECORDROUTE_JOB_TIMEOUT_MAX_SECS`, `RECORDROUTE_STT_TIMEOUT_PER_AUDIO_SEC_MS`, `RECORDROUTE_STT_TIMEOUT_BUFFER_MS`)로 제어
+  - 워커가 요청별 timeout budget을 사용하도록 조정하고 기존 timeout 회귀 테스트 통과 확인
+
 - 2026-02-23: Phase C-1 degraded readiness/운영 메트릭 노출 반영
   - `/readyz`가 용량 리젝션/디스패처 종료 시 `degraded` 상태를 503으로 반환하도록 조정
   - `/metrics` 엔드포인트에 readiness(ready/degraded), 엔진별 queue/running, 리젝션(engine/reason) 스냅샷 추가
@@ -83,7 +88,7 @@
 ## 5.0 오디오 전처리/처리량 정책
 
 - [x] 5.1 `symphonia` 기반 오디오 정규화 (16kHz/16-bit mono WAV)
-- [ ] 5.2 길이/예산 계산 기반 timeout 산정식 적용
+- [x] 5.2 길이/예산 계산 기반 timeout 산정식 적용
 - [ ] 5.3 whisper-server 추론 책임 한정(변환 책임 제거)
 
 ## 6.0 슈퍼비전/운영 안정성
@@ -100,6 +105,6 @@
 
 ## 다음 우선순위 (실행 단위)
 
-1. 엔진별 semaphore/워커 모델로 큐 추상화(`stt/summarize/embed`) 고도화
+1. whisper-server 추론 책임 한정(변환 책임 제거)
 2. 엔진별 클라이언트/포트 설정(`18101`, `18102`, `18103`) + readiness 연동
-3. 잡 상태 전이 확장(`running|completed|failed|timeout|canceled`) 및 타임아웃 계층 연결
+3. 운영 점검 시나리오(장애/복구/부하) 문서화

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ use workers::build_dispatchers;
 struct AppState {
     ready: bool,
     degraded: Arc<AtomicBool>,
+    config: Arc<AppConfig>,
     jobs: Arc<JobStore>,
     dispatchers: Arc<HashMap<EngineKind, EngineDispatcher>>,
     rejection_metrics: Arc<RejectionMetrics>,
@@ -81,6 +82,7 @@ pub(crate) struct JobRequest {
     pub(crate) job_id: JobId,
     pub(crate) engine: EngineKind,
     pub(crate) payload: Value,
+    pub(crate) timeout_budget: Duration,
     pub(crate) queue_depth_guard: Option<QueueDepthGuard>,
 }
 
@@ -96,6 +98,10 @@ pub(crate) struct AppConfig {
     embed_concurrency: usize,
     engine_timeout_secs: u64,
     pub(crate) job_timeout_secs: u64,
+    pub(crate) job_timeout_min_secs: u64,
+    pub(crate) job_timeout_max_secs: u64,
+    pub(crate) stt_timeout_per_audio_sec_ms: u64,
+    pub(crate) stt_timeout_buffer_ms: u64,
     engine_connect_timeout_ms: u64,
     engine_retry_count: usize,
     engine_base_backoff_ms: u64,
@@ -195,6 +201,13 @@ impl AppConfig {
             embed_concurrency: read_usize_env("RECORDROUTE_EMBED_CONCURRENCY", 2),
             engine_timeout_secs: read_u64_env("RECORDROUTE_ENGINE_TIMEOUT_SECS", 60),
             job_timeout_secs: read_u64_env("RECORDROUTE_JOB_TIMEOUT_SECS", 120),
+            job_timeout_min_secs: read_u64_env("RECORDROUTE_JOB_TIMEOUT_MIN_SECS", 30),
+            job_timeout_max_secs: read_u64_env("RECORDROUTE_JOB_TIMEOUT_MAX_SECS", 900),
+            stt_timeout_per_audio_sec_ms: read_u64_env(
+                "RECORDROUTE_STT_TIMEOUT_PER_AUDIO_SEC_MS",
+                1_500,
+            ),
+            stt_timeout_buffer_ms: read_u64_env("RECORDROUTE_STT_TIMEOUT_BUFFER_MS", 5_000),
             engine_connect_timeout_ms: read_u64_env("RECORDROUTE_ENGINE_CONNECT_TIMEOUT_MS", 1_500),
             engine_retry_count: read_usize_env("RECORDROUTE_ENGINE_RETRY_COUNT", 1),
             engine_base_backoff_ms: read_u64_env("RECORDROUTE_ENGINE_BACKOFF_MS", 200),
@@ -413,6 +426,7 @@ async fn run_server() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let state = AppState {
         ready: true,
         degraded: Arc::new(AtomicBool::new(false)),
+        config: Arc::new(config.clone()),
         jobs,
         dispatchers: Arc::new(dispatchers),
         rejection_metrics: Arc::new(RejectionMetrics::new()),
@@ -555,13 +569,16 @@ fn route_request(request_line: &str, state: &AppState) -> String {
             };
 
             let job = state.jobs.create_queued_job(engine);
+            let timeout_budget = derive_job_timeout_budget(engine, query, &state.config);
             let request = JobRequest {
                 job_id: job.job_id.clone(),
                 engine,
                 payload: json!({
                     "job_id": job.job_id,
                     "engine": engine.as_str(),
+                    "timeout_budget_ms": timeout_budget.as_millis(),
                 }),
+                timeout_budget,
                 queue_depth_guard: None,
             };
 
@@ -640,6 +657,50 @@ fn route_request(request_line: &str, state: &AppState) -> String {
         ("GET", _) => json_error_response(404, "not_found", "not found"),
         _ => json_error_response(405, "method_not_allowed", "method not allowed"),
     }
+}
+
+fn derive_job_timeout_budget(
+    engine: EngineKind,
+    query: Option<&str>,
+    config: &AppConfig,
+) -> Duration {
+    let default_timeout = Duration::from_secs(config.job_timeout_secs);
+    let Some(query) = query else {
+        return default_timeout;
+    };
+
+    let min_ms = config.job_timeout_min_secs.saturating_mul(1_000);
+    let max_ms = config.job_timeout_max_secs.saturating_mul(1_000);
+    let min_ms = min_ms.min(max_ms);
+    let max_ms = max_ms.max(min_ms);
+
+    if engine != EngineKind::Stt {
+        let clamped = default_timeout.as_millis() as u64;
+        return Duration::from_millis(clamped.clamp(min_ms, max_ms));
+    }
+
+    let Some(audio_ms) = query_u64(query, "audio_ms") else {
+        let clamped = default_timeout.as_millis() as u64;
+        return Duration::from_millis(clamped.clamp(min_ms, max_ms));
+    };
+
+    let per_audio_sec_ms = config.stt_timeout_per_audio_sec_ms;
+    let buffer_ms = config.stt_timeout_buffer_ms;
+    let estimated_ms = audio_ms
+        .saturating_mul(per_audio_sec_ms)
+        .checked_div(1_000)
+        .unwrap_or(u64::MAX)
+        .saturating_add(buffer_ms);
+
+    Duration::from_millis(estimated_ms.clamp(min_ms, max_ms))
+}
+
+fn query_u64(query: &str, key: &str) -> Option<u64> {
+    query
+        .split('&')
+        .filter_map(|token| token.split_once('='))
+        .find_map(|(k, v)| (k == key).then_some(v))
+        .and_then(|v| v.parse::<u64>().ok())
 }
 
 fn rejection_reason_for_full(
@@ -970,6 +1031,10 @@ mod tests {
             embed_concurrency: concurrency,
             engine_timeout_secs: 60,
             job_timeout_secs: 2,
+            job_timeout_min_secs: 1,
+            job_timeout_max_secs: 30,
+            stt_timeout_per_audio_sec_ms: 1_500,
+            stt_timeout_buffer_ms: 5_000,
             engine_connect_timeout_ms: 50,
             engine_retry_count: 0,
             engine_base_backoff_ms: 1,
@@ -996,6 +1061,7 @@ mod tests {
         AppState {
             ready: true,
             degraded: Arc::new(AtomicBool::new(false)),
+            config: Arc::new(config),
             jobs,
             dispatchers: Arc::new(dispatchers),
             rejection_metrics: Arc::new(RejectionMetrics::new()),
@@ -1019,6 +1085,10 @@ mod tests {
             embed_concurrency: concurrency,
             engine_timeout_secs: 60,
             job_timeout_secs,
+            job_timeout_min_secs: 0,
+            job_timeout_max_secs: 30,
+            stt_timeout_per_audio_sec_ms: 1_500,
+            stt_timeout_buffer_ms: 5_000,
             engine_connect_timeout_ms: 50,
             engine_retry_count: 0,
             engine_base_backoff_ms: 1,
@@ -1045,6 +1115,7 @@ mod tests {
         AppState {
             ready: true,
             degraded: Arc::new(AtomicBool::new(false)),
+            config: Arc::new(config),
             jobs,
             dispatchers: Arc::new(dispatchers),
             rejection_metrics: Arc::new(RejectionMetrics::new()),
@@ -1391,6 +1462,7 @@ mod tests {
             &AppState {
                 ready: true,
                 degraded: Arc::new(AtomicBool::new(false)),
+                config: Arc::new(AppConfig::from_env()),
                 jobs: store,
                 dispatchers: Arc::new(HashMap::new()),
                 rejection_metrics: Arc::new(RejectionMetrics::new()),
@@ -1398,6 +1470,36 @@ mod tests {
             JobStatus::Completed,
         );
         assert_eq!(completed, 32 * 200);
+    }
+
+    #[tokio::test]
+    async fn timeout_budget_formula_applies_for_stt_audio_length() {
+        let client = Arc::new(MockEngineClient {
+            fail_with_5xx: Arc::new(AtomicBool::new(false)),
+            delay: Duration::ZERO,
+            inflight: Arc::new(AtomicUsize::new(0)),
+            max_inflight: Arc::new(AtomicUsize::new(0)),
+        });
+        let state = build_state(8, 1, client);
+
+        let budget =
+            derive_job_timeout_budget(EngineKind::Stt, Some("audio_ms=10000"), &state.config);
+        assert_eq!(budget, Duration::from_secs(20));
+    }
+
+    #[tokio::test]
+    async fn timeout_budget_is_clamped_to_max() {
+        let client = Arc::new(MockEngineClient {
+            fail_with_5xx: Arc::new(AtomicBool::new(false)),
+            delay: Duration::ZERO,
+            inflight: Arc::new(AtomicUsize::new(0)),
+            max_inflight: Arc::new(AtomicUsize::new(0)),
+        });
+        let state = build_state(8, 1, client);
+
+        let budget =
+            derive_job_timeout_budget(EngineKind::Stt, Some("audio_ms=999999999"), &state.config);
+        assert_eq!(budget, Duration::from_secs(30));
     }
 
     async fn wait_for_status(state: &AppState, job_id: &str, target: JobStatus) {

--- a/src/workers.rs
+++ b/src/workers.rs
@@ -57,7 +57,7 @@ pub fn spawn_worker_pool(
     worker_count: usize,
     jobs: Arc<JobStore>,
     engine_client: Arc<dyn EngineClient>,
-    job_timeout: Duration,
+    _job_timeout: Duration,
 ) {
     let receiver = Arc::new(Mutex::new(receiver));
 
@@ -94,8 +94,10 @@ pub fn spawn_worker_pool(
                     "job started"
                 );
 
+                let timeout_budget = request.timeout_budget;
+
                 match timeout(
-                    job_timeout,
+                    timeout_budget,
                     engine_client.call(request.engine, request.payload),
                 )
                 .await
@@ -134,7 +136,7 @@ pub fn spawn_worker_pool(
                             "job_timeout",
                             format!(
                                 "job exceeded timeout budget: {} ms",
-                                job_timeout.as_millis()
+                                timeout_budget.as_millis()
                             ),
                         );
                         tracing::warn!(


### PR DESCRIPTION
### Motivation
- Provide predictable per-request job timeouts for STT workloads by deriving a timeout budget from audio length instead of using a fixed job timeout. 
- Complete TODO 5.2 (length/ budget-based timeout formula) so long-running audio jobs receive a sensible timeout estimate while protecting the system with min/max clamps and saturation guards. 

### Description
- Add per-request `timeout_budget: Duration` to `JobRequest` and propagate a computed budget from the router into workers. 
- Extend `AppConfig` with environment-controllable parameters `job_timeout_min_secs`, `job_timeout_max_secs`, `stt_timeout_per_audio_sec_ms`, and `stt_timeout_buffer_ms`, and compute budgets with `derive_job_timeout_budget` (formula: clamp((audio_ms * per_audio_sec_ms / 1000) + buffer_ms, min, max)).
- Apply `request.timeout_budget` in the worker timeout instead of a fixed timeout and include the budget (ms) in the job payload for observability. 
- Add unit tests for the timeout formula (normal case and clamp-to-max) and update WBS/docs (`TODO/TODO.md`, `README.md`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) to reflect the new policy.

### Testing
- Ran `cargo test` (Rust unit tests) and all tests passed (19 passed). 
- Ran frontend build via `cd frontend && npm run build` and the build succeeded. 
- Ran `cargo clippy --all-targets -- -D warnings` which failed due to pre-existing dead-code / clippy issues in other modules (unrelated to the timeout budgeting change); tests and runtime behavior verified despite the lint debt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c74ecd0cc832e9a74ce62970151cf)