### PR TITLE
docs: add Windows Rust toolchain troubleshooting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,3 +92,26 @@ WBS 1.2 재완료 게이트(구현 라우트/파라미터 ↔ OpenAPI path/param
 권장:
 - “현재 상태”와 “목표 상태”를 문서에서 명확히 분리
 - 레거시 참조 경로를 명시해 온보딩 혼선을 줄이기
+
+## 8) Rust 빌드(Windows) 트러블슈팅
+
+Windows에서 `cargo build` 실행 시 아래 오류가 발생하면 rustup toolchain/component 불일치 가능성이 큽니다.
+
+```powershell
+cargo build
+error: the 'rustc.exe' binary ... is not applicable to the 'stable-x86_64-pc-windows-msvc' toolchain
+```
+
+복구 절차(순서 고정):
+
+```powershell
+rustup show
+rustup toolchain uninstall stable-x86_64-pc-windows-msvc
+rustup toolchain install stable-x86_64-pc-windows-msvc --profile default
+rustup default stable-x86_64-pc-windows-msvc
+rustup component add rustc cargo clippy rustfmt --toolchain stable-x86_64-pc-windows-msvc
+rustup update
+cargo build
+```
+
+지속 실패 시 `where rustc`, `rustup which rustc`로 PATH 중복을 점검하고 Visual Studio Build Tools(`MSVC v143`, `Windows 10/11 SDK`) 설치 상태를 확인합니다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@
 
 ## 현재 프로젝트 전제
 
+- Windows `cargo build`에서 `rustc.exe ... not applicable` 오류가 나면 rustup toolchain/component 재설치(`stable-x86_64-pc-windows-msvc`) 절차를 우선 적용합니다(상세 커맨드는 `README.md`/`AGENTS.md` 참조).
 - WBS `1.2 OpenAPI/API 계약 재정렬`은 구현 라우트/파라미터와 OpenAPI 1:1 매핑 재검증 전까지 재검토 상태로 관리합니다.
 - 재완료 게이트는 `docs/openapi-wbs-1.2-recompletion-gate.md` 단일 체크리스트를 기준으로 판정하며, 7개 항목 미충족 시 `NOT READY`를 유지합니다.
 - 주간 점검에는 계약 드리프트 점검(구현↔OpenAPI path/param 대조, CI 정적 계약 점검 로그 확인 + 경로 파라미터 명칭 일치 여부 확인 + 기준 엔드포인트 세트 `/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}` 고정)을 필수 항목으로 포함하며, 회차 로그에는 CI 정적 점검 스크립트 산출물 링크/경로를 첨부합니다.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -7,6 +7,7 @@
 
 ## 핵심 컨텍스트
 
+- Windows `cargo build`에서 `rustc.exe ... not applicable` 오류가 나면 rustup toolchain/component 재설치(`stable-x86_64-pc-windows-msvc`) 절차를 우선 적용합니다(상세 커맨드는 `README.md`/`AGENTS.md` 참조).
 - WBS `1.2 OpenAPI/API 계약 재정렬`은 구현 라우트/파라미터와 OpenAPI 1:1 매핑 재검증 전까지 재검토 상태로 관리합니다.
 - 재완료 게이트는 `docs/openapi-wbs-1.2-recompletion-gate.md` 단일 체크리스트를 기준으로 판정하며, 7개 항목 미충족 시 `NOT READY`를 유지합니다.
 - 주간 점검에는 계약 드리프트 점검(구현↔OpenAPI path/param 대조, CI 정적 계약 점검 로그 확인 + 경로 파라미터 명칭 일치 여부 확인 + 기준 엔드포인트 세트 `/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}` 고정)을 필수 항목으로 포함하며, 회차 로그에는 CI 정적 점검 스크립트 산출물 링크/경로를 첨부합니다.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,29 @@ cd frontend
 npm run build
 ```
 
+### Rust 빌드(Windows) 트러블슈팅
+
+Windows에서 아래와 같은 오류가 발생하면(`rustc.exe ... is not applicable to ...`) Rust toolchain/component 불일치 상태일 가능성이 큽니다.
+
+```powershell
+cargo build
+error: the 'rustc.exe' binary ... is not applicable to the 'stable-x86_64-pc-windows-msvc' toolchain
+```
+
+아래 순서로 복구합니다.
+
+```powershell
+rustup show
+rustup toolchain uninstall stable-x86_64-pc-windows-msvc
+rustup toolchain install stable-x86_64-pc-windows-msvc --profile default
+rustup default stable-x86_64-pc-windows-msvc
+rustup component add rustc cargo clippy rustfmt --toolchain stable-x86_64-pc-windows-msvc
+rustup update
+cargo build
+```
+
+여전히 동일하면 `where rustc`, `rustup which rustc`로 PATH 오염(다중 rustc) 여부를 확인하고, Visual Studio Build Tools의 `MSVC v143` + `Windows 10/11 SDK` 설치 상태를 점검합니다.
+
 ## Rust 전환 가이드
 
 - 단일 진입점/엔진 경계 기준은 `docs/architecture.md`를 먼저 확인합니다.


### PR DESCRIPTION
### Motivation

- A Windows `cargo build` failure (`rustc.exe ... is not applicable to the 'stable-x86_64-pc-windows-msvc' toolchain`) was reported and needs canonical recovery documentation.
- The troubleshooting flow belongs in both user-facing and agent-standard docs to reduce repeated triage steps.

### Description

- Added a `Rust 빌드(Windows) 트러블슈팅` section to `README.md` containing the canonical `rustup` toolchain reinstall/repair sequence and fallback checks (`where rustc`, `rustup which rustc`, VS Build Tools checks).
- Added the same troubleshooting guidance as `## 8) Rust 빌드(Windows) 트러블슈팅` to `AGENTS.md` so agent operations align with user docs.  
- Updated summary docs `CLAUDE.md` and `GEMINI.md` with a pointer to the new guidance (`README.md`/`AGENTS.md`).
- Changes committed with message `docs: add Windows rust toolchain troubleshooting guide` and a PR created titled `docs: add Windows rust toolchain troubleshooting guidance`.

### Testing

- Performed RTD pre-change checks (Steps 1–4) and post-change checks (Steps 5–18) and recorded all as `PASS` with rationale for each step.  
- Ran a markdown link/path existence check script that validated local links referenced in the modified files and returned `OK`.  
- Verified repository working tree status with `git status --short` before and after the commit and observed a clean state after commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e80d87040832eb60f97cf193326a7)