### PR TITLE
Add cross-platform install/run scripts and model defaults to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,15 @@ RECORDROUTE_SWAGGER_PORT=14000
 LLAMA_TEXT_URL=http://127.0.0.1:18101
 LLAMA_EMBED_URL=http://127.0.0.1:18102
 WHISPER_URL=http://127.0.0.1:18103
+
+# 설치 스크립트 선행 게이트(필수)
+# - 절대경로 또는 models 하위 파일명(상대경로) 지정 가능
+RECORDROUTE_DEFAULT_STT_MODEL=ggml-large-v3-turbo.bin
+RECORDROUTE_DEFAULT_SUMMARIZE_MODEL=Qwen2.5-7B-Instruct-Q5_K_M.gguf
+RECORDROUTE_DEFAULT_EMBED_MODEL=bge-m3-q8_0.gguf
+
+# 설치 중 모델 누락 시 pull(P) 선택을 위한 선택값(옵션)
+# - huggingface-cli download <repo> <file> 에 사용
+RECORDROUTE_STT_MODEL_REPO=openai/whisper-large-v3
+RECORDROUTE_SUMMARIZE_MODEL_REPO=Qwen/Qwen2.5-7B-Instruct-GGUF
+RECORDROUTE_EMBED_MODEL_REPO=BAAI/bge-m3

--- a/scripts/install_unix.sh
+++ b/scripts/install_unix.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[RecordRoute] Unix install started."
+
+require_env() {
+  local var_name="$1"
+  local label="$2"
+  if [[ -z "${!var_name:-}" ]]; then
+    echo "[ERROR] ${label} env (${var_name}) is not set."
+    return 1
+  fi
+}
+
+pull_model() {
+  local model_var="$1"
+  local model_dir="$2"
+  local model_repo_var="$3"
+  local model_file="${!model_var}"
+  local model_repo="${!model_repo_var:-}"
+
+  if [[ -z "$model_repo" ]]; then
+    echo "[ERROR] Pull requested but ${model_repo_var} is not set."
+    echo "        Set repo id (e.g. org/repo) and rerun."
+    return 1
+  fi
+
+  if ! command -v huggingface-cli >/dev/null 2>&1; then
+    echo "[ERROR] huggingface-cli is required to pull models."
+    echo "        Install: pip install -U huggingface_hub"
+    return 1
+  fi
+
+  echo "[INFO] Pulling ${model_file} from ${model_repo} ..."
+  huggingface-cli download "$model_repo" "$model_file" \
+    --local-dir "$ROOT_DIR/$model_dir" \
+    --local-dir-use-symlinks False
+}
+
+ensure_model() {
+  local model_var="$1"
+  local model_dir="$2"
+  local model_repo_var="$3"
+  local model_value="${!model_var}"
+  local model_path="$model_value"
+
+  if [[ ! -f "$model_path" ]]; then
+    model_path="$ROOT_DIR/$model_dir/$model_value"
+  fi
+
+  if [[ -f "$model_path" ]]; then
+    echo "[OK] ${model_var} -> ${model_path}"
+    return 0
+  fi
+
+  echo "[WARN] Model not found for ${model_var} (${model_value})."
+  echo "       Expected path: ${model_path}"
+
+  local choice
+  read -r -p "Choose action: [C]ancel install / [P]ull model: " choice
+  if [[ "${choice^^}" == "P" ]]; then
+    pull_model "$model_var" "$model_dir" "$model_repo_var" || return 1
+
+    model_path="$model_value"
+    if [[ ! -f "$model_path" ]]; then
+      model_path="$ROOT_DIR/$model_dir/$model_value"
+    fi
+    if [[ -f "$model_path" ]]; then
+      echo "[OK] Pulled ${model_var} -> ${model_path}"
+      return 0
+    fi
+
+    echo "[ERROR] Model still missing after pull attempt: ${model_path}"
+    return 1
+  fi
+
+  echo "[ERROR] Install canceled because model file is missing."
+  return 1
+}
+
+require_env RECORDROUTE_DEFAULT_STT_MODEL "STT default model"
+require_env RECORDROUTE_DEFAULT_SUMMARIZE_MODEL "Summarize default model"
+require_env RECORDROUTE_DEFAULT_EMBED_MODEL "Embed default model"
+
+ensure_model RECORDROUTE_DEFAULT_STT_MODEL "models/stt" RECORDROUTE_STT_MODEL_REPO
+ensure_model RECORDROUTE_DEFAULT_SUMMARIZE_MODEL "models/text" RECORDROUTE_SUMMARIZE_MODEL_REPO
+ensure_model RECORDROUTE_DEFAULT_EMBED_MODEL "models/embed" RECORDROUTE_EMBED_MODEL_REPO
+
+echo "[1/3] Installing frontend dependencies..."
+npm --prefix frontend install
+
+echo "[2/3] Building frontend..."
+npm --prefix frontend run build
+
+echo "[3/3] Building Rust orchestrator..."
+cargo build --release
+
+echo "[RecordRoute] Install completed successfully."

--- a/scripts/install_windows.bat
+++ b/scripts/install_windows.bat
@@ -1,0 +1,117 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+set "ROOT_DIR=%~dp0.."
+pushd "%ROOT_DIR%" >nul
+
+echo [RecordRoute] Windows install started.
+
+call :require_env RECORDROUTE_DEFAULT_STT_MODEL "STT default model"
+if errorlevel 1 goto :fail
+call :require_env RECORDROUTE_DEFAULT_SUMMARIZE_MODEL "Summarize default model"
+if errorlevel 1 goto :fail
+call :require_env RECORDROUTE_DEFAULT_EMBED_MODEL "Embed default model"
+if errorlevel 1 goto :fail
+
+call :ensure_model RECORDROUTE_DEFAULT_STT_MODEL "models\stt" RECORDROUTE_STT_MODEL_REPO
+if errorlevel 1 goto :fail
+call :ensure_model RECORDROUTE_DEFAULT_SUMMARIZE_MODEL "models\text" RECORDROUTE_SUMMARIZE_MODEL_REPO
+if errorlevel 1 goto :fail
+call :ensure_model RECORDROUTE_DEFAULT_EMBED_MODEL "models\embed" RECORDROUTE_EMBED_MODEL_REPO
+if errorlevel 1 goto :fail
+
+echo [1/3] Installing frontend dependencies...
+call npm --prefix frontend install
+if errorlevel 1 goto :fail
+
+echo [2/3] Building frontend...
+call npm --prefix frontend run build
+if errorlevel 1 goto :fail
+
+echo [3/3] Building Rust orchestrator...
+call cargo build --release
+if errorlevel 1 goto :fail
+
+echo [RecordRoute] Install completed successfully.
+popd >nul
+exit /b 0
+
+:require_env
+set "VAR_NAME=%~1"
+set "LABEL=%~2"
+call set "VAR_VALUE=%%%VAR_NAME%%%"
+if not defined VAR_VALUE (
+    echo [ERROR] %LABEL% env (%VAR_NAME%) is not set.
+    exit /b 1
+)
+exit /b 0
+
+:ensure_model
+set "MODEL_VAR=%~1"
+set "MODEL_DIR=%~2"
+set "MODEL_REPO_VAR=%~3"
+call set "MODEL_VALUE=%%%MODEL_VAR%%%"
+set "MODEL_PATH=!MODEL_VALUE!"
+
+if not exist "!MODEL_PATH!" (
+    set "MODEL_PATH=%ROOT_DIR%\%MODEL_DIR%\!MODEL_VALUE!"
+)
+
+if exist "!MODEL_PATH!" (
+    echo [OK] !MODEL_VAR! -> !MODEL_PATH!
+    exit /b 0
+)
+
+echo [WARN] Model not found for !MODEL_VAR! (!MODEL_VALUE!).
+echo        Expected path: !MODEL_PATH!
+set /p CHOICE="Choose action: [C]ancel install / [P]ull model: "
+
+if /I "!CHOICE!"=="P" (
+    call :pull_model "%MODEL_VAR%" "%MODEL_DIR%" "%MODEL_REPO_VAR%"
+    if errorlevel 1 exit /b 1
+    call set "MODEL_VALUE=%%%MODEL_VAR%%%"
+    set "MODEL_PATH=!MODEL_VALUE!"
+    if not exist "!MODEL_PATH!" set "MODEL_PATH=%ROOT_DIR%\%MODEL_DIR%\!MODEL_VALUE!"
+    if exist "!MODEL_PATH!" (
+        echo [OK] Pulled !MODEL_VAR! -> !MODEL_PATH!
+        exit /b 0
+    )
+    echo [ERROR] Model still missing after pull attempt: !MODEL_PATH!
+    exit /b 1
+)
+
+echo [ERROR] Install canceled because model file is missing.
+exit /b 1
+
+:pull_model
+set "MODEL_VAR=%~1"
+set "MODEL_DIR=%~2"
+set "MODEL_REPO_VAR=%~3"
+call set "MODEL_FILE=%%%MODEL_VAR%%%"
+call set "MODEL_REPO=%%%MODEL_REPO_VAR%%%"
+
+if not defined MODEL_REPO (
+    echo [ERROR] Pull requested but %MODEL_REPO_VAR% is not set.
+    echo        Set repo id (e.g. org/repo) and rerun.
+    exit /b 1
+)
+
+where huggingface-cli >nul 2>nul
+if errorlevel 1 (
+    echo [ERROR] huggingface-cli is required to pull models.
+    echo        Install: pip install -U huggingface_hub
+    exit /b 1
+)
+
+echo [INFO] Pulling %MODEL_FILE% from %MODEL_REPO% ...
+call huggingface-cli download "%MODEL_REPO%" "%MODEL_FILE%" --local-dir "%ROOT_DIR%\%MODEL_DIR%" --local-dir-use-symlinks False
+if errorlevel 1 (
+    echo [ERROR] huggingface-cli download failed.
+    exit /b 1
+)
+exit /b 0
+
+:fail
+echo [RecordRoute] Install failed.
+popd >nul
+exit /b 1

--- a/scripts/run_unix.sh
+++ b/scripts/run_unix.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cleanup() {
+  local exit_code=$?
+  if [[ -n "${API_PID:-}" ]] && kill -0 "$API_PID" >/dev/null 2>&1; then
+    kill "$API_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${FRONTEND_PID:-}" ]] && kill -0 "$FRONTEND_PID" >/dev/null 2>&1; then
+    kill "$FRONTEND_PID" >/dev/null 2>&1 || true
+  fi
+  exit "$exit_code"
+}
+trap cleanup INT TERM EXIT
+
+echo "[RecordRoute] Starting Rust API server..."
+(
+  cd "$ROOT_DIR"
+  cargo run
+) &
+API_PID=$!
+
+echo "[RecordRoute] Starting frontend dev server..."
+(
+  cd "$ROOT_DIR/frontend"
+  npm run dev
+) &
+FRONTEND_PID=$!
+
+echo "[RecordRoute] Rust API PID: $API_PID"
+echo "[RecordRoute] Frontend PID: $FRONTEND_PID"
+echo "[RecordRoute] Press Ctrl+C to stop both services."
+
+wait -n "$API_PID" "$FRONTEND_PID"

--- a/scripts/run_windows.bat
+++ b/scripts/run_windows.bat
@@ -1,0 +1,22 @@
+@echo off
+setlocal EnableExtensions
+
+set "ROOT_DIR=%~dp0.."
+pushd "%ROOT_DIR%" >nul
+
+echo [RecordRoute] Starting Rust API server...
+start "RecordRoute Rust API" cmd /k "cd /d %ROOT_DIR% && cargo run"
+if errorlevel 1 goto :fail
+
+echo [RecordRoute] Starting frontend dev server...
+start "RecordRoute Frontend" cmd /k "cd /d %ROOT_DIR%\frontend && npm run dev"
+if errorlevel 1 goto :fail
+
+echo [RecordRoute] Servers started in separate windows.
+popd >nul
+exit /b 0
+
+:fail
+echo [RecordRoute] Failed to start one or more services.
+popd >nul
+exit /b 1


### PR DESCRIPTION
### Motivation
- Provide a simple, cross-platform way to install dependencies, ensure required model files, and run the dev servers for the project. 
- Make model defaults and optional Hugging Face repo IDs explicit in `.env.example` so installs can validate or auto-pull models.

### Description
- Extended `.env.example` with `RECORDROUTE_DEFAULT_*` model variables and optional `RECORDROUTE_*_MODEL_REPO` values for STT, summarization, and embedding models. 
- Added `scripts/install_unix.sh` which validates required env vars, checks for model files, optionally pulls missing models via `huggingface-cli`, installs frontend deps with `npm`, builds the frontend, and builds the Rust orchestrator with `cargo build --release`.
- Added `scripts/install_windows.bat` which mirrors the Unix installer logic and uses `huggingface-cli` for pulls, `npm` for frontend install/build, and `cargo` for the Rust build on Windows.
- Added `scripts/run_unix.sh` which starts the Rust API and frontend dev server in background, traps signals, and performs cleanup on exit. 
- Added `scripts/run_windows.bat` which launches the Rust API and frontend in new Windows console windows.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e58d0d664832ea57233fdac400687)