### PR TITLE
docs: add 'rejected' to TODO enum, align status enum wording, add weekly drift checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Rust 백엔드는 `/healthz`/`/readyz`/`/metrics` + `POST /jobs`/`GET /jobs/{job
 - Python 기반 구 구현은 현재 저장소에 포함되어 있지 않으며, 필요 시 별도 레거시 보관소를 참조합니다.
 - Rust 오케스트레이터 + C++(llama.cpp/whisper.cpp) 엔진 분리 아키텍처를 목표로 합니다.
 - 프론트엔드는 유지하되, 향후 Rust API 계약에 맞춰 점진적으로 연결합니다.
-- 현재 상태/목표 상태의 API 상태 enum 기준은 `queued|running|completed|failed|timeout|canceled|rejected`입니다(OpenAPI 기준).
+- 상태 전이/에러 코드 설명은 OpenAPI enum을 단일 기준으로 유지합니다(상태: `queued|running|completed|failed|timeout|canceled|rejected`).
 
 ## 목표 상태 (문서/구현 고정 기준)
 

--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -114,7 +114,7 @@
 ## 4.0 잡 모델/오류 계약
 
 - [x] 4.1 잡 상태 전이 모델 (`queued` 초기 상태 + 조회 스켈레톤)
-- [x] 4.1-확장 잡 상태 전이 전체 모델 (`running|completed|failed|timeout|canceled`)
+- [x] 4.1-확장 잡 상태 전이 전체 모델 (`running|completed|failed|timeout|canceled|rejected`)
 - [x] 4.2 타임아웃 계층 분리 (HTTP vs Job)
 - [x] 4.3 에러 코드/응답 필드 계약 고정
 

--- a/docs/operations/weekly-drill/README.md
+++ b/docs/operations/weekly-drill/README.md
@@ -85,6 +85,7 @@ OpenAPI/API 계약 드리프트를 조기 탐지하기 위해, 매 주간 점검
 
 - [ ] 구현 라우트 집합과 OpenAPI path 집합의 차이가 없는지 확인
 - [ ] 구현 파라미터(path/query)와 OpenAPI 파라미터 정의가 1:1 매핑되는지 확인
+- [ ] 상태 enum 7종(`queued|running|completed|failed|timeout|canceled|rejected`)이 구현/문서/OpenAPI 간 완전 일치하는지 확인
 - [ ] 불일치가 발생하면 회차 결과를 FAIL로 판정하고 액션 아이템(책임자/기한) 등록
 - [ ] CI 정적 계약 점검 결과(필수 path/param 존재 체크) 링크 또는 로그 요약 첨부
 


### PR DESCRIPTION
### Motivation

- 문서 간 잡 상태 enum 표기가 일부 누락되어 있어 OpenAPI/구현 문서 간 드리프트 가능성이 존재하므로 `rejected`를 포함해 7종 상태 기준으로 통일합니다. 
- README/CLAUDE/GEMINI의 상태 enum 요약 문구가 달라 문서 일관성이 떨어져 이를 동일 문구로 정렬합니다.
- 주간 계약 드리프트 점검에서 enum 불일치를 조기에 탐지할 수 있도록 체크리스트 항목을 추가합니다.

### Description

- `TODO/TODO.md`의 "4.1-확장" 항목을 업데이트해 상태 전이 목록에 `rejected`를 추가했습니다. 
- `README.md`의 상태 enum 요약 문구를 `CLAUDE.md` 및 `GEMINI.md`와 동일한 문구(상태: `queued|running|completed|failed|timeout|canceled|rejected`)로 정렬했습니다. 
- `docs/operations/weekly-drill/README.md`의 계약 드리프트 주간 점검 항목에 "상태 enum 7종 완전 일치(queued|running|completed|failed|timeout|canceled|rejected) 확인" 항목을 추가했습니다. 

### Testing

- 사본/패치 적용과 검증은 스크립트/명령으로 수행하고 결과를 텍스트 검색으로 확인했으며, 주요 검증 명령은 아래와 같습니다: `rg -n -F`로 README/CLAUDE/GEMINI의 통일된 문구 존재 여부, `rg -n -F`로 TODO의 4.1-확장 라인 반영 여부, 및 `rg -n -F`로 weekly-drill 체크리스트 신규 항목 반영 여부를 확인했습니다. 
- 변경된 파일들(`README.md`, `TODO/TODO.md`, `docs/operations/weekly-drill/README.md`)의 diff를 검사해 의도한 문구만 변경되었음을 확인했습니다. 
- RTD 절차(사전 Step 1~4 및 후행 Step 5~18)를 수행해 모두 PASS 판정을 기록했으며 보안·롤백 위험은 없음을 검증했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d1cec58b4832eba55f1c4aa37efd7)