### PR TITLE
docs(api): add /metrics schema and document POST /jobs audio_ms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@
 
 ## 현재 프로젝트 전제
 
-- OpenAPI 계약(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)은 Rust 목표 엔드포인트 기준으로 정렬되어 있습니다.
+- OpenAPI 계약(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)은 Rust 목표 엔드포인트(`/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}`) 기준으로 정렬되어 있습니다.
 - 루트에 Rust 실행 코드(`Cargo.toml`)가 존재하며, 백엔드 전환 구현이 진행 중입니다.
 - 운영 중 코드 기준은 `frontend/`(현행) + 루트 Rust 코드입니다.
 - 오디오 변환 기본 전략은 외부 `ffmpeg` 호출이 아니라 Rust `symphonia` 크레이트 사용입니다.
@@ -26,6 +26,7 @@
 - `POST /jobs` 과부하 응답은 `429(queue_full|engine_full)` 규약으로 구분되며 엔진/사유별 리젝션 카운트를 기록합니다.
 - `/readyz`는 수용량 압박 시 `503 degraded`로 응답하며, `/metrics`에서 readiness/queue/rejection 스냅샷(JSON)을 노출합니다.
 - STT는 `audio_ms` 길이 입력이 있을 때 처리율/버퍼/상하한 기반 timeout budget 산정식을 적용합니다.
+- `POST /jobs`는 `audio_ms` query 파라미터(선택)를 받아 STT timeout budget 산정에 사용하며, 미지정 시 기본 timeout을 사용합니다.
 - STT payload는 `audio_contract`를 통해 Rust(`recordroute_symphonia`) 전처리 완료/변환 불필요(`conversion_required=false`) 계약을 명시합니다.
 - 운영 점검 시나리오(장애/복구/부하) runbook은 `docs/operations-runbook-scenarios.md`를 기준으로 사용합니다.
 - 운영 runbook은 인증/인가/비밀관리 참조와 계량 롤백 기준, Owner/Approver, 보안 영향 검토 필드를 포함한 버전을 기준으로 사용합니다.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -7,12 +7,13 @@
 
 ## 핵심 컨텍스트
 
-- OpenAPI 계약(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)은 Rust 목표 엔드포인트 기준으로 정렬되어 있습니다.
+- OpenAPI 계약(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)은 Rust 목표 엔드포인트(`/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}`) 기준으로 정렬되어 있습니다.
 - 저장소는 Rust 전환 진행 중이며, 레거시 Python 코드는 현 저장소에 포함되어 있지 않습니다.
 - 루트에는 Rust 실행 코드가 존재하며, 문서/프론트와 함께 Rust 구현 변경도 작업 대상입니다.
 - `POST /jobs` 과부하 응답은 `429(queue_full|engine_full)`로 구분되며, 리젝션은 엔진/사유 라벨 카운트로 관측합니다.
 - `/readyz`는 수용량 압박 시 `503 degraded`로 응답하며, `/metrics`에서 readiness/queue/rejection 스냅샷(JSON)을 노출합니다.
 - STT는 `audio_ms` 길이 입력이 있을 때 처리율/버퍼/상하한 기반 timeout budget 산정식을 적용합니다.
+- `POST /jobs`는 `audio_ms` query 파라미터(선택)를 받아 STT timeout budget 산정에 사용하며, 미지정 시 기본 timeout을 사용합니다.
 - 오디오 전처리/변환 기본안은 Rust `symphonia` 크레이트 기반입니다.
 - STT payload는 `audio_contract`를 포함하며 whisper-server는 변환 없이 추론만 수행한다는 계약(`conversion_required=false`)을 사용합니다.
 - 운영 점검 시나리오(장애/복구/부하) runbook은 `docs/operations-runbook-scenarios.md`를 기준으로 사용합니다.

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ RecordRoute는 음성/문서 처리 파이프라인을 **Rust 중심 아키텍�
 - `frontend/`: 현재 유지 중인 웹 프론트엔드
 - `docs/`: Rust 전환/설계 문서
 
-Rust 백엔드는 `/healthz`/`/readyz` + `POST /jobs`/`GET /jobs/{id}`와 엔진별 bounded queue/worker 기반 처리 흐름(queued→running→completed|failed|timeout|canceled|rejected)까지 반영되어 있으며, 엔진 슈퍼비전/전처리/Swagger 분리 배포 구성을 단계적으로 이전합니다.
+Rust 백엔드는 `/healthz`/`/readyz`/`/metrics` + `POST /jobs`/`GET /jobs/{id}`와 엔진별 bounded queue/worker 기반 처리 흐름(queued→running→completed|failed|timeout|canceled|rejected)까지 반영되어 있으며, 엔진 슈퍼비전/전처리/Swagger 분리 배포 구성을 단계적으로 이전합니다.
 
 
 > 문서 동기화: 2026-02-24 기준 운영 안정화 + 운영 점검 정례화 정책(7.4.1~7.4.4) 수립 완료 상태와 정렬됨.
 
 ## 운영 안정화 메모 (Phase B-2)
 
-- OpenAPI 계약은 Rust 목표 엔드포인트(`/healthz`, `/readyz`, `POST /jobs`, `GET /jobs/{job_id}`) 기준으로 정렬되어 있습니다.
+- OpenAPI 계약은 Rust 목표 엔드포인트(`/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}`) 기준으로 정렬되어 있습니다.
 - 동시성 상한은 semaphore 대기 태스크 누적 대신 **고정 worker 개수**로 강제합니다.
 - bounded queue 백프레셔를 유지하며, 과부하 시 `POST /jobs`는 `429(queue_full|engine_full)`로 원인을 구분해 응답합니다.
 - 리젝션 관측성은 엔진/사유 라벨(`engine`, `reason`) 단위 카운트로 기록합니다.
@@ -32,6 +32,13 @@ Rust 백엔드는 `/healthz`/`/readyz` + `POST /jobs`/`GET /jobs/{id}`와 엔진
 - `vendor/`는 외부 엔진 소스 코드를 버전관리하고, 빌드 산출물만 `.gitignore`로 제외합니다.
 
 오디오 전처리/변환은 기존 `ffmpeg` 실행 방식 대신 Rust `symphonia` 크레이트 기반 구현을 목표 기준으로 문서화합니다.
+
+
+## API 변경 이력
+
+- 2026-02-24: OpenAPI(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)에 `GET /metrics` 경로와 metrics 응답 스키마(readiness: ready/degraded, 엔진별 queue/running, rejections)를 명시했습니다.
+- 2026-02-24: `POST /jobs` query parameter에 `audio_ms`를 추가하고, 미지정 시 기본 timeout 사용 + min/max clamp 동작을 문서화했습니다.
+- 2026-02-24: 에러 코드 enum을 현재 구현 코드(`queue_full`, `engine_full`, `engine_dispatcher_closed` 포함)와 일치하도록 재검증/동기화했습니다.
 
 ## RTD(배포준비) 점검 규칙
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -33,6 +33,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StatusResponse'
+  /metrics:
+    get:
+      summary: Queue/rejection/readiness metrics snapshot
+      responses:
+        '200':
+          description: metrics snapshot
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricsResponse'
   /jobs:
     post:
       summary: Enqueue a job
@@ -42,6 +52,18 @@ paths:
           schema:
             type: string
             enum: [stt, summarize, embed]
+        - in: query
+          name: audio_ms
+          required: false
+          description: >
+            STT timeout budget 산정용 오디오 길이(ms). 0 이상 정수(uint64)만 유효하며,
+            stt 엔진에서만 산식(`audio_ms * per_audio_sec_ms / 1000 + buffer_ms`)에 사용됩니다.
+            값이 없거나 파싱되지 않으면 기본 timeout(`RECORDROUTE_JOB_TIMEOUT_SECS`)을 사용하고,
+            최종 budget은 min/max 설정(`RECORDROUTE_JOB_TIMEOUT_MIN_SECS`, `RECORDROUTE_JOB_TIMEOUT_MAX_SECS`)으로 clamp 됩니다.
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
       responses:
         '202':
           description: accepted
@@ -91,6 +113,29 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 components:
   schemas:
+    ErrorCode:
+      type: string
+      enum:
+        - queue_full
+        - engine_full
+        - engine_dispatcher_closed
+        - engine_dispatcher_unavailable
+        - engine_connect_timeout
+        - engine_request_timeout
+        - engine_transport_error
+        - engine_upstream_4xx
+        - engine_upstream_5xx
+        - engine_retry_exhausted
+        - engine_endpoint_invalid
+        - engine_invalid_http
+        - engine_invalid_json
+        - engine_not_configured
+        - job_timeout
+        - job_canceled
+        - invalid_job_id
+        - job_not_found
+        - not_found
+        - method_not_allowed
     StatusResponse:
       type: object
       required: [status]
@@ -98,6 +143,62 @@ components:
         status:
           type: string
           example: ok
+    MetricsReadiness:
+      type: object
+      required: [ready, degraded]
+      properties:
+        ready:
+          type: boolean
+        degraded:
+          type: boolean
+    EngineMetrics:
+      type: object
+      required: [engine, queue_depth, queue_capacity, worker_count, running]
+      properties:
+        engine:
+          type: string
+          enum: [stt, summarize, embed]
+        queue_depth:
+          type: integer
+          minimum: 0
+        queue_capacity:
+          type: integer
+          minimum: 0
+        worker_count:
+          type: integer
+          minimum: 0
+        running:
+          type: integer
+          minimum: 0
+    RejectionMetric:
+      type: object
+      required: [engine, reason, count]
+      properties:
+        engine:
+          type: string
+          enum: [stt, summarize, embed]
+        reason:
+          type: string
+        count:
+          type: integer
+          format: int64
+          minimum: 0
+    MetricsResponse:
+      type: object
+      required: [readiness, engines, rejections]
+      properties:
+        readiness:
+          allOf:
+            - $ref: '#/components/schemas/MetricsReadiness'
+          description: readiness 상태 스냅샷(ready/degraded)
+        engines:
+          type: array
+          items:
+            $ref: '#/components/schemas/EngineMetrics'
+        rejections:
+          type: array
+          items:
+            $ref: '#/components/schemas/RejectionMetric'
     JobCreatedResponse:
       type: object
       required: [job_id]
@@ -112,20 +213,7 @@ components:
       required: [code, message]
       properties:
         code:
-          type: string
-          enum:
-            - queue_full
-            - engine_full
-            - engine_dispatcher_closed
-            - engine_connect_timeout
-            - engine_request_timeout
-            - engine_transport_error
-            - engine_upstream_4xx
-            - engine_upstream_5xx
-            - engine_retry_exhausted
-            - job_timeout
-            - job_canceled
-            - invalid_job_id
+          $ref: '#/components/schemas/ErrorCode'
         message:
           type: string
     Job:
@@ -163,6 +251,6 @@ components:
       required: [code, message]
       properties:
         code:
-          type: string
+          $ref: '#/components/schemas/ErrorCode'
         message:
           type: string

--- a/docs/swagger/openapi.yaml
+++ b/docs/swagger/openapi.yaml
@@ -33,6 +33,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StatusResponse'
+  /metrics:
+    get:
+      summary: Queue/rejection/readiness metrics snapshot
+      responses:
+        '200':
+          description: metrics snapshot
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricsResponse'
   /jobs:
     post:
       summary: Enqueue a job
@@ -42,6 +52,18 @@ paths:
           schema:
             type: string
             enum: [stt, summarize, embed]
+        - in: query
+          name: audio_ms
+          required: false
+          description: >
+            STT timeout budget 산정용 오디오 길이(ms). 0 이상 정수(uint64)만 유효하며,
+            stt 엔진에서만 산식(`audio_ms * per_audio_sec_ms / 1000 + buffer_ms`)에 사용됩니다.
+            값이 없거나 파싱되지 않으면 기본 timeout(`RECORDROUTE_JOB_TIMEOUT_SECS`)을 사용하고,
+            최종 budget은 min/max 설정(`RECORDROUTE_JOB_TIMEOUT_MIN_SECS`, `RECORDROUTE_JOB_TIMEOUT_MAX_SECS`)으로 clamp 됩니다.
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
       responses:
         '202':
           description: accepted
@@ -91,6 +113,29 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 components:
   schemas:
+    ErrorCode:
+      type: string
+      enum:
+        - queue_full
+        - engine_full
+        - engine_dispatcher_closed
+        - engine_dispatcher_unavailable
+        - engine_connect_timeout
+        - engine_request_timeout
+        - engine_transport_error
+        - engine_upstream_4xx
+        - engine_upstream_5xx
+        - engine_retry_exhausted
+        - engine_endpoint_invalid
+        - engine_invalid_http
+        - engine_invalid_json
+        - engine_not_configured
+        - job_timeout
+        - job_canceled
+        - invalid_job_id
+        - job_not_found
+        - not_found
+        - method_not_allowed
     StatusResponse:
       type: object
       required: [status]
@@ -98,6 +143,62 @@ components:
         status:
           type: string
           example: ok
+    MetricsReadiness:
+      type: object
+      required: [ready, degraded]
+      properties:
+        ready:
+          type: boolean
+        degraded:
+          type: boolean
+    EngineMetrics:
+      type: object
+      required: [engine, queue_depth, queue_capacity, worker_count, running]
+      properties:
+        engine:
+          type: string
+          enum: [stt, summarize, embed]
+        queue_depth:
+          type: integer
+          minimum: 0
+        queue_capacity:
+          type: integer
+          minimum: 0
+        worker_count:
+          type: integer
+          minimum: 0
+        running:
+          type: integer
+          minimum: 0
+    RejectionMetric:
+      type: object
+      required: [engine, reason, count]
+      properties:
+        engine:
+          type: string
+          enum: [stt, summarize, embed]
+        reason:
+          type: string
+        count:
+          type: integer
+          format: int64
+          minimum: 0
+    MetricsResponse:
+      type: object
+      required: [readiness, engines, rejections]
+      properties:
+        readiness:
+          allOf:
+            - $ref: '#/components/schemas/MetricsReadiness'
+          description: readiness 상태 스냅샷(ready/degraded)
+        engines:
+          type: array
+          items:
+            $ref: '#/components/schemas/EngineMetrics'
+        rejections:
+          type: array
+          items:
+            $ref: '#/components/schemas/RejectionMetric'
     JobCreatedResponse:
       type: object
       required: [job_id]
@@ -112,20 +213,7 @@ components:
       required: [code, message]
       properties:
         code:
-          type: string
-          enum:
-            - queue_full
-            - engine_full
-            - engine_dispatcher_closed
-            - engine_connect_timeout
-            - engine_request_timeout
-            - engine_transport_error
-            - engine_upstream_4xx
-            - engine_upstream_5xx
-            - engine_retry_exhausted
-            - job_timeout
-            - job_canceled
-            - invalid_job_id
+          $ref: '#/components/schemas/ErrorCode'
         message:
           type: string
     Job:
@@ -163,6 +251,6 @@ components:
       required: [code, message]
       properties:
         code:
-          type: string
+          $ref: '#/components/schemas/ErrorCode'
         message:
           type: string


### PR DESCRIPTION
### Motivation

- Add an explicit observability contract for runtime readiness/queue/rejection snapshot to improve operational visibility.
- Allow STT clients to provide `audio_ms` so the orchestrator can derive a timeout budget based on audio length without changing runtime behavior.
- Ensure the OpenAPI error-code enum matches the Rust implementation for stable client/server error handling.

### Description

- Added `GET /metrics` path and `MetricsResponse`-related schemas (`MetricsReadiness`, `EngineMetrics`, `RejectionMetric`, `MetricsResponse`) to `docs/openapi.yaml` and synchronized the same file to `docs/swagger/openapi.yaml`.
- Introduced a shared `ErrorCode` enum in OpenAPI and updated `JobError.code` and `ErrorResponse.code` to reference it so documented error codes align with runtime strings (e.g. `queue_full`, `engine_full`, `engine_dispatcher_closed`, etc.).
- Added optional `audio_ms` query parameter to `POST /jobs` with `minimum: 0` and a description documenting the STT timeout-budget formula, the fallback to the default timeout when missing or unparseable, and min/max clamping behavior.
- Updated `README.md`, `CLAUDE.md`, and `GEMINI.md` to reflect the new `/metrics` endpoint, the `audio_ms` parameter, and an API change log entry describing these additions.

### Testing

- Verified `docs/openapi.yaml` and `docs/swagger/openapi.yaml` are identical with `cmp -s` (success).
- Confirmed presence of `GET /metrics`, `name: audio_ms`, `ErrorCode` and key error variants via `rg` searches (success).
- Performed a regex-based cross-check between the Rust source and the new OpenAPI `ErrorCode` enum to ensure coverage of implementation error strings (success; noted `job_id` is a non-error identifier and intentionally excluded).
- Ran repository state checks (`git status --short`) and basic sanity checks used during drafting (success); an attempted `PyYAML`-based parse failed due to missing environment dependency but a reliable fallback parser was used to complete validation (fallback success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d16174a6c832e93ba3c3b7af75c40)