### PR TITLE
feat(frontend): add Tauri-aware backend endpoint resolution

### DIFF
--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -5,6 +5,11 @@
 
 ## 작업 로그
 
+- 2026-02-25: WBS 9.0 Tauri 전환 선행 작업(프론트 런타임 엔드포인트 정책) 착수
+  - `frontend/src/runtime/endpoints.ts` 추가: 웹/데스크톱 런타임을 구분해 API base/WS URL 결정 로직을 단일화
+  - `VITE_API_BASE_URL`, `VITE_WS_URL` 우선 정책 유지 + `VITE_TAURI_BACKEND_URL` 단일 오버라이드 경로 추가
+  - Tauri 프로토콜(`tauri:`, `asset:`)에서는 기본 `127.0.0.1:8080` fallback을 사용해 PoC 단계의 연결 불확실성을 축소
+
 - 2026-02-24: WBS 7.4 운영 점검 정례화 정책 수립 완료 (7.4.1~7.4.4)
   - `docs/operations/weekly-drill/README.md`: 주기/역할/시나리오별 PASS/FAIL 기준/완료 조건 고정
   - `docs/operations/weekly-drill/_template.md`: 주간 점검 결과 템플릿 생성
@@ -185,6 +190,7 @@
 ## 9.0 Tauri 데스크톱 앱 전환
 
 - [ ] 9.1 Tauri 런처/런타임 PoC
+  - [x] 프론트 런타임 엔드포인트 해석 로직 단일화(`resolveApiBaseUrl`, `resolveWebSocketUrl`) 및 Tauri fallback 추가
   - [ ] Rust 오케스트레이터(`recordroute-orchestrator`)와 Swagger(`swagger_server`)를 Tauri lifecycle에서 기동/종료할 수 있는지 검증
   - [ ] Windows/Linux/macOS에서 기본 포트 충돌 없이 동시 기동되는지 검증
   - [ ] 앱 로그 수집/표시/회수 경로를 기존 run 스크립트(`scripts/run_*`)와 정렬
@@ -234,4 +240,3 @@
    - [ ] 설치 단계 빌드 반영: 프론트 설치/빌드 + Rust 빌드
    - [ ] 실행 스크립트 2종 작성: Windows `.bat`, macOS/Linux `.sh`
    - [ ] 실행 단계 반영: Rust 서버 + 프론트 서버 실행
-

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -16,13 +16,13 @@ import type {
   DestructiveApiAuth,
   SegmentItem,
 } from './types';
+import { resolveApiBaseUrl } from '../runtime/endpoints';
 
 interface ApiRequestOptions extends RequestInit {
   skipJson?: boolean;
 }
 
-
-const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined)?.trim().replace(/\/$/, '') ?? '';
+const API_BASE_URL = resolveApiBaseUrl();
 
 function withApiBase(path: string): string {
   if (!path.startsWith('/')) return path;

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
   readonly VITE_WS_URL?: string;
+  readonly VITE_TAURI_BACKEND_URL?: string;
 }
 
 interface ImportMeta {

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useCallback } from 'react';
+import { resolveWebSocketUrl } from '../runtime/endpoints';
 
 type MessageHandler = (
   taskId: string,
@@ -14,11 +15,7 @@ export function useWebSocket(onMessage: MessageHandler) {
 
   const connect = useCallback(() => {
     try {
-      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-      const configuredWsUrl = (import.meta.env.VITE_WS_URL as string | undefined)?.trim();
-      const wsUrl = configuredWsUrl && configuredWsUrl.length > 0
-        ? configuredWsUrl
-        : `${protocol}//${window.location.host}/ws`;
+      const wsUrl = resolveWebSocketUrl();
       const ws = new WebSocket(wsUrl);
 
       ws.onopen = () => {

--- a/frontend/src/runtime/endpoints.ts
+++ b/frontend/src/runtime/endpoints.ts
@@ -1,0 +1,42 @@
+const DEFAULT_TAURI_BACKEND_HTTP = 'http://127.0.0.1:8080';
+const DEFAULT_TAURI_BACKEND_WS = 'ws://127.0.0.1:8080/ws';
+
+function trimUrl(value: string | undefined): string {
+  return value?.trim() ?? '';
+}
+
+function isTauriRuntime(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.location.protocol === 'tauri:' || window.location.protocol === 'asset:';
+}
+
+export function resolveApiBaseUrl(): string {
+  const tauriBackendUrl = trimUrl(import.meta.env.VITE_TAURI_BACKEND_URL).replace(/\/$/, '');
+  const configuredApiBase = trimUrl(import.meta.env.VITE_API_BASE_URL).replace(/\/$/, '');
+  if (configuredApiBase.length > 0) return configuredApiBase;
+  if (tauriBackendUrl.length > 0) return tauriBackendUrl;
+  if (isTauriRuntime()) return DEFAULT_TAURI_BACKEND_HTTP;
+  return '';
+}
+
+export function resolveWebSocketUrl(): string {
+  const configuredWsUrl = trimUrl(import.meta.env.VITE_WS_URL);
+  if (configuredWsUrl.length > 0) return configuredWsUrl;
+
+  const tauriBackendUrl = trimUrl(import.meta.env.VITE_TAURI_BACKEND_URL).replace(/\/$/, '');
+  if (tauriBackendUrl.length > 0) {
+    const asWsProtocol = tauriBackendUrl.replace(/^http:/, 'ws:').replace(/^https:/, 'wss:');
+    return `${asWsProtocol}/ws`;
+  }
+
+  if (isTauriRuntime()) {
+    return DEFAULT_TAURI_BACKEND_WS;
+  }
+
+  if (typeof window === 'undefined') {
+    return DEFAULT_TAURI_BACKEND_WS;
+  }
+
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${protocol}//${window.location.host}/ws`;
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, low-risk PoC to make the frontend robust when launched inside a Tauri desktop runtime by removing fragile `window.location` assumptions for API/WS endpoints.  
- Preserve existing environment override behavior while adding a single, explicit Tauri override option to reduce connection ambiguity during early desktop migration.  
- Avoid packaging/permission scope changes and keep the change limited to URL resolution and documentation/WBS bookkeeping.  

### Description
- Added `frontend/src/runtime/endpoints.ts` which exports `resolveApiBaseUrl()` and `resolveWebSocketUrl()` and implements Tauri runtime detection (`tauri:`/`asset:`) with localhost fallback to `127.0.0.1:8080`.  
- Updated `frontend/src/api/client.ts` to use `resolveApiBaseUrl()` as the source of truth for `API_BASE_URL`.  
- Updated `frontend/src/hooks/useWebSocket.ts` to use `resolveWebSocketUrl()` instead of constructing the URL from `window.location`.  
- Added `VITE_TAURI_BACKEND_URL` to `frontend/src/env.d.ts` as an optional single backend override, and recorded the kickoff in `TODO/TODO.md` under WBS 9.1.  

### Testing
- Built the frontend production bundle with `cd frontend && npm run build`, which completed successfully and produced the `dist/` artifacts.  
- Verified repository state with `git status --short` and confirmed the intended files were staged/committed.  
- Performed a smoke review of the modified frontend files to ensure env precedence is `VITE_API_BASE_URL` / `VITE_WS_URL` then `VITE_TAURI_BACKEND_URL` then Tauri fallback, and found no regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ed3493300832ea74d5358e46342b5)