### PR TITLE
docs(todo): emphasize WBS 1.2 1:1 mapping checklist text

### DIFF
--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -132,7 +132,7 @@
 - [ ] 1.2 OpenAPI/API 계약을 Rust 목표 엔드포인트 기준으로 재정렬 (재검토)
   - 재완료 조건:
     - [ ] `docs/openapi.yaml`, `docs/swagger/openapi.yaml`에 Rust 목표 엔드포인트가 동일하게 반영되어 있다.
-    - [ ] 구현 라우트/파라미터와 OpenAPI path/query/path-param의 **1:1 매핑 확인** 체크를 통과했다.
+    - [ ] 구현 라우트/파라미터와 OpenAPI path/query/path-param의 ***1:1 매핑 확인*** 체크를 통과했다.
     - [ ] 계약 드리프트 점검 항목(주간 점검/CI 정적 점검)이 활성 상태다.
     - [ ] 문서 경로 파라미터 명칭 통일(`GET /jobs/{job_id}`) 체크포인트를 통과했다.
 


### PR DESCRIPTION
### Motivation
- Clarify the WBS 1.2 re-completion checklist item formatting in `TODO/TODO.md` by applying the requested emphasis style to the "1:1 매핑 확인" phrase for consistency and visibility.

### Description
- Updated `TODO/TODO.md` to change `**1:1 매핑 확인**` to `***1:1 매핑 확인***` (single-line documentation edit) and committed the change with message `docs(todo): emphasize WBS 1.2 1:1 mapping checklist text`.

### Testing
- Verified the edit with `git diff -- TODO/TODO.md` and `git status --short` and committed the change; verification commands completed successfully and the PR was created.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a10811fe60832e8d9264edc7afd1e9)