### PR TITLE
feat(orchestrator): lock STT audio contract to rust preprocessing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 이 문서는 저장소 루트(`./`) 기준 에이전트 작업 표준입니다.
 
-> 문서 동기화 메모: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, 길이/예산 기반 job timeout 산정식, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리, readyz degraded + /metrics 노출) 상태를 README/CLAUDE/GEMINI/TODO와 정렬.
+> 문서 동기화 메모: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, 길이/예산 기반 job timeout 산정식, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리, readyz degraded + /metrics 노출) + STT `audio_contract`(conversion_required=false) 상태를 README/CLAUDE/GEMINI/TODO와 정렬.
 
 ## 1) 프로젝트 구조 인식
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@
 - `POST /jobs` 과부하 응답은 `429(queue_full|engine_full)` 규약으로 구분되며 엔진/사유별 리젝션 카운트를 기록합니다.
 - `/readyz`는 수용량 압박 시 `503 degraded`로 응답하며, `/metrics`에서 readiness/queue/rejection 스냅샷(JSON)을 노출합니다.
 - STT는 `audio_ms` 길이 입력이 있을 때 처리율/버퍼/상하한 기반 timeout budget 산정식을 적용합니다.
+- STT payload는 `audio_contract`를 통해 Rust(`recordroute_symphonia`) 전처리 완료/변환 불필요(`conversion_required=false`) 계약을 명시합니다.
 
 ## 작업 체크리스트
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -14,6 +14,7 @@
 - `/readyz`는 수용량 압박 시 `503 degraded`로 응답하며, `/metrics`에서 readiness/queue/rejection 스냅샷(JSON)을 노출합니다.
 - STT는 `audio_ms` 길이 입력이 있을 때 처리율/버퍼/상하한 기반 timeout budget 산정식을 적용합니다.
 - 오디오 전처리/변환 기본안은 Rust `symphonia` 크레이트 기반입니다.
+- STT payload는 `audio_contract`를 포함하며 whisper-server는 변환 없이 추론만 수행한다는 계약(`conversion_required=false`)을 사용합니다.
 
 ## 우선 참조
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Rust 백엔드는 `/healthz`/`/readyz` + `POST /jobs`/`GET /jobs/{id}`와 엔진
 - 엔진 HTTP 호출은 `connect_timeout` + read/write timeout을 적용해 connect 지연과 응답 지연 모두 시간 상한 내 실패합니다.
 - `job_id`는 `[a-zA-Z0-9_-]`, 1..64 규칙으로 검증되며 invalid 입력은 `400 invalid_job_id`로 응답합니다.
 - queue depth는 **근사 지표(accepted enqueue 기준)**로 정의하고 RAII guard Drop으로 감소 정합성을 보장합니다.
+- STT 엔진 payload는 `audio_contract`(normalized_by=`recordroute_symphonia`, format=`wav_mono_pcm16_16khz`, conversion_required=false)를 포함해 whisper-server의 변환 책임을 제거합니다.
 
 오디오 전처리/변환은 기존 `ffmpeg` 실행 방식 대신 Rust `symphonia` 크레이트 기반 구현을 목표 기준으로 문서화합니다.
 

--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -10,6 +10,10 @@
   - timeout 파라미터는 환경변수(`RECORDROUTE_JOB_TIMEOUT_MIN_SECS`, `RECORDROUTE_JOB_TIMEOUT_MAX_SECS`, `RECORDROUTE_STT_TIMEOUT_PER_AUDIO_SEC_MS`, `RECORDROUTE_STT_TIMEOUT_BUFFER_MS`)로 제어
   - 워커가 요청별 timeout budget을 사용하도록 조정하고 기존 timeout 회귀 테스트 통과 확인
 
+- 2026-02-23: Phase E-1 whisper-server 추론 책임 한정(변환 책임 제거) 반영
+  - STT 엔진 payload에 `audio_contract`(normalized_by/format/conversion_required=false)를 명시해 변환 책임이 Rust에 있음을 고정
+  - whisper-server는 변환 없이 추론 전용 경로를 사용한다는 계약을 테스트로 검증
+
 - 2026-02-23: Phase C-1 degraded readiness/운영 메트릭 노출 반영
   - `/readyz`가 용량 리젝션/디스패처 종료 시 `degraded` 상태를 503으로 반환하도록 조정
   - `/metrics` 엔드포인트에 readiness(ready/degraded), 엔진별 queue/running, 리젝션(engine/reason) 스냅샷 추가
@@ -89,7 +93,7 @@
 
 - [x] 5.1 `symphonia` 기반 오디오 정규화 (16kHz/16-bit mono WAV)
 - [x] 5.2 길이/예산 계산 기반 timeout 산정식 적용
-- [ ] 5.3 whisper-server 추론 책임 한정(변환 책임 제거)
+- [x] 5.3 whisper-server 추론 책임 한정(변환 책임 제거)
 
 ## 6.0 슈퍼비전/운영 안정성
 
@@ -105,6 +109,5 @@
 
 ## 다음 우선순위 (실행 단위)
 
-1. whisper-server 추론 책임 한정(변환 책임 제거)
-2. 엔진별 클라이언트/포트 설정(`18101`, `18102`, `18103`) + readiness 연동
-3. 운영 점검 시나리오(장애/복구/부하) 문서화
+1. 엔진별 클라이언트/포트 설정(`18101`, `18102`, `18103`) + readiness 연동
+2. 운영 점검 시나리오(장애/복구/부하) 문서화

--- a/src/main.rs
+++ b/src/main.rs
@@ -573,11 +573,7 @@ fn route_request(request_line: &str, state: &AppState) -> String {
             let request = JobRequest {
                 job_id: job.job_id.clone(),
                 engine,
-                payload: json!({
-                    "job_id": job.job_id,
-                    "engine": engine.as_str(),
-                    "timeout_budget_ms": timeout_budget.as_millis(),
-                }),
+                payload: build_engine_payload(&job.job_id, engine, timeout_budget),
                 timeout_budget,
                 queue_depth_guard: None,
             };
@@ -657,6 +653,24 @@ fn route_request(request_line: &str, state: &AppState) -> String {
         ("GET", _) => json_error_response(404, "not_found", "not found"),
         _ => json_error_response(405, "method_not_allowed", "method not allowed"),
     }
+}
+
+fn build_engine_payload(job_id: &JobId, engine: EngineKind, timeout_budget: Duration) -> Value {
+    let mut payload = json!({
+        "job_id": job_id,
+        "engine": engine.as_str(),
+        "timeout_budget_ms": timeout_budget.as_millis(),
+    });
+
+    if engine == EngineKind::Stt {
+        payload["audio_contract"] = json!({
+            "normalized_by": "recordroute_symphonia",
+            "format": "wav_mono_pcm16_16khz",
+            "conversion_required": false,
+        });
+    }
+
+    payload
 }
 
 fn derive_job_timeout_budget(
@@ -1191,6 +1205,27 @@ mod tests {
         assert!(get_response.starts_with("HTTP/1.1 200 OK"));
         assert!(get_response.contains("\"status\":\"completed\""));
         assert!(get_response.contains("\"result\""));
+    }
+
+    #[tokio::test]
+    async fn stt_payload_declares_rust_audio_preprocessing_contract() {
+        let client = Arc::new(MockEngineClient {
+            fail_with_5xx: Arc::new(AtomicBool::new(false)),
+            delay: Duration::from_millis(10),
+            inflight: Arc::new(AtomicUsize::new(0)),
+            max_inflight: Arc::new(AtomicUsize::new(0)),
+        });
+        let state = build_state(8, 1, client);
+
+        let response = route_request("POST /jobs?engine=stt HTTP/1.1", &state);
+        let created_job_id = extract_job_id(&response);
+
+        wait_for_status(&state, &created_job_id, JobStatus::Completed).await;
+
+        let get_response = route_request(&format!("GET /jobs/{created_job_id} HTTP/1.1"), &state);
+        assert!(get_response.contains("\"audio_contract\""));
+        assert!(get_response.contains("\"normalized_by\":\"recordroute_symphonia\""));
+        assert!(get_response.contains("\"conversion_required\":false"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Make the STT engine contract explicit by locking audio preprocessing responsibility to the Rust orchestrator so downstream engines (whisper-server) are inference-only and do not perform conversion.
- Prevent contract drift and ensure operators can rely on a documented, test-verified `audio_contract` field describing normalized audio format and conversion requirements.

### Description
- Factor payload creation into `build_engine_payload` and inject an `audio_contract` JSON field for `engine=stt` that declares `normalized_by = "recordroute_symphonia"`, `format = "wav_mono_pcm16_16khz"`, and `conversion_required = false` (changes in `src/main.rs`).
- Add a unit test `stt_payload_declares_rust_audio_preprocessing_contract` that enqueues an STT job and verifies the resulting job snapshot contains the `audio_contract` fields.
- Update documentation and tracking artifacts (`TODO/TODO.md`, `README.md`, `CLAUDE.md`, `GEMINI.md`, `AGENTS.md`) to reflect the contract and mark WBS 5.3 complete.
- Keep existing enqueue/queue/worker flows unchanged and preserve external API responses (`POST /jobs` / `GET /jobs/{id}`) while expanding only the internal engine payload.

### Testing
- Ran `cargo fmt` successfully.
- Ran `cargo test`; all tests passed (20 passed; 0 failed), including the new STT payload contract test.
- Ran `cargo clippy --all-targets`; checks completed with non-critical warnings only and no blocking lints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ce4e64948832ebcae8cee2e2eab08)