### PR TITLE
Make Vite dev proxy target configurable and normalize URLs (support WS conversion)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,31 @@ import react from '@vitejs/plugin-react-swc';
 import tailwindcss from '@tailwindcss/vite';
 import path from 'path';
 
+function normalizeHttpTarget(url: string): string {
+  return url.replace(/\/$/, '');
+}
+
+function resolveDevProxyHttpTarget(): string {
+  const fromApiBase = process.env.VITE_API_BASE_URL?.trim();
+  if (fromApiBase && fromApiBase.length > 0) {
+    return normalizeHttpTarget(fromApiBase);
+  }
+
+  const fromTauriBackend = process.env.VITE_TAURI_BACKEND_URL?.trim();
+  if (fromTauriBackend && fromTauriBackend.length > 0) {
+    return normalizeHttpTarget(fromTauriBackend);
+  }
+
+  return 'http://localhost:8080';
+}
+
+function resolveDevProxyWsTarget(httpTarget: string): string {
+  return httpTarget.replace(/^http:/, 'ws:').replace(/^https:/, 'wss:');
+}
+
+const devProxyHttpTarget = resolveDevProxyHttpTarget();
+const devProxyWsTarget = resolveDevProxyWsTarget(devProxyHttpTarget);
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
@@ -17,32 +42,32 @@ export default defineConfig({
   server: {
     port: 3000,
     proxy: {
-      '/upload': 'http://localhost:8080',
-      '/process': 'http://localhost:8080',
-      '/history': 'http://localhost:8080',
-      '/tasks': 'http://localhost:8080',
-      '/search': 'http://localhost:8080',
-      '/similar': 'http://localhost:8080',
-      '/delete': 'http://localhost:8080',
-      '/cancel': 'http://localhost:8080',
-      '/models': 'http://localhost:8080',
-      '/download': 'http://localhost:8080',
-      '/shutdown': 'http://localhost:8080',
-      '/reset': 'http://localhost:8080',
-      '/update_filename': 'http://localhost:8080',
-      '/update_stt_text': 'http://localhost:8080',
-      '/check_existing_stt': 'http://localhost:8080',
-      '/reset_summary_embedding': 'http://localhost:8080',
-      '/reset_all_tasks': 'http://localhost:8080',
-      '/delete_records': 'http://localhost:8080',
-      '/progress': 'http://localhost:8080',
-      '/file_search': 'http://localhost:8080',
-      '/cache': 'http://localhost:8080',
-      '/incremental_embedding': 'http://localhost:8080',
-      '/segments': 'http://localhost:8080',
-      '/api': 'http://localhost:8080',
+      '/upload': devProxyHttpTarget,
+      '/process': devProxyHttpTarget,
+      '/history': devProxyHttpTarget,
+      '/tasks': devProxyHttpTarget,
+      '/search': devProxyHttpTarget,
+      '/similar': devProxyHttpTarget,
+      '/delete': devProxyHttpTarget,
+      '/cancel': devProxyHttpTarget,
+      '/models': devProxyHttpTarget,
+      '/download': devProxyHttpTarget,
+      '/shutdown': devProxyHttpTarget,
+      '/reset': devProxyHttpTarget,
+      '/update_filename': devProxyHttpTarget,
+      '/update_stt_text': devProxyHttpTarget,
+      '/check_existing_stt': devProxyHttpTarget,
+      '/reset_summary_embedding': devProxyHttpTarget,
+      '/reset_all_tasks': devProxyHttpTarget,
+      '/delete_records': devProxyHttpTarget,
+      '/progress': devProxyHttpTarget,
+      '/file_search': devProxyHttpTarget,
+      '/cache': devProxyHttpTarget,
+      '/incremental_embedding': devProxyHttpTarget,
+      '/segments': devProxyHttpTarget,
+      '/api': devProxyHttpTarget,
       '/ws': {
-        target: 'ws://localhost:8080',
+        target: devProxyWsTarget,
         ws: true,
       },
     },


### PR DESCRIPTION
### Motivation
- Make the Vite dev server proxy target configurable via environment variables instead of hardcoding `http://localhost:8080` so the frontend can target alternate backends (e.g. `VITE_API_BASE_URL` or `VITE_TAURI_BACKEND_URL`).
- Ensure proxy target URLs are normalized (remove trailing slash) and derive a matching websocket target so `/ws` proxy works correctly with `ws://`/`wss://` schemes.

### Description
- Added `normalizeHttpTarget`, `resolveDevProxyHttpTarget`, and `resolveDevProxyWsTarget` helper functions to compute the HTTP and WS proxy targets from `VITE_API_BASE_URL` or `VITE_TAURI_BACKEND_URL` with a `http://localhost:8080` fallback.
- Introduced `devProxyHttpTarget` and `devProxyWsTarget` and replaced the previous hardcoded `http://localhost:8080` strings in the `server.proxy` map with these variables.
- Kept existing proxy path mappings unchanged other than switching to the resolved target variables and updated `/ws` to use the websocket-converted target.

### Testing
- Ran TypeScript type check with `tsc --noEmit`, which completed successfully.  
- Performed a production build with `vite build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fe24451cc832e9c03bf6dd85d76f3)