### PR TITLE
Document Tauri transition status and add Vite dev proxies for API and WebSocket

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,8 @@ WBS 1.2 재완료 게이트(구현 라우트/파라미터 ↔ OpenAPI path/param
 
 ## 4) 변경 우선순위
 
+- 2026-02-25 Tauri 전환 상태 점검 기준: WBS 9.0은 착수 단계이며, 완료로 간주 가능한 범위는 프론트 런타임 endpoint 해석 로직(`resolveApiBaseUrl`, `resolveWebSocketUrl`)과 `VITE_TAURI_BACKEND_URL` fallback까지로 제한합니다. lifecycle/보안/패키징/릴리스 게이트는 미완료로 유지합니다.
+
 
 정렬 상태 메모:
 - WBS `1.2 OpenAPI/API 계약 재정렬`은 구현 라우트/파라미터와 OpenAPI path/param 1:1 매핑 재검증 완료(수동/자동/증적 기록 충족) 상태로 관리합니다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@
 
 ## 현재 프로젝트 전제
 
+- 2026-02-25 Tauri 전환 상태 점검: WBS 9.0은 착수 단계이며, 완료 범위는 프론트 endpoint 해석 로직 단일화(`resolveApiBaseUrl`, `resolveWebSocketUrl`) + `VITE_TAURI_BACKEND_URL` fallback까지입니다. lifecycle/보안/패키징/릴리스 게이트는 미완료입니다.
+
 - Windows `cargo build`에서 `rustc.exe ... not applicable` 오류가 나면 rustup toolchain/component 재설치(`stable-x86_64-pc-windows-msvc`) 절차를 우선 적용합니다(상세 커맨드는 `README.md`/`AGENTS.md` 참조).
 - WBS `1.2 OpenAPI/API 계약 재정렬`은 구현 라우트/파라미터와 OpenAPI 1:1 매핑 재검증(수동/자동/증적 기록) 완료로 재완료(READY) 상태입니다.
 - 재완료 게이트는 `docs/openapi-wbs-1.2-recompletion-gate.md` 단일 체크리스트를 기준으로 판정하며, 현재 7개 항목 충족 상태를 유지합니다.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -7,6 +7,8 @@
 
 ## 핵심 컨텍스트
 
+- 2026-02-25 Tauri 전환 상태 점검: WBS 9.0은 착수 단계이며, 완료 범위는 프론트 endpoint 해석 로직 단일화(`resolveApiBaseUrl`, `resolveWebSocketUrl`) + `VITE_TAURI_BACKEND_URL` fallback까지입니다. lifecycle/보안/패키징/릴리스 게이트는 미완료입니다.
+
 - Windows `cargo build`에서 `rustc.exe ... not applicable` 오류가 나면 rustup toolchain/component 재설치(`stable-x86_64-pc-windows-msvc`) 절차를 우선 적용합니다(상세 커맨드는 `README.md`/`AGENTS.md` 참조).
 - WBS `1.2 OpenAPI/API 계약 재정렬`은 구현 라우트/파라미터와 OpenAPI 1:1 매핑 재검증(수동/자동/증적 기록) 완료로 재완료(READY) 상태입니다.
 - 재완료 게이트는 `docs/openapi-wbs-1.2-recompletion-gate.md` 단일 체크리스트를 기준으로 판정하며, 현재 7개 항목 충족 상태를 유지합니다.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Rust 백엔드는 `/healthz`/`/readyz`/`/metrics` + `POST /jobs`/`GET /jobs/{job
 
 ## 운영 안정화 메모 (Phase B-2)
 
+- 2026-02-25 Tauri 전환 상태 점검: **WBS 9.0은 착수 단계**이며, 현재 완료된 범위는 프론트 런타임 엔드포인트 해석(`resolveApiBaseUrl`, `resolveWebSocketUrl`)과 `VITE_TAURI_BACKEND_URL` fallback 정책까지입니다. Tauri lifecycle 기동/종료, 보안 allowlist/CSP, 패키징/릴리스 게이트는 미완료 상태로 유지합니다.
+
 - WBS `1.2 OpenAPI/API 계약 재정렬`은 구현 라우트/파라미터와 OpenAPI path/param 1:1 매핑 재검증(수동/자동/증적 기록)을 완료해 **재완료(READY)** 상태입니다.
 - 주간 운영 점검(`docs/operations/weekly-drill/README.md`)에 계약 드리프트 점검(구현↔OpenAPI path/param 대조 + CI 정적 점검 결과 첨부) 항목이 추가되었습니다.
 - CI 정적 계약 점검은 필수 path/param 존재 여부뿐 아니라 경로 파라미터 명칭(`job_id`) 일치 여부까지 검증해야 하며, 점검 로그에는 스크립트 산출물 링크/경로를 첨부해야 합니다.

--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -5,6 +5,11 @@
 
 ## 작업 로그
 
+- 2026-02-25: Tauri 전환 상태 점검(현황 재검증)
+  - 완료 확인: `frontend/src/runtime/endpoints.ts`에서 `resolveApiBaseUrl`/`resolveWebSocketUrl` + `VITE_TAURI_BACKEND_URL` fallback이 구현되어 9.1 선행 과제 1건만 완료
+  - 미완료 확인: Tauri lifecycle 기동/종료(오케스트레이터/Swagger), 다중 OS 포트 충돌 검증, 로그 수집 경로 정렬은 미착수
+  - 보안/배포 미완료: `tauri.conf.json` allowlist/CSP 최소권한 정책, 패키징/릴리스 smoke gate(9.3~9.5) 미확정
+
 - 2026-02-25: WBS 9.0 Tauri 전환 선행 작업(프론트 런타임 엔드포인트 정책) 착수
   - `frontend/src/runtime/endpoints.ts` 추가: 웹/데스크톱 런타임을 구분해 API base/WS URL 결정 로직을 단일화
   - `VITE_API_BASE_URL`, `VITE_WS_URL` 우선 정책 유지 + `VITE_TAURI_BACKEND_URL` 단일 오버라이드 경로 추가

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -39,6 +39,12 @@ export default defineConfig({
       '/file_search': 'http://localhost:8080',
       '/cache': 'http://localhost:8080',
       '/incremental_embedding': 'http://localhost:8080',
+      '/segments': 'http://localhost:8080',
+      '/api': 'http://localhost:8080',
+      '/ws': {
+        target: 'ws://localhost:8080',
+        ws: true,
+      },
     },
   },
 });


### PR DESCRIPTION
### Motivation

- Record project status updates to reflect the current Tauri transition (WBS 9.0) scope and completed front-end endpoint resolution work.  
- Keep summary files and TODOs synchronized with the authoritative `AGENTS.md` guidance about Tauri progress and runtime endpoint behavior.  
- Enable local development to reach the backend and WebSocket endpoints used by the front-end runtime during the Tauri migration PoC.

### Description

- Updated `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `README.md`, and `TODO/TODO.md` to add a 2026-02-25 Tauri transition status note clarifying that WBS 9.0 is in the initiation stage and that the completed scope is endpoint resolution (`resolveApiBaseUrl`, `resolveWebSocketUrl`) with `VITE_TAURI_BACKEND_URL` fallback.  
- Harmonized doc synchronization and operational notes to reflect the Tauri-related scope, outstanding lifecycle/security/packaging gates, and verification pointers.  
- Added development proxy entries in `frontend/vite.config.ts` for `'/segments'` and `'/api'` to forward to `http://localhost:8080`.  
- Added a WebSocket proxy configuration for `'/ws'` in `frontend/vite.config.ts` with `target: 'ws://localhost:8080'` and `ws: true` to support local WS connections.

### Testing

- Ran the front-end build with `cd frontend && npm run build` to validate the Vite config changes and the build completed successfully.  
- Per documentation-only change rules, performed a Markdown structure/links check on updated files and found no structural problems.  
- No Rust source changes were included, so `cargo test`/`cargo clippy` were not applicable for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ed48af534832e8bedb3dd419b4a0a)