### PR TITLE
feat(tauri): integrate contract-drift into tauri lifecycle CI and add runtime smoke checks + recovery guide

### DIFF
--- a/.github/workflows/tauri-lifecycle-poc.yml
+++ b/.github/workflows/tauri-lifecycle-poc.yml
@@ -7,7 +7,34 @@ on:
       - main
 
 jobs:
+  contract-drift:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run OpenAPI contract drift check
+        run: |
+          python scripts/check_contract_drift.py \
+            --spec docs/openapi.yaml \
+            --spec docs/swagger/openapi.yaml \
+            --report artifacts/contracts/${{ github.run_id }}/contract-drift-report.json
+
+      - name: Upload contract drift artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: contract-drift-report
+          path: artifacts/contracts/${{ github.run_id }}/contract-drift-report.json
+          if-no-files-found: error
+
   tauri-lifecycle-probe:
+    needs: contract-drift
     strategy:
       fail-fast: false
       matrix:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@
 
 > 2026-04-01 업데이트: WBS 9.3 기준 문서 `docs/tauri-packaging-security-baseline.md`를 추가하고 TODO/README/CLAUDE/GEMINI와 상태를 동기화.
 
+> 2026-02-28 업데이트: WBS 9.5 1차 구현(단일 CI 워크플로 결합 + WBS 1.2 엔드포인트 런타임 회귀 감시 + 1인 실패 복구 가이드 `docs/tauri-single-operator-recovery-guide.md`) 상태를 TODO/README/CLAUDE/GEMINI와 동기화.
+
 > 2026-02-27 업데이트: WBS 9.4 기준 문서 `docs/tauri-install-deploy-unified-flow.md`를 추가하고 TODO/README/CLAUDE/GEMINI와 상태를 동기화.
 
 > 2026-02-27 업데이트: WBS 9.5 릴리스 품질 게이트의 세부 체크포인트(CI 결합·1.2 재완료 회귀 감시·1인 복구 가이드 범위)를 TODO/README/CLAUDE/GEMINI와 동기화.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@
 - 2026-02-27: WBS 9.4 설치/배포 통합 기준 문서(`docs/tauri-install-deploy-unified-flow.md`) 추가 및 TODO 9.4 완료 상태 반영.
 
 - 2026-02-27: WBS 9.5 릴리스 품질 게이트 세부 체크포인트(CI 결합/`job_id` 회귀 감시/1인 복구 가이드 범위) 동기화.
+- 2026-02-28: WBS 9.5 1차 구현 반영(단일 CI 워크플로 결합 + WBS 1.2 엔드포인트 런타임 회귀 감시 + 1인 실패 복구 가이드 `docs/tauri-single-operator-recovery-guide.md`).
 
 ## 우선 확인 순서
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -14,6 +14,7 @@
 - 2026-02-27: WBS 9.4 설치/배포 통합 기준 문서(`docs/tauri-install-deploy-unified-flow.md`)를 추가하고 TODO 9.4 완료 상태를 동기화했습니다.
 
 - 2026-02-27: WBS 9.5 릴리스 품질 게이트 세부 체크포인트(CI 결합/`job_id` 회귀 감시/1인 복구 가이드 범위) 동기화.
+- 2026-02-28: WBS 9.5 1차 구현 반영(단일 CI 워크플로 결합 + WBS 1.2 엔드포인트 런타임 회귀 감시 + 1인 실패 복구 가이드 `docs/tauri-single-operator-recovery-guide.md`).
 
 ## 핵심 컨텍스트
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Rust 백엔드는 `/healthz`/`/readyz`/`/metrics` + `POST /jobs`/`GET /jobs/{job
 
 - 2026-02-27 업데이트: WBS 9.5 릴리스 품질 게이트의 세부 체크포인트(CI 결합, WBS 1.2 `job_id` 회귀 감시, 1인 복구 가이드 범위)를 TODO와 동기화했습니다.
 
+- 2026-02-28 업데이트: WBS 9.5 1차 구현으로 단일 CI 워크플로(`.github/workflows/tauri-lifecycle-poc.yml`)에 contract drift + Tauri lifecycle smoke gate를 결합했고, 1인 실패 복구 가이드(`docs/tauri-single-operator-recovery-guide.md`)를 추가했습니다.
+
 ## 운영 안정화 메모 (Phase B-2)
 
 - 2026-02-25 Tauri 전환 상태 점검: **WBS 9.0은 착수 단계**이며, 현재 완료된 범위는 프론트 런타임 엔드포인트 해석(`resolveApiBaseUrl`, `resolveWebSocketUrl`)과 `VITE_TAURI_BACKEND_URL` fallback 정책까지입니다. Tauri lifecycle 기동/종료, 보안 allowlist/CSP, 패키징/릴리스 게이트는 미완료 상태로 유지합니다.

--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -5,6 +5,11 @@
 
 ## 작업 로그
 
+- 2026-02-28: WBS 9.5 릴리스 품질 게이트 1차 구현
+  - `.github/workflows/tauri-lifecycle-poc.yml`에 `contract-drift` 잡을 추가하고 `tauri-lifecycle-probe` 잡이 이를 `needs`로 참조하도록 구성해 단일 워크플로에서 계약 점검 + Tauri smoke gate를 결합
+  - `src/bin/tauri_lifecycle_probe.rs`에 런타임 회귀 감시를 확장해 `/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}`를 1회 스모크로 검증
+  - 1인 실행 실패 복구 절차 문서 `docs/tauri-single-operator-recovery-guide.md`를 추가해 `scripts/install_*.sh|bat --check`, `scripts/run_*.sh|bat` 재실행, `artifacts/tauri-lifecycle/<ts-os-pid>/` 로그 확인 경로를 고정
+
 
 - 2026-02-28: WBS 9.1/스캐폴딩 상태 정합성 재정렬
   - 9.1 하위 항목 4건 완료 상태를 재확인하고 9.1 헤더 체크 상태를 `[x]`로 정렬
@@ -252,12 +257,12 @@
   - [x] 빌드 산출물 포함/제외(`target`, 앱 패키지 아티팩트) 정책을 `README/배포 문서`와 동기화
   - [x] 설치 게이트(필수 모델/의존성 확인)와 Tauri installer/업데이트 흐름 연동
 
-- [ ] 9.5 릴리스 품질 게이트
-  - [ ] `check_contract_drift`를 CI 필수 게이트로 유지하고 Tauri smoke test(기동 + 최소 기능 경로)와 단일 워크플로에서 결합
+- [x] 9.5 릴리스 품질 게이트
+  - [x] `check_contract_drift`를 CI 필수 게이트로 유지하고 Tauri smoke test(기동 + 최소 기능 경로)와 단일 워크플로에서 결합
     - 산출물 기준: CI 로그에 contract drift 결과 + Tauri smoke 결과 + 아티팩트 경로(`artifacts/tauri-lifecycle/<ts-os-pid>/`)가 함께 남아야 함
-  - [ ] WBS 1.2 재완료 규칙(`implement path/param 1:1`, path-param `job_id`)과 Tauri 런치 플로우 회귀 감시를 연동
+  - [x] WBS 1.2 재완료 규칙(`implement path/param 1:1`, path-param `job_id`)과 Tauri 런치 플로우 회귀 감시를 연동
     - 회귀 감시 기준 엔드포인트: `/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}`
-  - [ ] 1인 실행 스크립트 실패 시 사용자 복구 가이드(`fallback`, `재실행`, `로그 조회`)를 문서화
+  - [x] 1인 실행 스크립트 실패 시 사용자 복구 가이드(`fallback`, `재실행`, `로그 조회`)를 문서화
     - 문서 포함 범위: `scripts/install_*.sh|bat --check` 실패 대응, `scripts/run_*.sh|bat` 재실행 순서, 로그 수집/확인 위치
 ## 다음 우선순위 (실행 단위)
 
@@ -296,10 +301,10 @@
   - 현재 상태(2026-02-28): 세 기준 모두 미충족(미도입). 9.5/실사용 전환 전 별도 스캐폴딩 도입 태스크로 관리 필요.
 
 ### [P1] 실사용 기능/운영 정합성
-- [ ] 기존 9.5 항목의 실제 구현 반영 정렬(단일 게이트 통합 + 드리프트-런타임 연동 + 실패복구 가이드)
-  - [ ] 9.5.1 계약 점검(`check_contract_drift`)과 Tauri 라이프사이클 스모크(`tauri_lifecycle_probe`)를 단일 CI 워크플로/게이트로 통합
-  - [ ] WBS 1.2 기준 엔드포인트(`/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}`)를 Tauri 실행/표시 플로우와 1:1로 연결
-  - [ ] 스모크/런타임 실패 시 사용자 복구 절차(재시작, 환경 재설치, 로그 수집, 재검증) TODO 문서 항목으로 분리
+- [x] 기존 9.5 항목의 실제 구현 반영 정렬(단일 게이트 통합 + 드리프트-런타임 연동 + 실패복구 가이드)
+  - [x] 9.5.1 계약 점검(`check_contract_drift`)과 Tauri 라이프사이클 스모크(`tauri_lifecycle_probe`)를 단일 CI 워크플로/게이트로 통합
+  - [x] WBS 1.2 기준 엔드포인트(`/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}`)를 Tauri 실행/표시 플로우와 1:1로 연결
+  - [x] 스모크/런타임 실패 시 사용자 복구 절차(재시작, 환경 재설치, 로그 수집, 재검증) TODO 문서 항목으로 분리
 - [ ] 코드 완성도 강화(P0): `src/audio.rs` 정규화 유틸의 미사용 경고 제거 (`normalize_to_wav_mono_16k` 사용 경로 확정)
 - [ ] 코드 완성도 강화(P0): 업로드/전처리 파이프라인에서 `collect_mono_f32_from_f32`, `linear_resample`, `build_wav_mono_i16`를 실제 호출하도록 연결
 - [ ] 코드 완성도 강화(P1): `JobStatus::Canceled` 및 `mark_canceled`를 실제 취소 API/취소 이벤트(클라이언트 요청, 타임아웃 전환)와 연동

--- a/docs/tauri-single-operator-recovery-guide.md
+++ b/docs/tauri-single-operator-recovery-guide.md
@@ -1,0 +1,89 @@
+# Tauri 단일 실행자 실패 복구 가이드 (WBS 9.5)
+
+이 문서는 단일 실행자(1인) 기준으로 설치/실행 실패를 빠르게 복구하기 위한 표준 절차를 정의합니다.
+
+## 1) 설치 게이트 실패 복구 (`scripts/install_*.sh|bat --check`)
+
+### 1-1. Unix(macOS/Linux)
+
+```bash
+scripts/install_unix.sh --check
+```
+
+실패 시 순서:
+1. 누락된 필수 명령(`npm`, `cargo`) 설치
+2. 기본 모델 env 재설정
+   - `RECORDROUTE_DEFAULT_STT_MODEL`
+   - `RECORDROUTE_DEFAULT_SUMMARIZE_MODEL`
+   - `RECORDROUTE_DEFAULT_EMBED_MODEL`
+3. 모델 파일 경로 확인(상대 경로는 `<repo>/models/...` 기준)
+4. 모델이 없으면 `--yes-pull`로 재시도
+
+```bash
+scripts/install_unix.sh --yes-pull
+```
+
+### 1-2. Windows
+
+```bat
+scripts\install_windows.bat --check
+```
+
+실패 시 순서:
+1. 누락된 필수 명령(`npm`, `cargo`) 설치
+2. 기본 모델 env 재설정
+   - `RECORDROUTE_DEFAULT_STT_MODEL`
+   - `RECORDROUTE_DEFAULT_SUMMARIZE_MODEL`
+   - `RECORDROUTE_DEFAULT_EMBED_MODEL`
+3. 모델 파일 경로 확인(상대 경로는 `<repo>\models\...` 기준)
+4. 모델이 없으면 `--yes-pull`로 재시도
+
+```bat
+scripts\install_windows.bat --yes-pull
+```
+
+## 2) 실행 실패 복구 (`scripts/run_*.sh|bat`)
+
+### 2-1. Unix(macOS/Linux)
+
+기본 실행:
+
+```bash
+scripts/run_unix.sh
+```
+
+복구 순서:
+1. 실행 중 프로세스 정리 후 재실행
+2. release 바이너리 누락 시 `scripts/install_unix.sh` 또는 `cargo build --release` 후 `--release`로 재실행
+
+```bash
+scripts/run_unix.sh --release
+```
+
+### 2-2. Windows
+
+기본 실행:
+
+```bat
+scripts\run_windows.bat
+```
+
+복구 순서:
+1. 기존 Rust API/프론트 창 종료
+2. release 바이너리 누락 시 `scripts\install_windows.bat` 또는 `cargo build --release` 수행
+3. `--release` 모드로 재실행
+
+```bat
+scripts\run_windows.bat --release
+```
+
+## 3) 로그 조회/수집 위치
+
+- Tauri lifecycle smoke 로그: `artifacts/tauri-lifecycle/<ts-os-pid>/`
+  - `orchestrator.log`
+  - `swagger.log`
+  - `orchestrator-port-conflict.log`
+  - `summary.json`
+- 계약 점검 리포트: `artifacts/contracts/<run-id>/contract-drift-report.json`
+
+CI 실패 분석 시에는 위 경로의 산출물을 우선 확인하고, 재실행 전 env/포트 점유/모델 파일 상태를 점검합니다.

--- a/src/bin/tauri_lifecycle_probe.rs
+++ b/src/bin/tauri_lifecycle_probe.rs
@@ -18,6 +18,7 @@ struct ProbeSummary {
     swagger_port: u16,
     port_conflict_check: &'static str,
     startup_check: &'static str,
+    runtime_contract_check: &'static str,
     shutdown_check: &'static str,
     artifacts_dir: String,
 }
@@ -78,8 +79,17 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     )?;
 
     wait_http_ok(api_port, "/healthz", Duration::from_secs(20))?;
+    wait_http_ok(api_port, "/readyz", Duration::from_secs(20))?;
+    wait_http_ok(api_port, "/metrics", Duration::from_secs(20))?;
     wait_http_ok(swagger_port, "/", Duration::from_secs(20))?;
     wait_http_ok(swagger_port, "/openapi.yaml", Duration::from_secs(20))?;
+
+    let created_job_id = post_job_and_extract_job_id(api_port)?;
+    wait_http_ok(
+        api_port,
+        &format!("/jobs/{created_job_id}"),
+        Duration::from_secs(20),
+    )?;
 
     terminate_child(&mut swagger)?;
     terminate_child(&mut orchestrator)?;
@@ -93,6 +103,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         swagger_port,
         port_conflict_check: "pass",
         startup_check: "pass",
+        runtime_contract_check: "pass",
         shutdown_check: "pass",
         artifacts_dir: artifacts_dir.display().to_string(),
     };
@@ -220,13 +231,45 @@ fn wait_http_ok(
 }
 
 fn get_http_status(port: u16, path: &str) -> Result<u16, Box<dyn std::error::Error + Send + Sync>> {
+    let (status, _) = send_http_request(port, "GET", path)?;
+    Ok(status)
+}
+
+fn post_job_and_extract_job_id(
+    port: u16,
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    let (status, body) = send_http_request(port, "POST", "/jobs?engine=stt")?;
+    if status != 202 {
+        return Err(format!("expected 202 from POST /jobs?engine=stt, got {status}").into());
+    }
+
+    let parsed: serde_json::Value = serde_json::from_str(&body)
+        .map_err(|e| format!("failed to parse POST /jobs response body as json: {e}"))?;
+
+    let job_id = parsed
+        .get("job_id")
+        .and_then(|v| v.as_str())
+        .ok_or("missing string field `job_id` in POST /jobs response")?;
+
+    if job_id.is_empty() {
+        return Err("POST /jobs returned empty job_id".into());
+    }
+
+    Ok(job_id.to_string())
+}
+
+fn send_http_request(
+    port: u16,
+    method: &str,
+    path: &str,
+) -> Result<(u16, String), Box<dyn std::error::Error + Send + Sync>> {
     let mut stream = TcpStream::connect(("127.0.0.1", port))?;
     stream.set_read_timeout(Some(Duration::from_secs(2)))?;
     stream.set_write_timeout(Some(Duration::from_secs(2)))?;
 
     let req = format!(
-        "GET {} HTTP/1.1\r\nHost: 127.0.0.1:{}\r\nConnection: close\r\n\r\n",
-        path, port
+        "{} {} HTTP/1.1\r\nHost: 127.0.0.1:{}\r\nConnection: close\r\n\r\n",
+        method, path, port
     );
     stream.write_all(req.as_bytes())?;
 
@@ -239,7 +282,14 @@ fn get_http_status(port: u16, path: &str) -> Result<u16, Box<dyn std::error::Err
         .nth(1)
         .ok_or("invalid http status line")?
         .parse::<u16>()?;
-    Ok(code)
+
+    let body = raw
+        .split_once("\r\n\r\n")
+        .map(|(_, b)| b)
+        .unwrap_or_default()
+        .to_string();
+
+    Ok((code, body))
 }
 
 fn terminate_child(child: &mut Child) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {


### PR DESCRIPTION
### Motivation
- Close WBS 9.5 gaps by combining static OpenAPI contract checks with the Tauri lifecycle smoke probe so CI verifies both contract and runtime behavior in one workflow. 
- Improve runtime regression coverage for WBS 1.2 core endpoints (`/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}`) by expanding the lifecycle probe to exercise job creation and retrieval.
- Provide single-operator recovery steps so install/run CI or local smoke failures have a clear, repeatable recovery path.

### Description
- CI/workflow: added a `contract-drift` job to `.github/workflows/tauri-lifecycle-poc.yml` and made the existing `tauri-lifecycle-probe` job depend on it so contract checks run before the lifecycle smoke probe.
- Probe enhancements: extended `src/bin/tauri_lifecycle_probe.rs` to verify `/readyz` and `/metrics`, to `POST /jobs?engine=stt` and parse the returned `job_id`, and to `GET /jobs/{job_id}`; factored HTTP send/receive into `send_http_request`, and added `runtime_contract_check` to the probe summary JSON.
- Docs / meta: added `docs/tauri-single-operator-recovery-guide.md` with install/run failure recovery and artifact lookup instructions, and synchronized top-level docs (`README.md`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) and `TODO/TODO.md` to reflect the WBS 9.5 1st-phase implementation.

### Testing
- Ran `cargo fmt --all` (completed).
- Static contract checks: ran `cargo run --quiet --bin check_contract_drift` and `python3 scripts/check_contract_drift.py --spec docs/openapi.yaml --spec docs/swagger/openapi.yaml --report artifacts/contracts/local/contract-drift-report.json`; both produced PASS and wrote the report.
- Runtime smoke: ran `cargo run --quiet --bin tauri_lifecycle_probe` which produced an artifacts summary indicating the probe completed successfully.
- Unit & integration: ran `cargo test` which completed with all tests passing (no failures).
- Linting: ran `cargo clippy --all-targets --all-features`; the check completed (warnings reported but the run finished successfully).

All automated checks above completed successfully in this environment. The change set is limited to CI workflow, the probe binary, TODO/docs updates and the new recovery guide; no frontend runtime changes were made.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2509c99e0832ea3ce98651ab406bb)