### PR TITLE
Add CLI options, model pull policy, and preflight checks to install/run scripts on Unix and Windows

### DIFF
--- a/scripts/install_unix.sh
+++ b/scripts/install_unix.sh
@@ -4,7 +4,54 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+CHECK_ONLY=false
+MODEL_POLICY="prompt" # prompt|pull|cancel
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/install_unix.sh [options]
+
+Options:
+  --check      Validate env/model/prerequisites only (no install/build)
+  --yes-pull   Auto-pull missing models (non-interactive friendly)
+  --no-pull    Fail immediately when model is missing
+  -h, --help   Show help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      CHECK_ONLY=true
+      ;;
+    --yes-pull)
+      MODEL_POLICY="pull"
+      ;;
+    --no-pull)
+      MODEL_POLICY="cancel"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[ERROR] Unknown option: $1"
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
 echo "[RecordRoute] Unix install started."
+
+require_command() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "[ERROR] Required command not found: $cmd"
+    return 1
+  fi
+}
 
 require_env() {
   local var_name="$1"
@@ -40,16 +87,26 @@ pull_model() {
     --local-dir-use-symlinks False
 }
 
+resolve_model_path() {
+  local model_var="$1"
+  local model_dir="$2"
+  local model_value="${!model_var}"
+
+  if [[ -f "$model_value" ]]; then
+    printf '%s' "$model_value"
+    return 0
+  fi
+
+  printf '%s' "$ROOT_DIR/$model_dir/$model_value"
+}
+
 ensure_model() {
   local model_var="$1"
   local model_dir="$2"
   local model_repo_var="$3"
   local model_value="${!model_var}"
-  local model_path="$model_value"
-
-  if [[ ! -f "$model_path" ]]; then
-    model_path="$ROOT_DIR/$model_dir/$model_value"
-  fi
+  local model_path
+  model_path="$(resolve_model_path "$model_var" "$model_dir")"
 
   if [[ -f "$model_path" ]]; then
     echo "[OK] ${model_var} -> ${model_path}"
@@ -59,15 +116,26 @@ ensure_model() {
   echo "[WARN] Model not found for ${model_var} (${model_value})."
   echo "       Expected path: ${model_path}"
 
-  local choice
-  read -r -p "Choose action: [C]ancel install / [P]ull model: " choice
-  if [[ "${choice^^}" == "P" ]]; then
-    pull_model "$model_var" "$model_dir" "$model_repo_var" || return 1
-
-    model_path="$model_value"
-    if [[ ! -f "$model_path" ]]; then
-      model_path="$ROOT_DIR/$model_dir/$model_value"
+  local action="$MODEL_POLICY"
+  if [[ "$action" == "prompt" ]]; then
+    if [[ -t 0 ]]; then
+      local choice
+      read -r -p "Choose action: [C]ancel install / [P]ull model: " choice
+      if [[ "${choice^^}" == "P" ]]; then
+        action="pull"
+      else
+        action="cancel"
+      fi
+    else
+      action="cancel"
+      echo "[WARN] Non-interactive shell detected; defaulting to cancel."
+      echo "       Use --yes-pull to allow automatic model pull."
     fi
+  fi
+
+  if [[ "$action" == "pull" ]]; then
+    pull_model "$model_var" "$model_dir" "$model_repo_var" || return 1
+    model_path="$(resolve_model_path "$model_var" "$model_dir")"
     if [[ -f "$model_path" ]]; then
       echo "[OK] Pulled ${model_var} -> ${model_path}"
       return 0
@@ -81,6 +149,9 @@ ensure_model() {
   return 1
 }
 
+require_command npm
+require_command cargo
+
 require_env RECORDROUTE_DEFAULT_STT_MODEL "STT default model"
 require_env RECORDROUTE_DEFAULT_SUMMARIZE_MODEL "Summarize default model"
 require_env RECORDROUTE_DEFAULT_EMBED_MODEL "Embed default model"
@@ -88,6 +159,11 @@ require_env RECORDROUTE_DEFAULT_EMBED_MODEL "Embed default model"
 ensure_model RECORDROUTE_DEFAULT_STT_MODEL "models/stt" RECORDROUTE_STT_MODEL_REPO
 ensure_model RECORDROUTE_DEFAULT_SUMMARIZE_MODEL "models/text" RECORDROUTE_SUMMARIZE_MODEL_REPO
 ensure_model RECORDROUTE_DEFAULT_EMBED_MODEL "models/embed" RECORDROUTE_EMBED_MODEL_REPO
+
+if [[ "$CHECK_ONLY" == true ]]; then
+  echo "[RecordRoute] Check mode passed (no install/build executed)."
+  exit 0
+fi
 
 echo "[1/3] Installing frontend dependencies..."
 npm --prefix frontend install

--- a/scripts/install_windows.bat
+++ b/scripts/install_windows.bat
@@ -4,7 +4,50 @@ setlocal EnableExtensions EnableDelayedExpansion
 set "ROOT_DIR=%~dp0.."
 pushd "%ROOT_DIR%" >nul
 
+set "CHECK_ONLY=0"
+set "MODEL_POLICY=prompt"
+
+:parse_args
+if "%~1"=="" goto :args_done
+if /I "%~1"=="--check" (
+    set "CHECK_ONLY=1"
+    shift
+    goto :parse_args
+)
+if /I "%~1"=="--yes-pull" (
+    set "MODEL_POLICY=pull"
+    shift
+    goto :parse_args
+)
+if /I "%~1"=="--no-pull" (
+    set "MODEL_POLICY=cancel"
+    shift
+    goto :parse_args
+)
+if /I "%~1"=="-h" goto :help
+if /I "%~1"=="--help" goto :help
+
+echo [ERROR] Unknown option: %~1
+goto :help
+
+:help
+echo Usage: scripts\install_windows.bat [options]
+echo.
+echo Options:
+echo   --check      Validate env/model/prerequisites only (no install/build)
+echo   --yes-pull   Auto-pull missing models
+echo   --no-pull    Fail immediately when model is missing
+echo   -h, --help   Show help
+popd >nul
+exit /b 1
+
+:args_done
 echo [RecordRoute] Windows install started.
+
+call :require_command npm
+if errorlevel 1 goto :fail
+call :require_command cargo
+if errorlevel 1 goto :fail
 
 call :require_env RECORDROUTE_DEFAULT_STT_MODEL "STT default model"
 if errorlevel 1 goto :fail
@@ -19,6 +62,12 @@ call :ensure_model RECORDROUTE_DEFAULT_SUMMARIZE_MODEL "models\text" RECORDROUTE
 if errorlevel 1 goto :fail
 call :ensure_model RECORDROUTE_DEFAULT_EMBED_MODEL "models\embed" RECORDROUTE_EMBED_MODEL_REPO
 if errorlevel 1 goto :fail
+
+if "%CHECK_ONLY%"=="1" (
+  echo [RecordRoute] Check mode passed ^(no install/build executed^).
+  popd >nul
+  exit /b 0
+)
 
 echo [1/3] Installing frontend dependencies...
 call npm --prefix frontend install
@@ -36,12 +85,21 @@ echo [RecordRoute] Install completed successfully.
 popd >nul
 exit /b 0
 
+:require_command
+set "CMD=%~1"
+where %CMD% >nul 2>nul
+if errorlevel 1 (
+    echo [ERROR] Required command not found: %CMD%
+    exit /b 1
+)
+exit /b 0
+
 :require_env
 set "VAR_NAME=%~1"
 set "LABEL=%~2"
 call set "VAR_VALUE=%%%VAR_NAME%%%"
 if not defined VAR_VALUE (
-    echo [ERROR] %LABEL% env (%VAR_NAME%) is not set.
+    echo [ERROR] %LABEL% env ^(%VAR_NAME%^) is not set.
     exit /b 1
 )
 exit /b 0
@@ -58,24 +116,35 @@ if not exist "!MODEL_PATH!" (
 )
 
 if exist "!MODEL_PATH!" (
-    echo [OK] !MODEL_VAR! -> !MODEL_PATH!
+    echo [OK] !MODEL_VAR! -^> !MODEL_PATH!
     exit /b 0
 )
 
-echo [WARN] Model not found for !MODEL_VAR! (!MODEL_VALUE!).
+echo [WARN] Model not found for !MODEL_VAR! ^(!MODEL_VALUE!^).
 echo        Expected path: !MODEL_PATH!
-set /p CHOICE="Choose action: [C]ancel install / [P]ull model: "
 
-if /I "!CHOICE!"=="P" (
+set "ACTION=%MODEL_POLICY%"
+if /I "!ACTION!"=="prompt" (
+    set /p CHOICE="Choose action: [C]ancel install / [P]ull model: "
+    if /I "!CHOICE!"=="P" (
+        set "ACTION=pull"
+    ) else (
+        set "ACTION=cancel"
+    )
+)
+
+if /I "!ACTION!"=="pull" (
     call :pull_model "%MODEL_VAR%" "%MODEL_DIR%" "%MODEL_REPO_VAR%"
     if errorlevel 1 exit /b 1
+
     call set "MODEL_VALUE=%%%MODEL_VAR%%%"
     set "MODEL_PATH=!MODEL_VALUE!"
     if not exist "!MODEL_PATH!" set "MODEL_PATH=%ROOT_DIR%\%MODEL_DIR%\!MODEL_VALUE!"
     if exist "!MODEL_PATH!" (
-        echo [OK] Pulled !MODEL_VAR! -> !MODEL_PATH!
+        echo [OK] Pulled !MODEL_VAR! -^> !MODEL_PATH!
         exit /b 0
     )
+
     echo [ERROR] Model still missing after pull attempt: !MODEL_PATH!
     exit /b 1
 )
@@ -92,7 +161,7 @@ call set "MODEL_REPO=%%%MODEL_REPO_VAR%%%"
 
 if not defined MODEL_REPO (
     echo [ERROR] Pull requested but %MODEL_REPO_VAR% is not set.
-    echo        Set repo id (e.g. org/repo) and rerun.
+    echo        Set repo id ^(e.g. org/repo^) and rerun.
     exit /b 1
 )
 

--- a/scripts/run_unix.sh
+++ b/scripts/run_unix.sh
@@ -1,25 +1,84 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUN_MODE="dev" # dev|release
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/run_unix.sh [options]
+
+Options:
+  --release    Run compiled release binary instead of cargo run
+  -h, --help   Show help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --release)
+      RUN_MODE="release"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[ERROR] Unknown option: $1"
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+require_command() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "[ERROR] Required command not found: $cmd"
+    return 1
+  fi
+}
+
+require_command npm
+if [[ "$RUN_MODE" == "dev" ]]; then
+  require_command cargo
+fi
 
 cleanup() {
   local exit_code=$?
+  trap - INT TERM EXIT
   if [[ -n "${API_PID:-}" ]] && kill -0 "$API_PID" >/dev/null 2>&1; then
     kill "$API_PID" >/dev/null 2>&1 || true
   fi
   if [[ -n "${FRONTEND_PID:-}" ]] && kill -0 "$FRONTEND_PID" >/dev/null 2>&1; then
     kill "$FRONTEND_PID" >/dev/null 2>&1 || true
   fi
+  wait >/dev/null 2>&1 || true
   exit "$exit_code"
 }
 trap cleanup INT TERM EXIT
 
-echo "[RecordRoute] Starting Rust API server..."
-(
-  cd "$ROOT_DIR"
-  cargo run --bin recordroute-orchestrator
-) &
+if [[ "$RUN_MODE" == "release" ]]; then
+  RELEASE_BIN="$ROOT_DIR/target/release/recordroute-orchestrator"
+  if [[ ! -x "$RELEASE_BIN" ]]; then
+    echo "[ERROR] Release binary not found: $RELEASE_BIN"
+    echo "        Run scripts/install_unix.sh first or cargo build --release."
+    exit 1
+  fi
+
+  echo "[RecordRoute] Starting Rust API server (release binary)..."
+  (
+    cd "$ROOT_DIR"
+    "$RELEASE_BIN"
+  ) &
+else
+  echo "[RecordRoute] Starting Rust API server (cargo run)..."
+  (
+    cd "$ROOT_DIR"
+    cargo run --bin recordroute-orchestrator
+  ) &
+fi
 API_PID=$!
 
 echo "[RecordRoute] Starting frontend dev server..."
@@ -34,4 +93,3 @@ echo "[RecordRoute] Frontend PID: $FRONTEND_PID"
 echo "[RecordRoute] Press Ctrl+C to stop both services."
 
 wait -n "$API_PID" "$FRONTEND_PID"
-

--- a/scripts/run_windows.bat
+++ b/scripts/run_windows.bat
@@ -1,11 +1,51 @@
-﻿@echo off
+@echo off
 setlocal EnableExtensions
 
 set "ROOT_DIR=%~dp0.."
+set "RUN_MODE=dev"
+
+:parse_args
+if "%~1"=="" goto :args_done
+if /I "%~1"=="--release" (
+    set "RUN_MODE=release"
+    shift
+    goto :parse_args
+)
+if /I "%~1"=="-h" goto :help
+if /I "%~1"=="--help" goto :help
+
+echo [ERROR] Unknown option: %~1
+goto :help
+
+:help
+echo Usage: scripts\run_windows.bat [options]
+echo.
+echo Options:
+echo   --release    Run compiled release binary instead of cargo run
+echo   -h, --help   Show help
+exit /b 1
+
+:args_done
 pushd "%ROOT_DIR%" >nul
 
+call :require_command npm
+if errorlevel 1 goto :fail
+if /I "%RUN_MODE%"=="dev" (
+    call :require_command cargo
+    if errorlevel 1 goto :fail
+)
+
 echo [RecordRoute] Starting Rust API server...
-start "RecordRoute Rust API" cmd /k "cd /d %ROOT_DIR% && cargo run --bin recordroute-orchestrator"
+if /I "%RUN_MODE%"=="release" (
+    if not exist "%ROOT_DIR%\target\release\recordroute-orchestrator.exe" (
+        echo [ERROR] Release binary not found: %ROOT_DIR%\target\release\recordroute-orchestrator.exe
+        echo        Run scripts\install_windows.bat first or cargo build --release.
+        goto :fail
+    )
+    start "RecordRoute Rust API" cmd /k "cd /d %ROOT_DIR% && target\release\recordroute-orchestrator.exe"
+) else (
+    start "RecordRoute Rust API" cmd /k "cd /d %ROOT_DIR% && cargo run --bin recordroute-orchestrator"
+)
 if errorlevel 1 goto :fail
 
 echo [RecordRoute] Starting frontend dev server...
@@ -16,8 +56,16 @@ echo [RecordRoute] Servers started in separate windows.
 popd >nul
 exit /b 0
 
+:require_command
+set "CMD=%~1"
+where %CMD% >nul 2>nul
+if errorlevel 1 (
+    echo [ERROR] Required command not found: %CMD%
+    exit /b 1
+)
+exit /b 0
+
 :fail
 echo [RecordRoute] Failed to start one or more services.
 popd >nul
 exit /b 1
-


### PR DESCRIPTION
### Motivation
- Provide non-interactive and flexible install/run workflows by adding CLI flags for check-only mode, model pull behavior, and run mode selection, and add explicit preflight checks for required commands.
- Make model resolution and pulling more robust by resolving absolute/relative paths and supporting automatic pulls via `huggingface-cli` when configured.
- Allow running the compiled release binary for the orchestrator to enable production-style runs without requiring `cargo run`.

### Description
- Add CLI parsing to `scripts/install_unix.sh`/`scripts/install_windows.bat` for `--check`, `--yes-pull`, and `--no-pull`, introduce `MODEL_POLICY`, and implement `require_command`, `resolve_model_path`, and enhanced `ensure_model` behavior that supports non-interactive defaults and auto-pull via `pull_model`.
- Add CLI parsing to `scripts/run_unix.sh`/`scripts/run_windows.bat` for `--release`, introduce `RUN_MODE`, add `require_command` checks, support launching the compiled release binary (`target/release/recordroute-orchestrator`) or falling back to `cargo run`, and improve cleanup/wait handling in Unix run script.
- Wire up early exit for check-only mode in install scripts and update Windows echo/escaping and logging to be consistent with Unix changes.

### Testing
- Ran automated CI-style validations invoking `scripts/install_unix.sh --check` which verified environment and model preflight checks and completed successfully.
- Executed automated invocations of `scripts/run_unix.sh --release` and Windows batch argument parsing in CI runners to validate `--release` and model-policy branches, and these completed successfully.
- CI continues to exercise existing build steps (`npm --prefix frontend install`, `npm run build`, `cargo build --release`) and those steps passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ee52078a4832e9a87ac7bf9e932e3)