### PR TITLE
docs: codify WBS 1.2 recompletion gate checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@
 배포/자산 세부 운영 기준은 `docs/deployment-asset-policy.md`를 참조합니다.
 `main.rs` 분할/모듈화 실무 기준은 `docs/main-rs-modularization-guide.md`를 참조합니다.
 운영 점검 정례화 정책은 `docs/operations/weekly-drill/README.md`를 참조합니다.
+WBS 1.2 재완료 게이트(구현 라우트/파라미터 ↔ OpenAPI path/param 1:1 매핑) 기준은 `docs/openapi-wbs-1.2-recompletion-gate.md`를 단일 체크리스트로 참조합니다.
 7.4.5 완료 조건 누적 추적은 `docs/operations/weekly-drill/STATUS.md`를 기준으로 갱신합니다.
 실행 단위/의존성 추적은 `TODO/TODO.md`를 함께 참조합니다.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@
 ## 현재 프로젝트 전제
 
 - WBS `1.2 OpenAPI/API 계약 재정렬`은 구현 라우트/파라미터와 OpenAPI 1:1 매핑 재검증 전까지 재검토 상태로 관리합니다.
+- 재완료 게이트는 `docs/openapi-wbs-1.2-recompletion-gate.md` 단일 체크리스트를 기준으로 판정하며, 7개 항목 미충족 시 `NOT READY`를 유지합니다.
 - 주간 점검에는 계약 드리프트 점검(구현↔OpenAPI path/param 대조, CI 정적 계약 점검 로그 확인 + 경로 파라미터 명칭 일치 여부 확인 + 기준 엔드포인트 세트 `/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}` 고정)을 필수 항목으로 포함하며, 회차 로그에는 CI 정적 점검 스크립트 산출물 링크/경로를 첨부합니다.
 
 - OpenAPI 계약(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)은 Rust 목표 엔드포인트(`/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}`) 기준으로 정렬되어 있습니다.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,6 +8,7 @@
 ## 핵심 컨텍스트
 
 - WBS `1.2 OpenAPI/API 계약 재정렬`은 구현 라우트/파라미터와 OpenAPI 1:1 매핑 재검증 전까지 재검토 상태로 관리합니다.
+- 재완료 게이트는 `docs/openapi-wbs-1.2-recompletion-gate.md` 단일 체크리스트를 기준으로 판정하며, 7개 항목 미충족 시 `NOT READY`를 유지합니다.
 - 주간 점검에는 계약 드리프트 점검(구현↔OpenAPI path/param 대조, CI 정적 계약 점검 로그 확인 + 경로 파라미터 명칭 일치 여부 확인 + 기준 엔드포인트 세트 `/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}` 고정)을 필수 항목으로 포함하며, 회차 로그에는 CI 정적 점검 스크립트 산출물 링크/경로를 첨부합니다.
 
 - OpenAPI 계약(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)은 Rust 목표 엔드포인트(`/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}`) 기준으로 정렬되어 있습니다.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Rust 백엔드는 `/healthz`/`/readyz`/`/metrics` + `POST /jobs`/`GET /jobs/{job
 - WBS `1.2 OpenAPI/API 계약 재정렬`은 구현 라우트/파라미터와 OpenAPI path/param 1:1 매핑 재검증을 위해 **재검토 상태**로 환원되었습니다.
 - 주간 운영 점검(`docs/operations/weekly-drill/README.md`)에 계약 드리프트 점검(구현↔OpenAPI path/param 대조 + CI 정적 점검 결과 첨부) 항목이 추가되었습니다.
 - CI 정적 계약 점검은 필수 path/param 존재 여부뿐 아니라 경로 파라미터 명칭(`job_id`) 일치 여부까지 검증해야 하며, 점검 로그에는 스크립트 산출물 링크/경로를 첨부해야 합니다.
+- WBS 1.2 재완료 판정은 `docs/openapi-wbs-1.2-recompletion-gate.md` 체크리스트(경로/파라미터 1:1 매핑 + 증적 기록) **전체 충족 시에만 READY**입니다.
 
 - OpenAPI 계약은 Rust 목표 엔드포인트(`/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}`) 기준으로 정렬되어 있습니다.
 - 동시성 상한은 semaphore 대기 태스크 누적 대신 **고정 worker 개수**로 강제합니다.

--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -54,6 +54,7 @@
   - 당시 판정 기준 OpenAPI 버전(커밋): `78020f1`
   - 구현 라우트/파라미터와 OpenAPI 간 1:1 매핑 검증 대상 엔드포인트 세트를 `/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}`로 고정하고 증적 부족으로 완료 판정을 보류
   - 재완료 조건: Rust 구현 라우트/파라미터 ↔ OpenAPI path/param의 1:1 매핑 확인 체크리스트 통과
+  - 판정 체크리스트 기준 문서: `docs/openapi-wbs-1.2-recompletion-gate.md`
   - 후속 태스크: CI에 정적 계약 점검(필수 path/param 존재 + path-param 명칭 일치 검사 스크립트) 도입
   - 증적 규칙: 회차 로그에 CI 정적 계약 점검 스크립트 산출물 링크/경로(`artifacts/contracts/<run-id>/contract-drift-report.json` 등)를 첨부
 - 2026-02-22: Phase B-1 엔진별 큐 수용량/배압(429) 스켈레톤 도입
@@ -163,6 +164,7 @@
      - [x] 미해결 액션 아이템이 0건이거나, 모든 액션에 책임자/기한이 지정되어 있다.
 
 2. **WBS 1.2 재완료 게이트 — OpenAPI/API 계약 1:1 매핑 검증 자동화**
+   - [x] 재완료 판정 체크리스트 문서 고정 (`docs/openapi-wbs-1.2-recompletion-gate.md`)
    - [ ] 구현 라우트/파라미터와 OpenAPI path/param의 수동 대조 체크리스트 완료
    - [ ] CI 정적 계약 점검(필수 path/param 존재 + path-param 명칭 일치 확인 스크립트) 추가
    - [ ] 스크립트 결과와 산출물 링크/경로를 근거로 WBS 1.2 재완료 판정

--- a/docs/openapi-wbs-1.2-recompletion-gate.md
+++ b/docs/openapi-wbs-1.2-recompletion-gate.md
@@ -1,0 +1,57 @@
+# WBS 1.2 재완료 게이트 — OpenAPI/API 계약 1:1 매핑 체크리스트
+
+이 문서는 WBS `1.2 OpenAPI/API 계약 재정렬`의 **재완료 판정 기준**을 고정합니다.
+
+목표는 Rust 구현 라우트/파라미터와 OpenAPI path/param 사이의 1:1 매핑을 증적 기반으로 검증하여,
+운영 점검(주간 계약 드리프트 점검)과 CI 정적 점검의 판정 기준을 일치시키는 것입니다.
+
+## 1) 적용 범위
+
+- 구현 기준 엔드포인트(고정):
+  - `GET /healthz`
+  - `GET /readyz`
+  - `GET /metrics`
+  - `POST /jobs`
+  - `GET /jobs/{job_id}`
+- OpenAPI 기준 문서:
+  - `docs/openapi.yaml`
+  - `docs/swagger/openapi.yaml`
+
+## 2) 재완료 판정 체크리스트 (모두 충족 시에만 READY)
+
+아래 항목 중 하나라도 미충족이면 WBS 1.2는 **NOT READY**입니다.
+
+1. **경로 집합 일치**
+   - 구현 라우트 집합과 OpenAPI path 집합이 기준 엔드포인트 5종에서 완전 일치한다.
+2. **파라미터 1:1 매핑 일치**
+   - 각 엔드포인트의 path/query 파라미터 이름·필수 여부·위치가 구현과 OpenAPI에서 1:1로 일치한다.
+3. **경로 파라미터 명칭 일치**
+   - 잡 조회 경로 파라미터 명칭이 `job_id`로 통일되어 있다(`GET /jobs/{job_id}`).
+4. **상태 enum 일치**
+   - 잡 상태 enum이 `queued|running|completed|failed|timeout|canceled|rejected`로 구현/문서/OpenAPI에 동일하다.
+5. **주간 점검 항목 활성화**
+   - `docs/operations/weekly-drill/README.md`의 계약 드리프트 점검 체크리스트가 최신 기준으로 유지된다.
+6. **CI 정적 계약 점검 증적 확보**
+   - 필수 path/param 존재 + path-param 명칭 일치 검증 결과가 CI에서 확인 가능하다.
+7. **증적 링크/경로 기록**
+   - 회차 문서(또는 WBS 로그)에 정적 점검 산출물 링크/경로를 남긴다.
+   - 예: `artifacts/contracts/<run-id>/contract-drift-report.json`
+
+## 3) 판정 절차
+
+1. 수동 대조: 구현 라우트/파라미터 ↔ OpenAPI path/param 체크리스트를 먼저 수행합니다.
+2. 자동 대조: CI 정적 계약 점검 결과를 확인합니다.
+3. 증적 기록: 주간 점검 문서 또는 WBS 로그에 결과(PASS/FAIL)와 산출물 링크/경로를 남깁니다.
+4. 최종 판정: 2장 체크리스트 7개 항목이 모두 충족될 때만 `READY`로 판정합니다.
+
+## 4) FAIL 처리 규칙
+
+- 불일치가 하나라도 발견되면 즉시 `NOT READY`로 판정합니다.
+- 액션 아이템(원인, 담당자, 기한, 재검증 방법)을 등록하고 다음 점검 회차에 재검증합니다.
+- 재검증에서도 실패 시, WBS 1.2 완료 판정은 유지할 수 없습니다.
+
+## 5) 운영 문서 연계
+
+- 주간 운영 점검 기준: `docs/operations/weekly-drill/README.md`
+- 진행/완료 추적: `docs/operations/weekly-drill/STATUS.md`, `TODO/TODO.md`
+

--- a/docs/operations/weekly-drill/README.md
+++ b/docs/operations/weekly-drill/README.md
@@ -92,6 +92,7 @@ OpenAPI/API 계약 드리프트를 조기 탐지하기 위해, 매 주간 점검
 - [ ] CI 정적 계약 점검 스크립트 산출물 링크/경로(`artifacts/contracts/<run-id>/contract-drift-report.json` 등)를 회차 문서에 명시
 
 > 운영 담당은 점검 결과 문서(`YYYY-MM-DD.md`)에 계약 드리프트 점검 결과(PASS/FAIL + 근거)를 명시합니다.
+> WBS 1.2 재완료 판정 시에는 `docs/openapi-wbs-1.2-recompletion-gate.md` 체크리스트를 동일 기준으로 적용합니다.
 
 ## 7. 진행 현황 기록 규칙
 


### PR DESCRIPTION
### Motivation

- WBS 1.2 (OpenAPI/API 계약 재정렬) was in a re-review state because the completion gate and evidence rules were not fixed, causing inconsistent READY/NOT READY judgments across weekly operations and CI. 
- The change centralizes the recompletion decision criteria so weekly drills, TODO/WBS tracking, and CI static checks use the same authoritative checklist. 
- This is a documentation-only, low-risk improvement to make the approval gate explicit before automating checks or changing runtime code.

### Description

- Add `docs/openapi-wbs-1.2-recompletion-gate.md` with a single canonical 7-item READY/NOT READY checklist covering endpoint set, path/query parameter 1:1 mapping, `job_id` naming, enum consistency, CI evidence, FAIL handling, and the decision flow. 
- Update root and summary docs (`AGENTS.md`, `README.md`, `CLAUDE.md`, `GEMINI.md`) to reference the new gate document and clarify that WBS 1.2 is READY only when the checklist is fully satisfied. 
- Update execution tracking and operations docs (`TODO/TODO.md`, `docs/operations/weekly-drill/README.md`) to reference the gate and require CI artifact links as evidence for recompletion. 
- All changes are docs-only and limited to adding the canonical gate file plus cross-document synchronization to avoid criteria drift.

### Testing

- RTD pre-change checks (Step 1–4: planning/review/anti-overreach) were executed and passed, confirming scope, DoD, and minimal-change approach. 
- RTD post-change checks (Steps 5–18: implementation review, security/quality checks, final readiness) were executed and passed, concluding the document changes meet DoD and have clear rollback paths. 
- Automated verification commands run locally to validate the edits and references succeeded: `rg -n "openapi-wbs-1.2-recompletion-gate.md|재완료 게이트|NOT READY|READY" AGENTS.md README.md CLAUDE.md GEMINI.md TODO/TODO.md docs/operations/weekly-drill/README.md docs/openapi-wbs-1.2-recompletion-gate.md` (matches found) and repository status checks confirmed staged changes are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dba48ecbc832ead0831ec89a2d36a)