### PR TITLE
docs(todo): break down WBS 7.4 operational drill tasks

### DIFF
--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -5,6 +5,12 @@
 
 ## 작업 로그
 
+- 2026-02-24: WBS 7.4 운영 점검 정례화 기준선 등록
+  - 시작일: 2026-02-24 / 담당: 운영 담당(On-call) / 리뷰어: 서비스 오너
+  - 첫 점검 예정일: 2026-03-02(주간 점검 윈도우)
+  - 산출물 위치: `docs/operations/weekly-drill/` (회차별 결과), `docs/operations-runbook-scenarios.md` (기준 절차)
+  - 완료 누적 기준: 최근 4회 결과 + 미해결 액션 0건(또는 책임자/기한 지정)
+
 - 2026-02-23: Phase E-1 길이/예산 기반 job timeout 산정식 1차 반영
   - `POST /jobs?engine=stt&audio_ms=<ms>` 입력 시 `job_timeout = clamp((audio_ms * per_audio_sec_ms / 1000) + buffer_ms, min, max)` 산식으로 timeout budget 계산
   - timeout 파라미터는 환경변수(`RECORDROUTE_JOB_TIMEOUT_MIN_SECS`, `RECORDROUTE_JOB_TIMEOUT_MAX_SECS`, `RECORDROUTE_STT_TIMEOUT_PER_AUDIO_SEC_MS`, `RECORDROUTE_STT_TIMEOUT_BUFFER_MS`)로 제어
@@ -116,7 +122,20 @@
 - [x] 7.2 모델 manifest 정책 및 `.gitignore` 운영 검증
 - [x] 7.3 운영 점검 시나리오(장애/복구/부하) 문서화
   - 근거 문서: `docs/operations-runbook-scenarios.md`
+- [ ] 7.4 운영 점검 정례화(주기/역할/합격 기준/누적 완료조건)
+  - 최소 운영 cadence: 주 1회(기본), 릴리스 안정화 구간은 격주로 완화 가능
+  - 역할: 운영 담당(시나리오 실행/증적 수집), 리뷰어(판정/액션 승인)
+  - 산출물: `docs/operations/weekly-drill/<YYYY-MM-DD>.md` + 액션 트래킹 표
 
 ## 다음 우선순위 (실행 단위)
 
-1. 운영 점검 시나리오 기반 장애훈련(정기) 및 결과 누적
+1. **WBS 7.4 운영 점검 정례화 실행**
+   - 7.4.1 운영 주기/역할/산출물 고정: 운영 점검은 **주 1회 기본(안정화 시 격주 허용)** 으로 실행하고, 운영 담당과 리뷰어를 회차마다 명시하며 결과는 `docs/operations/weekly-drill/`에 남긴다.
+   - 7.4.2 시나리오 A(장애 주입) 기준: **최소 월 1회** 수행하며, PASS는 `readyz=degraded` 전이 관측 후 조치 완료 시점부터 **10분 이내 ready 복귀**가 확인될 때로 고정한다.
+   - 7.4.3 시나리오 B(복구 검증) 기준: **최소 월 1회** 수행하며, PASS는 복구 이후 `GET /jobs/{id}` 신규 요청이 정상 상태 전이(`queued→running→completed|failed`)를 재개하고 **30분 내 미처리 stuck job 0건**일 때로 고정한다.
+   - 7.4.4 시나리오 C(부하/배압) 기준: **최소 주 1회** 수행하며, PASS는 부하 구간에서 `429`가 발생할 때 **`reason=queue_full|engine_full` 라벨이 관측**되고, 부하 해제 후 **15분 이내 ready 복귀**가 확인될 때로 고정한다.
+   - 7.4.5 완료 조건 체크리스트:
+     - [ ] 최근 4회(최소 1개월) 점검 결과가 `docs/operations/weekly-drill/`에 누적되어 있다.
+     - [ ] 시나리오 A/B/C 각각의 최소 수행 빈도를 충족한다.
+     - [ ] 회차별 PASS/FAIL 및 근거 지표(ready 복귀 시간, 429 reason 관측)가 기록되어 있다.
+     - [ ] 미해결 액션 아이템이 0건이거나, 모든 액션에 책임자/기한이 지정되어 있다.


### PR DESCRIPTION
### Motivation
- Make the TODO entry for operational drills actionable by converting an abstract item into tracked WBS sub-tasks with clear cadence, roles, artifacts, and pass criteria.
- Improve reproducibility and auditability of routine operation drills (A/B/C scenarios) by fixing minimum frequencies and measurable PASS conditions.
- Establish a baseline record in the work log so future progress and compliance can be validated.

### Description
- Added a work-log baseline entry in `TODO/TODO.md` with start date, owner (On-call), reviewer, first scheduled run, artifact location, and accumulated-completion criterion. 
- Introduced `7.4 운영 점검 정례화` under WBS 7.0 and expanded it into concrete sub-tasks `7.4.1`–`7.4.5` in `TODO/TODO.md` that specify cadence, roles, artifact path (`docs/operations/weekly-drill/`), and completion checklist. 
- Specified scenario-level minimum frequencies and PASS criteria: A (failure injection) monthly with 10-minute ready recovery, B (recovery verification) monthly with 30-minute stuck-job requirement, and C (load/backpressure) weekly with reason-label observation and 15-minute ready recovery. 
- Added a completion checklist (recent N runs, frequency coverage, evidence recording, unresolved action handling) and committed the single-file change.

### Testing
- Performed RTD pre-change planning checks (`Step 1`–`Step 4`) and marked them as PASS using the RTD workflow verification. 
- After making the document change, performed RTD post-implementation checks (`Step 5`–`Step 18`) and marked them PASS (document-only change, no code/security impact, rollback via single-file revert). 
- Verified repository artifacts with `git diff -- TODO/TODO.md`, `git status --short`, and `git log --oneline -n 8`, all showing the intended single-file update and successful commit (`b57baec`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d02a73ec4832ebb2fc5cd5e0c1037)