### PR TITLE
docs(operations): add operations runbook and sync status across root docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 이 문서는 저장소 루트(`./`) 기준 에이전트 작업 표준입니다.
 
-> 문서 동기화 메모: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, 길이/예산 기반 job timeout 산정식, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리, readyz degraded + /metrics 노출) + STT `audio_contract`(conversion_required=false) 상태를 README/CLAUDE/GEMINI/TODO와 정렬.
+> 문서 동기화 메모: 2026-02-24 기준 운영 안정화 + STT `audio_contract`(conversion_required=false) + 운영 점검 시나리오 runbook(`docs/operations-runbook-scenarios.md`) 상태를 README/CLAUDE/GEMINI/TODO와 정렬.
 
 ## 1) 프로젝트 구조 인식
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 이 문서는 요약본이며, 상세 기준은 `AGENTS.md`를 따릅니다.
 
 
-> 문서 동기화: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, 길이/예산 기반 job timeout 산정식, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리, readyz degraded + /metrics 노출) 반영 상태와 정렬됨.
+> 문서 동기화: 2026-02-24 기준 운영 안정화 + 운영 점검 시나리오 runbook 반영 상태와 정렬됨.
 
 ## 우선 확인 순서
 
@@ -27,6 +27,7 @@
 - `/readyz`는 수용량 압박 시 `503 degraded`로 응답하며, `/metrics`에서 readiness/queue/rejection 스냅샷(JSON)을 노출합니다.
 - STT는 `audio_ms` 길이 입력이 있을 때 처리율/버퍼/상하한 기반 timeout budget 산정식을 적용합니다.
 - STT payload는 `audio_contract`를 통해 Rust(`recordroute_symphonia`) 전처리 완료/변환 불필요(`conversion_required=false`) 계약을 명시합니다.
+- 운영 점검 시나리오(장애/복구/부하) runbook은 `docs/operations-runbook-scenarios.md`를 기준으로 사용합니다.
 
 ## 작업 체크리스트
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -3,7 +3,7 @@
 최신 원본 기준은 `AGENTS.md`입니다. 이 문서는 실행 요약만 제공합니다.
 
 
-> 문서 동기화: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, 길이/예산 기반 job timeout 산정식, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리, readyz degraded + /metrics 노출) 반영 상태와 정렬됨.
+> 문서 동기화: 2026-02-24 기준 운영 안정화 + 운영 점검 시나리오 runbook 반영 상태와 정렬됨.
 
 ## 핵심 컨텍스트
 
@@ -15,6 +15,7 @@
 - STT는 `audio_ms` 길이 입력이 있을 때 처리율/버퍼/상하한 기반 timeout budget 산정식을 적용합니다.
 - 오디오 전처리/변환 기본안은 Rust `symphonia` 크레이트 기반입니다.
 - STT payload는 `audio_contract`를 포함하며 whisper-server는 변환 없이 추론만 수행한다는 계약(`conversion_required=false`)을 사용합니다.
+- 운영 점검 시나리오(장애/복구/부하) runbook은 `docs/operations-runbook-scenarios.md`를 기준으로 사용합니다.
 
 ## 우선 참조
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ RecordRoute는 음성/문서 처리 파이프라인을 **Rust 중심 아키텍�
 Rust 백엔드는 `/healthz`/`/readyz` + `POST /jobs`/`GET /jobs/{id}`와 엔진별 bounded queue/worker 기반 처리 흐름(queued→running→completed|failed|timeout|canceled|rejected)까지 반영되어 있으며, 엔진 슈퍼비전/전처리/Swagger 분리 배포 구성을 단계적으로 이전합니다.
 
 
-> 문서 동기화: 2026-02-23 기준 운영 안정화(고정 worker 동시성 상한, connect+request timeout 관철, 길이/예산 기반 job timeout 산정식, job_id 검증/로그 위생, queue depth guard, 429 reason/리젝션 메트릭 분리, readyz degraded + /metrics 노출) 반영 상태와 정렬됨.
+> 문서 동기화: 2026-02-24 기준 운영 안정화 + 운영 점검 시나리오(장애/복구/부하) runbook 반영 상태와 정렬됨.
 
 ## 운영 안정화 메모 (Phase B-2)
 

--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -10,6 +10,10 @@
   - timeout 파라미터는 환경변수(`RECORDROUTE_JOB_TIMEOUT_MIN_SECS`, `RECORDROUTE_JOB_TIMEOUT_MAX_SECS`, `RECORDROUTE_STT_TIMEOUT_PER_AUDIO_SEC_MS`, `RECORDROUTE_STT_TIMEOUT_BUFFER_MS`)로 제어
   - 워커가 요청별 timeout budget을 사용하도록 조정하고 기존 timeout 회귀 테스트 통과 확인
 
+- 2026-02-24: 운영 점검 시나리오(장애/복구/부하) runbook 문서화
+  - `docs/operations-runbook-scenarios.md`에 장애 주입/복구 판정/부하(429 reason) 점검 절차 및 롤백 기준 추가
+  - WBS 7.3 항목 완료 처리
+
 - 2026-02-23: Phase E-1 whisper-server 추론 책임 한정(변환 책임 제거) 반영
   - STT 엔진 payload에 `audio_contract`(normalized_by/format/conversion_required=false)를 명시해 변환 책임이 Rust에 있음을 고정
   - whisper-server는 변환 없이 추론 전용 경로를 사용한다는 계약을 테스트로 검증
@@ -105,9 +109,10 @@
 
 - [x] 7.1 API(18000) / Swagger(14000) 분리 배포 구성
 - [ ] 7.2 모델 manifest 정책 및 `.gitignore` 운영 검증
-- [ ] 7.3 운영 점검 시나리오(장애/복구/부하) 문서화
+- [x] 7.3 운영 점검 시나리오(장애/복구/부하) 문서화
+  - 근거 문서: `docs/operations-runbook-scenarios.md`
 
 ## 다음 우선순위 (실행 단위)
 
-1. 엔진별 클라이언트/포트 설정(`18101`, `18102`, `18103`) + readiness 연동
-2. 운영 점검 시나리오(장애/복구/부하) 문서화
+1. 모델 manifest 정책 및 `.gitignore` 운영 검증
+2. 운영 점검 시나리오 기반 장애훈련(정기) 및 결과 누적

--- a/docs/operations-runbook-scenarios.md
+++ b/docs/operations-runbook-scenarios.md
@@ -1,0 +1,121 @@
+# 운영 점검 시나리오 Runbook (장애/복구/부하)
+
+이 문서는 Rust 오케스트레이터 기준 운영 점검 절차를 정의합니다.
+목표는 **장애 감지 → 영향 축소 → 복구 확인 → 재발 방지 기록**을 표준화하는 것입니다.
+
+## 0. 범위와 전제
+
+- 대상 서비스: `recordroute-orchestrator` (`:18000`), Swagger 정적 서버(`:14000`)
+- 핵심 엔드포인트: `/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}`
+- 엔진 구성: `stt`, `summarize`, `embed` (엔진별 bounded queue + worker)
+- 상태 전이: `queued|running|completed|failed|timeout|canceled|rejected`
+- 리젝션 규약: `429(queue_full|engine_full)` + 리젝션 메트릭(`engine`, `reason`)
+
+> 주의: 이 문서는 운영 절차 가이드입니다. 인증/인가 정책, 비밀 관리 정책은 별도 보안 문서를 우선합니다.
+
+## 1. 공통 사전 점검
+
+1. 배포 버전/커밋 해시 기록
+2. 필수 환경변수 확인
+   - `RECORDROUTE_API_HOST`, `RECORDROUTE_API_PORT`
+   - `RECORDROUTE_*_QUEUE_CAPACITY`, `RECORDROUTE_*_CONCURRENCY`
+   - `RECORDROUTE_ENGINE_TIMEOUT_SECS`, `RECORDROUTE_JOB_TIMEOUT_*`
+3. 엔진 포트 라우팅 확인 (`18101`, `18102`, `18103`)
+4. 점검 시작 시점 기준 메트릭 스냅샷 저장 (`/metrics` 응답 원본)
+
+샘플 점검 명령:
+
+```bash
+curl -sS http://127.0.0.1:18000/healthz
+curl -sS -i http://127.0.0.1:18000/readyz
+curl -sS http://127.0.0.1:18000/metrics | jq .
+```
+
+## 2. 시나리오 A — 엔진 장애(프로세스 다운/응답 불가)
+
+### A-1. 목적
+- 단일 엔진 장애 시 전체 서비스가 아닌 해당 엔진 경로 중심으로 영향이 제한되는지 확인
+- readiness가 `degraded`로 전이되는지 확인
+
+### A-2. 절차
+1. 점검 대상 엔진 1개(`stt` 권장) 선택
+2. 해당 엔진 프로세스 강제 종료 또는 포트 차단으로 장애 주입
+3. 즉시 `/readyz` 상태 코드/바디 확인 (`503 degraded` 기대)
+4. `POST /jobs?engine=stt` 요청과 `POST /jobs?engine=summarize` 요청을 각각 수행
+5. `/metrics`에서 readiness 및 엔진별 queue/running/rejections 변화 확인
+
+### A-3. 기대 결과
+- `/healthz`는 프로세스 생존 기준으로 `200` 유지 가능
+- `/readyz`는 `503` + `degraded` 표기
+- 장애 엔진은 실패/타임아웃/리젝션이 증가하되, 타 엔진은 접수 가능 상태 유지
+
+### A-4. 복구 판정
+- 엔진 복구 후 `/readyz`가 `200 ready`로 회복
+- 신규 job이 정상적으로 `queued → running → completed` 전이
+- 리젝션 증가 추세가 정상 구간으로 복귀
+
+## 3. 시나리오 B — 큐 포화/부하(백프레셔 검증)
+
+### B-1. 목적
+- 과부하 시 무제한 적재가 아닌 bounded queue + `429` 리젝션이 동작하는지 확인
+- `queue_full` vs `engine_full` reason 분리가 관측 가능한지 확인
+
+### B-2. 절차
+1. 테스트 시간 동안 특정 엔진으로 burst 트래픽 송신
+2. `POST /jobs?engine=<target>`의 응답 코드/에러 바디 수집
+3. `/metrics`에서 `rejections(engine, reason)` 스냅샷 수집
+4. 부하 중단 후 queue_depth/running이 정상 수렴하는지 관찰
+
+### B-3. 기대 결과
+- 포화 구간에서 `429`가 발생하며 reason이 `queue_full|engine_full`로 구분
+- 타 엔진 큐는 독립적으로 처리되어 연쇄 포화가 제한됨
+- 부하 종료 후 큐 깊이 및 실행 수치가 정상치로 복귀
+
+## 4. 시나리오 C — 타임아웃/장시간 작업
+
+### C-1. 목적
+- HTTP 타임아웃과 Job 타임아웃 계층이 혼선 없이 분리되는지 확인
+- STT `audio_ms` 기반 timeout budget 산정식이 과도/과소하지 않은지 점검
+
+### C-2. 절차
+1. 짧은 입력/긴 입력 샘플 각각으로 STT job 실행
+2. `GET /jobs/{job_id}` 폴링으로 최종 상태와 error code 수집
+3. 타임아웃 발생 시 `timeout` 상태와 메시지 확인
+4. 관련 환경변수(`RECORDROUTE_JOB_TIMEOUT_*`, `RECORDROUTE_STT_TIMEOUT_*`) 기록
+
+### C-3. 기대 결과
+- 정상 길이 입력은 완료, 과도 길이/지연은 timeout으로 수렴
+- timeout이 발생해도 worker/queue가 누수 없이 다음 job 처리 가능
+
+## 5. 장애 대응 체크리스트 (운영자용)
+
+- [ ] 영향 범위(엔진/기능/API) 1차 분류
+- [ ] `/readyz`, `/metrics`, 최근 에러 로그 수집
+- [ ] 리젝션 reason 분포(`queue_full`, `engine_full`) 확인
+- [ ] 최근 설정 변경/배포 이력 대조
+- [ ] 임시 완화(트래픽 제한, 특정 엔진 격리, 재시작) 수행
+- [ ] 복구 검증(ready 복귀 + 주요 사용자 시나리오 성공)
+- [ ] 사후 보고(원인/영향/재발방지/롤백 포인트) 기록
+
+## 6. 롤백/완화 기준
+
+- 즉시 롤백 조건
+  - 다중 엔진 동시 장애로 `/readyz` 장시간 `degraded` 지속
+  - 리젝션 급증 + 큐 수렴 실패가 임계 시간 초과
+- 완화 우선순위
+  1. 트래픽 셰이핑/임시 rate limit
+  2. 문제 엔진만 격리(타 엔진 서비스 유지)
+  3. 직전 안정 버전으로 롤백
+
+## 7. 점검 결과 템플릿
+
+```markdown
+- 점검 일시:
+- 점검 버전(커밋):
+- 시나리오: A/B/C
+- 관찰 요약:
+- 수집 증거(readyz/metrics/job 샘플):
+- 실패/이슈:
+- 즉시 조치:
+- 후속 액션(담당/기한):
+```


### PR DESCRIPTION
### Motivation
- Provide a concrete operational runbook for incident/load scenarios (engine process failure, queue saturation/429s, job timeouts) so operators can run standardized checks and rollbacks. 
- Close WBS item 7.3 by linking the runbook as evidence and keep repository top-level documentation synchronized with the new runbook. 

### Description
- Add `docs/operations-runbook-scenarios.md` containing pre-checks, engine-failure, queue-saturation (429 reason separation), timeout scenarios, operator checklist, rollback criteria, and result template. 
- Update synchronization notes and summaries in `AGENTS.md`, `README.md`, `CLAUDE.md`, `GEMINI.md` to reference the new runbook and reflect the 2026-02-24 status. 
- Update `TODO/TODO.md` worklog and WBS: mark `7.3 운영 점검 시나리오(장애/복구/부하) 문서화` done and adjust next priorities. 
- Commit created with message: `docs(operations): add incident/load runbook and sync status docs`.

### Testing
- Verified relative Markdown links with a local Python script (`python - <<'PY' ... PY`) and the check passed. 
- Inspected repository state with `git status --short` and reviewed diffs via `git diff` to confirm intended file changes. 
- Confirmed commit recorded via `git log --oneline` and that files were added/modified as expected; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ce611d118832eb2e02765234aac8d)