### PR TITLE
build: remove rust-analyzer from pinned rustup components

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "stable"
-components = ["rustfmt", "clippy", "rust-analyzer"]
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
### Motivation
- Remove forced `rust-analyzer` installation from `rust-toolchain.toml` to avoid rustup component install failures/rollbacks on Windows when `bin\rust-analyzer.exe` conflicts, since `rust-analyzer` is an IDE aid and not required for building or testing.

### Description
- Updated `rust-toolchain.toml` to pin only `rustfmt` and `clippy`, removing `rust-analyzer` from the mandatory components.

### Testing
- Ran `cargo test` and all unit tests passed; ran `cargo clippy --all-targets --all-features` which completed successfully (warnings only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e7fcef344832eb508fdf12ff13989)