### PR TITLE
docs: unify GET /jobs path parameter naming to job_id

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@
 
 정렬 상태 메모:
 - WBS `1.2 OpenAPI/API 계약 재정렬`은 구현 라우트/파라미터와 OpenAPI path/param 1:1 매핑 재검증 완료 전까지 재검토 상태로 관리합니다.
-- 운영 점검 정례화(7.4.1~7.4.4)에는 계약 드리프트 주간 점검(구현↔OpenAPI path/param 대조 + CI 정적 계약 점검 확인)을 포함합니다.
+- 운영 점검 정례화(7.4.1~7.4.4)에는 계약 드리프트 주간 점검(구현↔OpenAPI path/param 대조 + CI 정적 계약 점검 확인 + 경로 파라미터 명칭 일치 검증)을 포함합니다.
 - OpenAPI 계약(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)은 Rust 목표 엔드포인트 기준으로 유지합니다.
 - OpenAPI 잡 상태 enum은 `queued|running|completed|failed|timeout|canceled|rejected`를 단일 기준으로 유지합니다.
 1. 계약 안정성(API 응답 필드/에러 규약)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 ## 현재 프로젝트 전제
 
 - WBS `1.2 OpenAPI/API 계약 재정렬`은 구현 라우트/파라미터와 OpenAPI 1:1 매핑 재검증 전까지 재검토 상태로 관리합니다.
-- 주간 점검에는 계약 드리프트 점검(구현↔OpenAPI path/param 대조, CI 정적 계약 점검 로그 확인)을 필수 항목으로 포함합니다.
+- 주간 점검에는 계약 드리프트 점검(구현↔OpenAPI path/param 대조, CI 정적 계약 점검 로그 확인 + 경로 파라미터 명칭 일치 여부 확인)을 필수 항목으로 포함합니다.
 
 - OpenAPI 계약(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)은 Rust 목표 엔드포인트(`/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}`) 기준으로 정렬되어 있습니다.
 - 상태 전이/에러 코드 설명은 OpenAPI enum을 단일 기준으로 유지합니다(상태: `queued|running|completed|failed|timeout|canceled|rejected`).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,7 +8,7 @@
 ## 핵심 컨텍스트
 
 - WBS `1.2 OpenAPI/API 계약 재정렬`은 구현 라우트/파라미터와 OpenAPI 1:1 매핑 재검증 전까지 재검토 상태로 관리합니다.
-- 주간 점검에는 계약 드리프트 점검(구현↔OpenAPI path/param 대조, CI 정적 계약 점검 로그 확인)을 필수 항목으로 포함합니다.
+- 주간 점검에는 계약 드리프트 점검(구현↔OpenAPI path/param 대조, CI 정적 계약 점검 로그 확인 + 경로 파라미터 명칭 일치 여부 확인)을 필수 항목으로 포함합니다.
 
 - OpenAPI 계약(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)은 Rust 목표 엔드포인트(`/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}`) 기준으로 정렬되어 있습니다.
 - 상태 전이/에러 코드 설명은 OpenAPI enum을 단일 기준으로 유지합니다(상태: `queued|running|completed|failed|timeout|canceled|rejected`).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ RecordRoute는 음성/문서 처리 파이프라인을 **Rust 중심 아키텍�
 - `frontend/`: 현재 유지 중인 웹 프론트엔드
 - `docs/`: Rust 전환/설계 문서
 
-Rust 백엔드는 `/healthz`/`/readyz`/`/metrics` + `POST /jobs`/`GET /jobs/{id}`와 엔진별 bounded queue/worker 기반 처리 흐름(queued→running→completed|failed|timeout|canceled|rejected)까지 반영되어 있으며, 엔진 슈퍼비전/전처리/Swagger 분리 배포 구성을 단계적으로 이전합니다.
+Rust 백엔드는 `/healthz`/`/readyz`/`/metrics` + `POST /jobs`/`GET /jobs/{job_id}`와 엔진별 bounded queue/worker 기반 처리 흐름(queued→running→completed|failed|timeout|canceled|rejected)까지 반영되어 있으며, 엔진 슈퍼비전/전처리/Swagger 분리 배포 구성을 단계적으로 이전합니다.
 
 
 > 문서 동기화: 2026-03-30 기준 운영 안정화 + 운영 점검 정례화(7.4.1~7.4.5) 완료 상태와 정렬됨.
@@ -16,6 +16,7 @@ Rust 백엔드는 `/healthz`/`/readyz`/`/metrics` + `POST /jobs`/`GET /jobs/{id}
 
 - WBS `1.2 OpenAPI/API 계약 재정렬`은 구현 라우트/파라미터와 OpenAPI path/param 1:1 매핑 재검증을 위해 **재검토 상태**로 환원되었습니다.
 - 주간 운영 점검(`docs/operations/weekly-drill/README.md`)에 계약 드리프트 점검(구현↔OpenAPI path/param 대조 + CI 정적 점검 결과 첨부) 항목이 추가되었습니다.
+- CI 정적 계약 점검은 필수 path/param 존재 여부뿐 아니라 경로 파라미터 명칭(`job_id`) 일치 여부까지 검증해야 합니다.
 
 - OpenAPI 계약은 Rust 목표 엔드포인트(`/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}`) 기준으로 정렬되어 있습니다.
 - 동시성 상한은 semaphore 대기 태스크 누적 대신 **고정 worker 개수**로 강제합니다.

--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -52,14 +52,14 @@
 - 2026-02-24: WBS 1.2(OpenAPI/API 계약 재정렬) 재검토 상태로 환원
   - 구현 라우트/파라미터와 OpenAPI 간 1:1 매핑 검증 증적이 부족해 완료 판정을 보류
   - 재완료 조건: Rust 구현 라우트/파라미터 ↔ OpenAPI path/param의 1:1 매핑 확인 체크리스트 통과
-  - 후속 태스크: CI에 정적 계약 점검(필수 path/param 존재 검사 스크립트) 도입
+  - 후속 태스크: CI에 정적 계약 점검(필수 path/param 존재 + path-param 명칭 일치 검사 스크립트) 도입
 - 2026-02-22: Phase B-1 엔진별 큐 수용량/배압(429) 스켈레톤 도입
   - `POST /jobs?engine=<stt|summarize|embed>` 라우팅 추가(기본값 `stt`)
   - 엔진별 bounded capacity 기반 큐 포화 시 `429 + queue_full|engine_full` 반환
   - 엔진별 큐 포화가 다른 큐 접수에는 영향을 주지 않는 단위 테스트 추가
 - 2026-02-22: Phase A+ 잡 API 스켈레톤 도입
   - `POST /jobs`에서 `202 + job_id` 반환 구현
-  - `GET /jobs/{id}` 인메모리 조회(초기 상태 `queued`) 구현
+  - `GET /jobs/{job_id}` 인메모리 조회(초기 상태 `queued`) 구현
   - 향후 엔진별 큐/실행기 연동 전까지 오케스트레이터 스켈레톤 상태 유지
 - 2026-02-22: Phase A 최소 HTTP 서버 도입
   - `tokio::net::TcpListener` 기반 API 서버 바인딩(`:18000` 기본값) 구현
@@ -79,7 +79,7 @@
 - [x] 비동기 런타임 초기화 (`tokio`)
 - [x] 기본 로깅/필터 초기화 (`tracing`, `tracing-subscriber`)
 - [x] API 서버 바인딩 (`:18000`)
-- [x] 작업 API (`POST /jobs`, `GET /jobs/{id}`)
+- [x] 작업 API (`POST /jobs`, `GET /jobs/{job_id}`)
 - [x] 헬스 엔드포인트 (`/healthz`, `/readyz`)
 - [x] 엔진별 큐 (`stt/summarize/embed`) 수용량/배압 스켈레톤
 - [x] 엔진 프로세스 슈퍼비전 (spawn/health/restart/shutdown)
@@ -97,6 +97,7 @@
     - [ ] `docs/openapi.yaml`, `docs/swagger/openapi.yaml`에 Rust 목표 엔드포인트가 동일하게 반영되어 있다.
     - [ ] 구현 라우트/파라미터와 OpenAPI path/query/path-param의 **1:1 매핑 확인** 체크를 통과했다.
     - [ ] 계약 드리프트 점검 항목(주간 점검/CI 정적 점검)이 활성 상태다.
+    - [ ] 문서 경로 파라미터 명칭 통일(`GET /jobs/{job_id}`) 체크포인트를 통과했다.
 
 ## 2.0 런타임 스캐폴딩
 
@@ -160,5 +161,5 @@
 
 2. **WBS 1.2 재완료 게이트 — OpenAPI/API 계약 1:1 매핑 검증 자동화**
    - [ ] 구현 라우트/파라미터와 OpenAPI path/param의 수동 대조 체크리스트 완료
-   - [ ] CI 정적 계약 점검(필수 path/param 존재 확인 스크립트) 추가
+   - [ ] CI 정적 계약 점검(필수 path/param 존재 + path-param 명칭 일치 확인 스크립트) 추가
    - [ ] 스크립트 결과를 근거로 WBS 1.2 재완료 판정


### PR DESCRIPTION
### Motivation

- Align top-level documentation with OpenAPI (`docs/openapi.yaml`) by standardizing the jobs path parameter to `GET /jobs/{job_id}`.
- Add an explicit WBS 1.2 checkpoint to ensure documentation path-parameter naming is validated during re-review.
- Prevent recurrence by requiring CI static contract checks to validate path-parameter naming (not just presence of paths/params).

### Description

- Unified endpoint notation from `GET /jobs/{id}` to `GET /jobs/{job_id}` in `README.md`, `TODO/TODO.md`, `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`.
- Added a WBS 1.2 re-review checklist item in `TODO/TODO.md`: "document path-parameter naming consistency (`GET /jobs/{job_id}`)".
- Extended process/CI guidance text to require CI static contract checks to verify both required path/params and path-parameter name equality (`job_id`) across docs; updated weekly contract-drift guidance to include path-parameter name verification.
- Committed changes (commit `aed4d04`) and opened a PR draft reflecting these documentation and process updates.

### Testing

- Verified there are no remaining `GET /jobs/{id}` occurrences with `rg -n "GET /jobs/\{id\}" README.md TODO/TODO.md CLAUDE.md GEMINI.md AGENTS.md || true` and confirmed matches were replaced.
- Ran cross-check searches for the new phrasing and CI rule markers with `rg -n "GET /jobs/\{id\}|GET /jobs/\{job_id\}|path-param 명칭|WBS 1\.2|정적 계약 점검" ...` and confirmed expected matches.
- Performed repository sanity checks with `git status --short` and committed the changes; all automated checks described above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d1c1d7058832e89f39d5bf1d316fe)