### PR TITLE
docs: add WBS 9.4 Tauri install/deploy unified flow and sync deployment docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@
 
 > 2026-04-01 업데이트: WBS 9.3 기준 문서 `docs/tauri-packaging-security-baseline.md`를 추가하고 TODO/README/CLAUDE/GEMINI와 상태를 동기화.
 
+> 2026-02-27 업데이트: WBS 9.4 기준 문서 `docs/tauri-install-deploy-unified-flow.md`를 추가하고 TODO/README/CLAUDE/GEMINI와 상태를 동기화.
+
 ## 1) 프로젝트 구조 인식
 
 - `frontend/`: 운영 중인 프론트엔드 코드
@@ -31,6 +33,7 @@
 세부 정책은 `docs/rust-cpp-backend-rewrite-plan.md`를 단일 기준으로 따르며, 아키텍처 기준선은 `docs/architecture.md`를 참조합니다.
 배포/자산 세부 운영 기준은 `docs/deployment-asset-policy.md`를 참조합니다.
 Tauri 패키징/보안 기준은 `docs/tauri-packaging-security-baseline.md`를 참조합니다.
+Tauri 설치/배포 통합 플로우 기준은 `docs/tauri-install-deploy-unified-flow.md`를 참조합니다.
 `main.rs` 분할/모듈화 실무 기준은 `docs/main-rs-modularization-guide.md`를 참조합니다.
 최종 사용자 조작 절차는 `docs/user-operation-manual.md`를 참조합니다.
 운영 점검 정례화 정책은 `docs/operations/weekly-drill/README.md`를 참조합니다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,8 @@
 
 - 2026-04-01: WBS 9.3 패키징/보안 기준 문서(`docs/tauri-packaging-security-baseline.md`) 추가 및 TODO 9.3 완료 상태 반영.
 
+- 2026-02-27: WBS 9.4 설치/배포 통합 기준 문서(`docs/tauri-install-deploy-unified-flow.md`) 추가 및 TODO 9.4 완료 상태 반영.
+
 ## 우선 확인 순서
 
 1. `AGENTS.md`
@@ -26,6 +28,8 @@
 - 2026-02-25 Tauri 전환 상태 점검: WBS 9.0은 착수 단계이며, 완료 범위는 프론트 endpoint 해석 로직 단일화(`resolveApiBaseUrl`, `resolveWebSocketUrl`) + `VITE_TAURI_BACKEND_URL` fallback까지입니다. lifecycle/보안/패키징/릴리스 게이트는 미완료입니다.
 
 - 2026-03-30 이후 9.1 보강: `src/bin/tauri_lifecycle_probe.rs` + `.github/workflows/tauri-lifecycle-poc.yml`로 오케스트레이터/Swagger lifecycle 기동·종료, 포트 충돌, 3OS 매트릭스 검증, 로그 아티팩트 수집 경로(`artifacts/tauri-lifecycle/<ts-os-pid>/`)를 자동화했습니다.
+- WBS 9.4 설치/배포 자동화 통합: 설치 게이트(`scripts/install_*.sh|bat --check`)를 Tauri installer/업데이트 진입 조건으로 고정하고, 빌드 산출물 포함/제외 정책을 README/배포 문서와 동기화했습니다.
+
 
 - Windows `cargo build`에서 `rustc.exe ... not applicable` 오류가 나면 rustup toolchain/component 재설치(`stable-x86_64-pc-windows-msvc`) 절차를 우선 적용합니다(상세 커맨드는 `README.md`/`AGENTS.md` 참조).
 - WBS `1.2 OpenAPI/API 계약 재정렬`은 구현 라우트/파라미터와 OpenAPI 1:1 매핑 재검증(수동/자동/증적 기록) 완료로 재완료(READY) 상태입니다.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -9,11 +9,15 @@
 
 - 2026-04-01: WBS 9.3 패키징/보안 기준 문서(`docs/tauri-packaging-security-baseline.md`)를 추가하고 TODO 9.3 완료 상태를 동기화했습니다.
 
+- 2026-02-27: WBS 9.4 설치/배포 통합 기준 문서(`docs/tauri-install-deploy-unified-flow.md`)를 추가하고 TODO 9.4 완료 상태를 동기화했습니다.
+
 ## 핵심 컨텍스트
 
 - 2026-02-25 Tauri 전환 상태 점검: WBS 9.0은 착수 단계이며, 완료 범위는 프론트 endpoint 해석 로직 단일화(`resolveApiBaseUrl`, `resolveWebSocketUrl`) + `VITE_TAURI_BACKEND_URL` fallback까지입니다. lifecycle/보안/패키징/릴리스 게이트는 미완료입니다.
 
 - 2026-03-30 이후 9.1 보강: `src/bin/tauri_lifecycle_probe.rs` + `.github/workflows/tauri-lifecycle-poc.yml`로 오케스트레이터/Swagger lifecycle 기동·종료, 포트 충돌, 3OS 매트릭스 검증, 로그 아티팩트 수집 경로(`artifacts/tauri-lifecycle/<ts-os-pid>/`)를 자동화했습니다.
+- WBS 9.4 설치/배포 자동화 통합: 설치 게이트(`scripts/install_*.sh|bat --check`)를 Tauri installer/업데이트 진입 조건으로 고정하고, 빌드 산출물 포함/제외 정책을 README/배포 문서와 동기화했습니다.
+
 
 - Windows `cargo build`에서 `rustc.exe ... not applicable` 오류가 나면 rustup toolchain/component 재설치(`stable-x86_64-pc-windows-msvc`) 절차를 우선 적용합니다(상세 커맨드는 `README.md`/`AGENTS.md` 참조).
 - WBS `1.2 OpenAPI/API 계약 재정렬`은 구현 라우트/파라미터와 OpenAPI 1:1 매핑 재검증(수동/자동/증적 기록) 완료로 재완료(READY) 상태입니다.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Rust 백엔드는 `/healthz`/`/readyz`/`/metrics` + `POST /jobs`/`GET /jobs/{job
 
 - 2026-04-01 업데이트: WBS 9.3 패키징/보안 기준선 문서(`docs/tauri-packaging-security-baseline.md`)를 추가하고, allowlist/CSP 최소 권한·환경변수/비밀 관리·`engine_manager` 정합 종료/재시작 정책을 확정했습니다.
 
+- 2026-02-27 업데이트: WBS 9.4 설치/배포 자동화 통합 문서(`docs/tauri-install-deploy-unified-flow.md`)를 추가하고, 설치 게이트(`scripts/install_*.sh|bat --check`) 기반 Tauri installer/업데이트 연동 및 빌드 산출물 포함/제외 정책을 동기화했습니다.
+
 ## 운영 안정화 메모 (Phase B-2)
 
 - 2026-02-25 Tauri 전환 상태 점검: **WBS 9.0은 착수 단계**이며, 현재 완료된 범위는 프론트 런타임 엔드포인트 해석(`resolveApiBaseUrl`, `resolveWebSocketUrl`)과 `VITE_TAURI_BACKEND_URL` fallback 정책까지입니다. Tauri lifecycle 기동/종료, 보안 allowlist/CSP, 패키징/릴리스 게이트는 미완료 상태로 유지합니다.
@@ -52,6 +54,14 @@ Rust 백엔드는 `/healthz`/`/readyz`/`/metrics` + `POST /jobs`/`GET /jobs/{job
 - 2026-02-24: OpenAPI(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)에 `GET /metrics` 경로와 metrics 응답 스키마(readiness: ready/degraded, 엔진별 queue/running, rejections)를 명시했습니다.
 - 2026-02-24: `POST /jobs` query parameter에 `audio_ms`를 추가하고, 미지정 시 기본 timeout 사용 + min/max clamp 동작을 문서화했습니다.
 - 2026-02-24: 에러 코드 enum을 현재 구현 코드(`queue_full`, `engine_full`, `engine_dispatcher_closed` 포함)와 일치하도록 재검증/동기화했습니다.
+
+
+## WBS 9.4 설치/배포 통합 기준
+
+- 단일 사용자 플로우는 `사전 점검(--check) → 빌드/패키징 → 실행 검증 → 업데이트` 순서를 따릅니다.
+- Unix/macOS/Linux는 `scripts/install_unix.sh --check`, Windows는 `scripts\install_windows.bat --check`를 설치/업데이트 진입 게이트로 사용합니다.
+- 빌드 산출물 정책: 배포 후보(`frontend/dist/**`, `target/release/recordroute-orchestrator[.exe]`)와 제외 대상(`target/**` 중간 산출물, 패키징 임시 파일)을 분리합니다.
+- 상세 기준은 `docs/tauri-install-deploy-unified-flow.md`, `docs/deployment-asset-policy.md`를 참조합니다.
 
 ## RTD(배포준비) 점검 규칙
 

--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -11,6 +11,11 @@
   - `RECORDROUTE_*` 환경변수 주입 경로, 모델 경로, 비밀 마스킹/비노출 전략 확정
   - `engine_manager` 기반 종료(`shutdown`)/장애 재시작/업그레이드 재진입 상태 정합성(`Booting/Ready/Degraded/Stopping/Stopped`) 명시
 
+
+- 2026-02-27: WBS 9.4 설치/배포 자동화 통합 완료
+  - `docs/tauri-install-deploy-unified-flow.md`: 설치 게이트(`--check`)→빌드/패키징→실행 검증→업데이트 단일 사용자 플로우 고정
+  - `README.md`, `docs/deployment-asset-policy.md`에 빌드 산출물 포함/제외(`frontend/dist`, `target/release`, `target/**` 중간 산출물 제외) 정책 동기화
+  - Tauri installer/업데이트 진입 전 `scripts/install_*.sh|bat --check` PASS를 필수 조건으로 명시
 - 2026-02-25: WBS 8.0 설치/실행 자동화 스크립트 완료(READY)
   - `scripts/install_windows.bat`, `scripts/install_unix.sh`: 기본 모델 env 검증, 누락 시 중단, 모델 파일 확인/미존재 시 중단 또는 pull 선택지 제공
   - 설치 단계 자동화: 프론트 의존성 설치 + 프론트 빌드 + Rust release 빌드 통합
@@ -230,10 +235,10 @@
   - [x] 종료 처리(`shutdown`), 장애 재시작, 업그레이드 재진입 경로를 `engine_manager` 상태와 정합성 있게 정의
   - 기준 문서: `docs/tauri-packaging-security-baseline.md`
 
-- [ ] 9.4 설치/배포 자동화 통합
-  - [ ] 기존 설치/실행 스크립트(`scripts/install_*.sh`, `scripts/run_*.sh`)와 Tauri 배포 플로우를 1개 사용자 플로우로 통합
-  - [ ] 빌드 산출물 포함/제외(`target`, 앱 패키지 아티팩트) 정책을 `README/배포 문서`와 동기화
-  - [ ] 설치 게이트(필수 모델/의존성 확인)와 Tauri installer/업데이트 흐름 연동
+- [x] 9.4 설치/배포 자동화 통합
+  - [x] 기존 설치/실행 스크립트(`scripts/install_*.sh`, `scripts/run_*.sh`)와 Tauri 배포 플로우를 1개 사용자 플로우로 통합
+  - [x] 빌드 산출물 포함/제외(`target`, 앱 패키지 아티팩트) 정책을 `README/배포 문서`와 동기화
+  - [x] 설치 게이트(필수 모델/의존성 확인)와 Tauri installer/업데이트 흐름 연동
 
 - [ ] 9.5 릴리스 품질 게이트
   - [ ] `check_contract_drift`를 CI에서 유지하고 Tauri smoke test(기동/기능 최소 경로) 결합

--- a/docs/deployment-asset-policy.md
+++ b/docs/deployment-asset-policy.md
@@ -84,8 +84,18 @@
 - [x] 저장소에 `/vendor`, `/models`, 빌드 산출물 정책이 `.gitignore`와 함께 반영되었는가?
 - [x] 모델 원본 없이 manifest만으로 버전/체크섬 추적이 가능한가?
 
-## 6) 관련 문서
+## 6) Tauri 설치/배포 통합 정책 (WBS 9.4)
+
+- 단일 사용자 플로우(사전 점검→빌드/패키징→실행 검증→업데이트)는
+  `docs/tauri-install-deploy-unified-flow.md`를 기준으로 유지합니다.
+- 설치 게이트는 `scripts/install_*.sh|bat --check` 결과를 단일 기준으로 사용합니다.
+- `--check` 실패(필수 모델/의존성 누락) 상태에서는 Tauri installer/업데이트 단계를 시작하지 않습니다.
+- 배포 후보에는 `frontend/dist/**`, `target/release/recordroute-orchestrator[.exe]`, 운영 문서를 포함합니다.
+- 배포/버전관리 공통 제외 대상은 `target/**` 중간 산출물, 패키징 임시 산출물, 모델 raw 데이터입니다.
+
+## 7) 관련 문서
 
 - 기준 계획: `docs/rust-cpp-backend-rewrite-plan.md`
 - 아키텍처 기준선: `docs/architecture.md`
 - 실행 단위 추적: `TODO/TODO.md`
+- Tauri 통합 가이드: `docs/tauri-install-deploy-unified-flow.md`

--- a/docs/tauri-install-deploy-unified-flow.md
+++ b/docs/tauri-install-deploy-unified-flow.md
@@ -1,0 +1,75 @@
+# Tauri 설치/배포 자동화 통합 가이드 (WBS 9.4)
+
+## 1) 목적과 범위
+
+이 문서는 기존 설치/실행 스크립트(`scripts/install_*.sh|bat`, `scripts/run_*.sh|bat`)와
+Tauri 배포 흐름을 **단일 사용자 플로우**로 연결하기 위한 운영 기준입니다.
+
+- 목표: 사용자가 플랫폼별로 동일한 단계(`사전 점검 → 빌드/패키징 → 실행/검증 → 업데이트`)를 따른다.
+- 비범위: Tauri 릴리스 채널/자동 업데이트 서버 구현 자체(9.5 게이트에서 최종 품질 판정).
+
+## 2) 단일 사용자 플로우
+
+### Step A. 사전 점검(설치 게이트)
+
+1. Unix/macOS/Linux
+   - `scripts/install_unix.sh --check`
+2. Windows
+   - `scripts\install_windows.bat --check`
+
+검증 항목:
+- 필수 도구(`npm`, `cargo`) 존재
+- 필수 모델 env(`RECORDROUTE_DEFAULT_STT_MODEL`, `RECORDROUTE_DEFAULT_SUMMARIZE_MODEL`, `RECORDROUTE_DEFAULT_EMBED_MODEL`) 설정
+- 모델 파일 존재(또는 pull 가능성 확인)
+
+> 정책: `--check`가 실패하면 Tauri installer/업데이트 단계로 진행하지 않습니다.
+
+### Step B. 빌드/패키징
+
+1. 기존 Rust+Frontend 빌드
+   - `scripts/install_unix.sh` 또는 `scripts\install_windows.bat`
+2. Tauri 패키징 기준 적용
+   - 권한/보안/환경변수 정책은 `docs/tauri-packaging-security-baseline.md`를 따릅니다.
+   - 런타임 endpoint 계약은 `docs/tauri-frontend-backend-contract-alignment.md`를 따릅니다.
+
+### Step C. 실행/검증
+
+- 개발/운영 점검 실행
+  - Unix/macOS/Linux: `scripts/run_unix.sh [--release]`
+  - Windows: `scripts\run_windows.bat [--release]`
+- Tauri lifecycle 회귀는 `src/bin/tauri_lifecycle_probe.rs` + `.github/workflows/tauri-lifecycle-poc.yml`로 검증합니다.
+
+### Step D. 업데이트(업그레이드 재진입)
+
+- 업데이트 전 동일한 사전 점검(`--check`)을 재실행합니다.
+- 모델/의존성 누락이 감지되면 업데이트를 중단하고 복구 후 재시도합니다.
+- 종료/재시작 정합성은 `engine_manager` 상태 전이(`Booting/Ready/Degraded/Stopping/Stopped`) 기준을 유지합니다.
+
+## 3) 빌드 산출물 포함/제외 정책
+
+### 포함(배포 후보)
+
+- Frontend 정적 빌드 산출물(`frontend/dist/**`)
+- Rust 릴리스 바이너리(`target/release/recordroute-orchestrator[.exe]`)
+- Swagger 분리 실행 스크립트(`scripts/run-swagger.sh`)
+- 운영/배포 문서(`README.md`, `docs/deployment-asset-policy.md`, 본 문서)
+
+### 제외(버전관리/배포 패키지 공통)
+
+- Rust 중간 산출물 및 캐시(`target/**` 전반)
+- 앱 패키징 임시 산출물(로컬 빌드 디렉터리, 서명 전 임시 파일)
+- 모델 raw 데이터(`models/**`), 단 `manifest.yml|yaml|json`은 추적
+
+세부 ignore 원칙은 `.gitignore` 및 `docs/deployment-asset-policy.md`를 기준으로 유지합니다.
+
+## 4) 운영 체크리스트(9.4 완료 기준)
+
+- [x] 기존 설치/실행 스크립트와 Tauri 배포 흐름의 단계 연결(사전 점검→빌드→검증→업데이트) 문서화
+- [x] 빌드 산출물 포함/제외 정책을 README/배포 문서와 동기화
+- [x] 설치 게이트(`--check`)를 Tauri installer/업데이트 진입 조건으로 고정
+
+## 5) 리스크/롤백
+
+- 리스크: 모델 env 누락 또는 모델 파일 부재 시 설치/업데이트 실패.
+- 완화: `--check` 선실행, 누락 시 pull 또는 중단을 명시적으로 선택.
+- 롤백: 릴리스 바이너리/프론트 산출물 교체 배포 시 이전 버전 아티팩트로 즉시 복원.


### PR DESCRIPTION
### Motivation
- Provide a single, documented user flow that integrates the existing install/run scripts with the Tauri packaging/installer path (WBS 9.4) and make the install gate deterministic for installer/update flows.
- Align deployment artifact include/exclude policies across README and deployment guidance so packaging and version-control rules are consistent.
- Update project tracking artifacts (TODO/AGENTS/CLAUDE/GEMINI) so WBS 9.4 is reflected in repo-wide status and references.

### Description
- Added `docs/tauri-install-deploy-unified-flow.md` describing the unified user flow (`--check` preflight → build/packaging → run/verification → update), build artifact inclusion/exclusion, and rollback guidance.
- Updated `docs/deployment-asset-policy.md` to include a Tauri install/deploy integration section that fixes the install gate to `scripts/install_*.sh|bat --check` and synchronizes included/excluded artifact lists.
- Updated top-level context documents (`README.md`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) to reference the new WBS 9.4 guide and reflect the change in the project status narrative.
- Marked WBS 9.4 as complete in `TODO/TODO.md` and added the WBS 9.4 checklist items as completed.
- No runtime code changes; this is a documentation-only change set and a repo metadata sync.

### Testing
- Ran a relative-link verification script across updated markdown files (`python` check) which passed (`OK`).
- Ran targeted grep/rg checks for the new WBS 9.4 keywords and file references which returned expected matches (passed).
- Verified repository status (`git status --short`) was clean after committing the documentation changes and created the commit `b590963` and a PR titled "docs: complete WBS 9.4 install/deploy automation integration" (commit and PR creation succeeded).
- RTD Steps 1–4 (planning/review/minimization) were executed and marked PASS for this doc-focused change, and RTD Steps 5–18 validations (document consistency, link checks, rollback guidance present) were completed for a READY state.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a104116934832e8d7e30ede14a1944)