### PR TITLE
docs: strengthen operations runbook rollback and security references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 이 문서는 저장소 루트(`./`) 기준 에이전트 작업 표준입니다.
 
 > 문서 동기화 메모: 2026-02-24 기준 운영 안정화 + STT `audio_contract`(conversion_required=false) + 운영 점검 시나리오 runbook(`docs/operations-runbook-scenarios.md`) 상태를 README/CLAUDE/GEMINI/TODO와 정렬.
+> 동기화 포인트: runbook 0장/6장 보강(보안 참조, 계량 롤백 트리거, Owner/Approver, 보안 영향 검토, RTD Step 7/17 주석) 반영 상태를 유지합니다.
 
 ## 1) 프로젝트 구조 인식
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@
 - STT는 `audio_ms` 길이 입력이 있을 때 처리율/버퍼/상하한 기반 timeout budget 산정식을 적용합니다.
 - STT payload는 `audio_contract`를 통해 Rust(`recordroute_symphonia`) 전처리 완료/변환 불필요(`conversion_required=false`) 계약을 명시합니다.
 - 운영 점검 시나리오(장애/복구/부하) runbook은 `docs/operations-runbook-scenarios.md`를 기준으로 사용합니다.
+- 운영 runbook은 인증/인가/비밀관리 참조와 계량 롤백 기준, Owner/Approver, 보안 영향 검토 필드를 포함한 버전을 기준으로 사용합니다.
 - 모델 자산은 raw 데이터 미추적, `models/**/manifest.yml|yaml|json` 메타데이터만 추적합니다.
 - `vendor/`는 소스 추적을 유지하고 빌드 산출물만 ignore 합니다.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -16,6 +16,7 @@
 - 오디오 전처리/변환 기본안은 Rust `symphonia` 크레이트 기반입니다.
 - STT payload는 `audio_contract`를 포함하며 whisper-server는 변환 없이 추론만 수행한다는 계약(`conversion_required=false`)을 사용합니다.
 - 운영 점검 시나리오(장애/복구/부하) runbook은 `docs/operations-runbook-scenarios.md`를 기준으로 사용합니다.
+- 운영 runbook은 인증/인가/비밀관리 참조와 계량 롤백 기준, Owner/Approver, 보안 영향 검토 필드를 포함한 버전을 기준으로 사용합니다.
 - 모델 자산은 raw 데이터 미추적, `models/**/manifest.yml|yaml|json` 메타데이터만 추적합니다.
 - `vendor/`는 소스 추적을 유지하고 빌드 산출물만 ignore 합니다.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Rust 백엔드는 `/healthz`/`/readyz` + `POST /jobs`/`GET /jobs/{id}`와 엔진
 - bounded queue 백프레셔를 유지하며, 과부하 시 `POST /jobs`는 `429(queue_full|engine_full)`로 원인을 구분해 응답합니다.
 - 리젝션 관측성은 엔진/사유 라벨(`engine`, `reason`) 단위 카운트로 기록합니다.
 - `/readyz`는 수용량 압박(큐 포화/디스패처 종료) 발생 시 `503 {"status":"degraded"}`로 응답해 운영 경보 신호를 제공합니다.
+- 운영 runbook(`docs/operations-runbook-scenarios.md`)은 인증/인가/비밀관리 참조, 계량 롤백 트리거, 롤백 Owner/Approver, 보안 영향 검토 필드를 포함합니다.
 - 길이(`audio_ms`) 기반으로 STT job timeout budget을 산정하며, 처리율/버퍼/상하한(min/max)은 환경변수로 조정합니다.
 - `/metrics`는 readiness(ready/degraded), 엔진별 큐/워커/러닝 수, 리젝션 카운트 스냅샷(JSON)를 제공합니다.
 - 엔진 HTTP 호출은 `connect_timeout` + read/write timeout을 적용해 connect 지연과 응답 지연 모두 시간 상한 내 실패합니다.

--- a/docs/operations-runbook-scenarios.md
+++ b/docs/operations-runbook-scenarios.md
@@ -11,7 +11,18 @@
 - 상태 전이: `queued|running|completed|failed|timeout|canceled|rejected`
 - 리젝션 규약: `429(queue_full|engine_full)` + 리젝션 메트릭(`engine`, `reason`)
 
-> 주의: 이 문서는 운영 절차 가이드입니다. 인증/인가 정책, 비밀 관리 정책은 별도 보안 문서를 우선합니다.
+### 0-1. 인증/인가/비밀관리 참조
+
+- 저장소 내부 참조(현재 확인 가능 문서)
+  - 인증/검증 책임 경계: `docs/architecture.md` (Rust 오케스트레이터의 요청 인증/검증 책임)
+  - 배포/운영 분리 원칙: `docs/deployment-asset-policy.md`
+- 저장소에는 인증/인가/비밀관리 전용 정책 문서가 분리되어 있지 않습니다.
+- 운영 환경 기준 문서 위치(시스템/경로)
+  - 시스템명: **Kubernetes (cluster runtime)**
+  - 비밀값 원천 경로: `k8s namespace(recordroute)/Secret/*` (환경별 Secret 리소스)
+  - 주입 지점 경로: `Deployment.spec.template.spec.containers[].env[].valueFrom.secretKeyRef`
+
+> 주의: 본 문서는 운영 절차(runbook) 가이드입니다. 인증/인가/비밀관리의 최종 판정은 위 보안 기준(저장소 참조 + 운영 환경 시스템 경로)을 우선합니다.
 
 ## 1. 공통 사전 점검
 
@@ -99,13 +110,23 @@ curl -sS http://127.0.0.1:18000/metrics | jq .
 
 ## 6. 롤백/완화 기준
 
+> RTD 주석: 이 섹션의 체크 항목은 **RTD Step 7(보안/크리티컬 이슈)** 및 **RTD Step 17(배포 준비도 판정)** 에 직접 사용됩니다.
+
 - 즉시 롤백 조건
-  - 다중 엔진 동시 장애로 `/readyz` 장시간 `degraded` 지속
-  - 리젝션 급증 + 큐 수렴 실패가 임계 시간 초과
+  - `/readyz`가 `503 degraded` 상태로 **연속 10분 초과** 지속
+  - `rejections_total(engine, reason)` 5분 합계가 최근 1시간 중앙값 대비 **3배 이상**으로 **2개 연속 구간** 급증
+  - 부하 중단 후에도 `queue_depth`가 엔진별 최대 큐 깊이의 **30% 이상으로 10분 내 미수렴**
+  - 인증/인가/비밀관리 이상(권한 오판정, 비밀 노출 의심) 1건 이상 확인 시 즉시 롤백 또는 서비스 격리
 - 완화 우선순위
   1. 트래픽 셰이핑/임시 rate limit
   2. 문제 엔진만 격리(타 엔진 서비스 유지)
   3. 직전 안정 버전으로 롤백
+
+### 6-1. 롤백 실행 책임 체계 (필수 필드)
+
+- 롤백 실행 책임자(Owner): `<이름/팀>`
+- 롤백 승인자(Approver): `<이름/직책>`
+- 실행/승인 시각: `<YYYY-MM-DD HH:MM TZ>`
 
 ## 7. 점검 결과 템플릿
 
@@ -125,6 +146,9 @@ curl -sS http://127.0.0.1:18000/metrics | jq .
 - 아래 필드는 모든 시나리오에서 필수입니다.
   - `즉시 조치`
   - `롤백 여부(실시/미실시 + 근거)`
+  - `롤백 실행 책임자(Owner)`
+  - `롤백 승인자(Approver)`
+  - `보안 영향 검토(있음/없음 + 근거)`
   - `재실행 예정일`
 - 시나리오 B(부하/포화)에서는 아래 필드를 추가로 필수 기록합니다.
   - `rejection 분포(건수): queue_full=<n>, engine_full=<n>`
@@ -140,6 +164,9 @@ curl -sS http://127.0.0.1:18000/metrics | jq .
 - 실패/이슈:
 - 즉시 조치:
 - 롤백 여부(실시/미실시 + 근거):
+- 롤백 실행 책임자(Owner):
+- 롤백 승인자(Approver):
+- 보안 영향 검토(있음/없음 + 근거):
 - 재실행 예정일:
 - rejection 분포(건수): queue_full=<n>, engine_full=<n>  # 시나리오 B 필수, 그 외 N/A
 - 후속 액션(담당/기한):
@@ -162,6 +189,9 @@ curl -sS http://127.0.0.1:18000/metrics | jq .
 - 실패/이슈: 피크 구간에서 queue_full 비중이 예상보다 높음(37건)
 - 즉시 조치: STT 입력 burst를 20% 감쇠하도록 임시 rate limit 적용
 - 롤백 여부(실시/미실시 + 근거): 미실시(ready 유지, 큐 수렴 확인됨)
+- 롤백 실행 책임자(Owner): oncall-ops-1
+- 롤백 승인자(Approver): sre-lead
+- 보안 영향 검토(있음/없음 + 근거): 없음(인증/인가/비밀값 경로 변경 없음, 오류는 부하 제어 범주)
 - 재실행 예정일: 2026-02-26
 - rejection 분포(건수): queue_full=37(75.5%), engine_full=12(24.5%)
 - 후속 액션(담당/기한): 큐 용량/worker 재튜닝안 작성 (ops-team, 2026-02-27)


### PR DESCRIPTION
### Motivation

- Improve the operational runbook to make rollback decisions actionable by adding explicit security references, quantitative rollback triggers, and responsible parties for executing/approving rollbacks. 
- Ensure the runbook entries are directly usable in RTD checks by annotating items referenced by RTD Step 7 and Step 17.

### Description

- Enhanced `docs/operations-runbook-scenarios.md`: added `0-1. 인증/인가/비밀관리 참조` (links to `docs/architecture.md` and `docs/deployment-asset-policy.md` and an operational K8s Secret path), annotated rollback section for RTD use, and added quantitative rollback triggers (e.g. `/readyz` degraded > 10 minutes, rejections spike thresholds, queue non-convergence). 
- Added rollback responsibility template fields under a new `6-1. 롤백 실행 책임 체계` (Owner / Approver / execution timestamp) and added `보안 영향 검토(있음/없음 + 근거)` to the point-check template in section 7. 
- Synchronized summary docs to reflect the runbook update: `README.md`, `CLAUDE.md`, `GEMINI.md`, and `AGENTS.md` were updated to reference the strengthened runbook and its new fields. 
- Commit created with message: `docs: strengthen operations runbook rollback and security references` and a PR draft was generated.

### Testing

- RTD checks: Per repository policy, RTD Step 1~4 were executed before edits and marked **PASS**, and RTD Step 5~18 were executed after edits and marked **PASS** (all checks and justifications recorded in the change process). 
- Automated verification: searched/verified inserted markers and fields using `rg` for key phrases (e.g. `0-1. 인증/인가/비밀관리 참조`, `RTD 주석`, `Owner`, `Approver`, `보안 영향 검토`) and confirmed presence in `docs/operations-runbook-scenarios.md`, `README.md`, `CLAUDE.md`, `GEMINI.md`, and `AGENTS.md` (all succeeded). 
- Repository hygiene: verified `git status` clean and committed the changes successfully. 

All automated checks above succeeded; no runtime code changes were made so no build/test tooling (e.g. `cargo test`, `npm run build`) was required for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d06109a20832e85a0e2a82db05810)