### PR TITLE
docs: align job status terminology with OpenAPI enums

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@
 
 정렬 상태 메모:
 - OpenAPI 계약(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)은 Rust 목표 엔드포인트 기준으로 유지합니다.
+- OpenAPI 잡 상태 enum은 `queued|running|completed|failed|timeout|canceled|rejected`를 단일 기준으로 유지합니다.
 1. 계약 안정성(API 응답 필드/에러 규약)
 2. 운영 안전성(타임아웃, 큐 포화, 헬스체크)
 3. 성능 최적화(검색/벡터/read-heavy 경로)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@
 ## 현재 프로젝트 전제
 
 - OpenAPI 계약(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)은 Rust 목표 엔드포인트(`/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}`) 기준으로 정렬되어 있습니다.
+- 상태 전이/에러 코드 설명은 OpenAPI enum을 단일 기준으로 유지합니다(상태: `queued|running|completed|failed|timeout|canceled|rejected`).
 - 루트에 Rust 실행 코드(`Cargo.toml`)가 존재하며, 백엔드 전환 구현이 진행 중입니다.
 - 운영 중 코드 기준은 `frontend/`(현행) + 루트 Rust 코드입니다.
 - 오디오 변환 기본 전략은 외부 `ffmpeg` 호출이 아니라 Rust `symphonia` 크레이트 사용입니다.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,6 +8,7 @@
 ## 핵심 컨텍스트
 
 - OpenAPI 계약(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)은 Rust 목표 엔드포인트(`/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}`) 기준으로 정렬되어 있습니다.
+- 상태 전이/에러 코드 설명은 OpenAPI enum을 단일 기준으로 유지합니다(상태: `queued|running|completed|failed|timeout|canceled|rejected`).
 - 저장소는 Rust 전환 진행 중이며, 레거시 Python 코드는 현 저장소에 포함되어 있지 않습니다.
 - 루트에는 Rust 실행 코드가 존재하며, 문서/프론트와 함께 Rust 구현 변경도 작업 대상입니다.
 - `POST /jobs` 과부하 응답은 `429(queue_full|engine_full)`로 구분되며, 리젝션은 엔진/사유 라벨 카운트로 관측합니다.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Rust 백엔드는 `/healthz`/`/readyz`/`/metrics` + `POST /jobs`/`GET /jobs/{id}
 - Python 기반 구 구현은 현재 저장소에 포함되어 있지 않으며, 필요 시 별도 레거시 보관소를 참조합니다.
 - Rust 오케스트레이터 + C++(llama.cpp/whisper.cpp) 엔진 분리 아키텍처를 목표로 합니다.
 - 프론트엔드는 유지하되, 향후 Rust API 계약에 맞춰 점진적으로 연결합니다.
+- 현재 상태/목표 상태의 API 상태 enum 기준은 `queued|running|completed|failed|timeout|canceled|rejected`입니다(OpenAPI 기준).
+
+## 목표 상태 (문서/구현 고정 기준)
+
+- 상태 전이 설명은 OpenAPI 상태 enum을 단일 기준으로 유지합니다: `queued -> running -> completed|failed|timeout|canceled`, 예외 전이 `queued -> rejected`.
+- 에러 코드 설명은 OpenAPI ErrorCode enum을 단일 기준으로 유지합니다: `queue_full|engine_full|engine_dispatcher_closed|engine_dispatcher_unavailable|engine_connect_timeout|engine_request_timeout|engine_transport_error|engine_upstream_4xx|engine_upstream_5xx|engine_retry_exhausted|engine_endpoint_invalid|engine_invalid_http|engine_invalid_json|engine_not_configured|job_timeout|job_canceled|invalid_job_id|job_not_found|not_found|method_not_allowed`.
 
 ## 개발 시작
 

--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -40,6 +40,10 @@
   - 엔진/사유(`engine`, `reason`) 단위 리젝션 카운터를 오케스트레이터 메모리 지표로 추가
   - 관련 단위 테스트(사유 분기, 리젝션 카운트) 갱신 및 통과
 
+- 2026-02-24: 상태 전이/에러 코드 설명 문구를 OpenAPI enum 기준으로 고정(문서 드리프트 완화)
+  - `docs/architecture.md`, `docs/rust-cpp-backend-rewrite-plan.md`, `README.md`, `TODO/TODO.md` 상태명 표기를 `queued|running|completed|failed|timeout|canceled|rejected`로 교차 점검/정렬
+  - 상태 전이와 에러 코드 설명은 OpenAPI enum을 단일 기준 텍스트로 유지
+
 - 2026-02-23: OpenAPI/API 계약 Rust 목표 엔드포인트 정렬 상태 확인 및 WBS 반영
   - `docs/openapi.yaml`, `docs/swagger/openapi.yaml` 기준 엔드포인트가 `/healthz`, `/readyz`, `POST /jobs`, `GET /jobs/{job_id}`로 정렬됨을 재검증
   - 잡 상태/에러 코드(enum)가 Rust 오케스트레이터 구현 계약(`queued|running|completed|failed|timeout|canceled|rejected`, `invalid_job_id`, `queue_full|engine_full` 등)과 일치함을 확인

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@
 - Rust 계층이 다음 책임을 전담한다.
   - 요청 인증/검증
   - 큐 라우팅(`stt/summarize/embed`)
-  - 작업 상태 관리(`queued|running|succeeded|failed|rejected`)
+  - 작업 상태 관리(`queued|running|completed|failed|timeout|canceled|rejected`)
   - 타임아웃/재시도/배압 정책
   - 엔진 헬스체크 및 슈퍼비전
 - Swagger UI는 `:14000`에서 별도 프로세스로 운영하며, API 가용성과 분리한다.
@@ -47,8 +47,10 @@
 
 ## 4. 잡 상태 머신
 
-- 기본 전이: `queued -> running -> succeeded|failed`
-- 예외 전이: `queued -> rejected` (`queue_full`)
+- OpenAPI 기준 상태 enum(고정): `queued|running|completed|failed|timeout|canceled|rejected`
+- 기본 전이(OpenAPI 기준): `queued -> running -> completed|failed|timeout|canceled`
+- 예외 전이(OpenAPI 기준): `queued -> rejected` (enqueue 거부 시)
+- OpenAPI 기준 에러 코드 enum(고정): `queue_full|engine_full|engine_dispatcher_closed|engine_dispatcher_unavailable|engine_connect_timeout|engine_request_timeout|engine_transport_error|engine_upstream_4xx|engine_upstream_5xx|engine_retry_exhausted|engine_endpoint_invalid|engine_invalid_http|engine_invalid_json|engine_not_configured|job_timeout|job_canceled|invalid_job_id|job_not_found|not_found|method_not_allowed`
 - 상태 메타데이터:
   - `created_at_ms`
   - `started_at_ms`
@@ -66,12 +68,15 @@
 
 ### 현재 상태
 - 저장소 루트 Rust 서버는 `/healthz`, `/readyz`, `POST /jobs`, `GET /jobs/{id}`를 제공한다.
-- 엔진별 bounded queue + worker + concurrency limit + 실패/배압 상태 전이까지 구현되어 있다.
+- 상태/오류 계약은 OpenAPI enum 기준으로 관리한다.
+  - 상태: `queued|running|completed|failed|timeout|canceled|rejected`
+  - 에러 코드: `queue_full|engine_full|engine_dispatcher_closed|engine_dispatcher_unavailable|engine_connect_timeout|engine_request_timeout|engine_transport_error|engine_upstream_4xx|engine_upstream_5xx|engine_retry_exhausted|engine_endpoint_invalid|engine_invalid_http|engine_invalid_json|engine_not_configured|job_timeout|job_canceled|invalid_job_id|job_not_found|not_found|method_not_allowed`
 
 ### 목표 상태
 - Rust API(`:18000`) + 엔진 3종(`18101~18103`) + Swagger(`:14000`) 분리 운영
 - 엔진 프로세스 슈퍼비전/헬스체크/재시작 정책 고도화
 - `symphonia` 전처리 및 `/process` 전체 워크플로우 전환
+- 상태 전이/에러 코드는 OpenAPI enum 기준(`queued|running|completed|failed|timeout|canceled|rejected` 및 ErrorCode enum)으로 문서·구현·운영 가이드를 고정 유지
 
 ## 7. 로컬 실행 및 테스트
 
@@ -88,7 +93,7 @@ cargo test
 
 - `queue_depth{engine}`: accepted enqueue 기준의 **근사값**. RAII guard Drop으로 감소 정합성 보장.
 - `in_flight{engine}`: 실제 처리 중 작업 수(최대값이 worker 수를 넘지 않아야 함).
-- `jobs_total{engine,status}`: `succeeded|failed|rejected` 누적 카운트.
+- `jobs_total{engine,status}`: `completed|failed|timeout|canceled|rejected` 누적 카운트.
 - `engine_timeout_total{engine}`: connect/read/write timeout 누적 카운트.
 - `engine_latency_ms{engine}`: 가능하면 p50/p95/p99 추적.
 

--- a/docs/rust-cpp-backend-rewrite-plan.md
+++ b/docs/rust-cpp-backend-rewrite-plan.md
@@ -23,6 +23,10 @@ WBS 추적은 `TODO/TODO.md`를 사용합니다.
 
 > 본 계획의 목적은 "목표 상태"를 유지하되, 문서/구현 간 간극을 단계별로 닫는 것입니다.
 
+- 상태 전이/에러 코드는 OpenAPI(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`) enum을 단일 기준으로 유지
+  - 상태: `queued|running|completed|failed|timeout|canceled|rejected`
+  - 에러 코드: `queue_full|engine_full|engine_dispatcher_closed|engine_dispatcher_unavailable|engine_connect_timeout|engine_request_timeout|engine_transport_error|engine_upstream_4xx|engine_upstream_5xx|engine_retry_exhausted|engine_endpoint_invalid|engine_invalid_http|engine_invalid_json|engine_not_configured|job_timeout|job_canceled|invalid_job_id|job_not_found|not_found|method_not_allowed`
+
 ### 방금 반영된 단계 (Phase B-1)
 - `POST /jobs?engine=<stt|summarize|embed>` 엔진 라우팅 스켈레톤 추가 (기본값 `stt`)
 - 엔진별 인메모리 bounded capacity 확인 후 포화 시 `429(queue_full)` 반환
@@ -59,8 +63,8 @@ WBS 추적은 `TODO/TODO.md`를 사용합니다.
 - `GET /jobs/{id}` → 상태 조회
 - `GET /healthz` / `GET /readyz`
 
-잡 상태 표준:
-- `queued | running | completed | failed | timeout | canceled`
+잡 상태 표준(OpenAPI enum 기준):
+- `queued | running | completed | failed | timeout | canceled | rejected`
 
 ### 2.2 Swagger 서버 (`:14000`, 별도 프로세스)
 - Swagger UI/문서만 담당


### PR DESCRIPTION
### Motivation
- Remove inconsistent status wording (`succeeded`) and prevent future drift by making the OpenAPI status/error enums the single source of truth. 
- Clarify “current state vs goal state” language so documentation, implementation plans, and runbooks reference the same enum values.

### Description
- Replaced `succeeded` with `completed` and added explicit OpenAPI enum wording (`queued|running|completed|failed|timeout|canceled|rejected`) and state-transition text in `docs/architecture.md`.
- Added OpenAPI enum baseline and ErrorCode enum text to `docs/rust-cpp-backend-rewrite-plan.md` and included `rejected` in the plan’s job-state list.
- Injected a short synchronization note into `README.md` and added a TODO entry to `TODO/TODO.md` tracking the OpenAPI-enum lock-in action.
- Synchronized root-level docs per repo policy by updating `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` to reference the OpenAPI enum as the authoritative definition.

### Testing
- RTD pre-change (Steps 1–4) and post-change verification (Steps 5–17) were performed per `docs/RTD.md` and all steps passed for this documentation-only change. 
- Automated text checks using `rg` confirmed there are no remaining occurrences of the deprecated `succeeded` wording in the targeted docs and verified the OpenAPI enum wording is present where expected. 
- Diffs were reviewed to ensure only documentation files were modified and no runtime/build files were changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d17524de8832eb2cbcc70e5a5be35)