### PR TITLE
docs(todo): mark WBS 1.2 route/parameter 1:1 mapping check complete

### DIFF
--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -20,7 +20,8 @@
 - [x] 1.2 OpenAPI/API 계약을 Rust 목표 엔드포인트 기준으로 재정렬 (재검토)
   - 재완료 조건:
     - [x] `docs/openapi.yaml`, `docs/swagger/openapi.yaml`에 Rust 목표 엔드포인트가 동일하게 반영되어 있다.
-    - [ ] 구현 라우트/파라미터와 OpenAPI path/query/path-param의 ***1:1 매핑 확인*** 체크를 통과했다.
+    - [x] 구현 라우트/파라미터와 OpenAPI path/query/path-param의 ***1:1 매핑 확인*** 체크를 통과했다.
+      - 근거: `docs/openapi-impl-path-param-manual-checklist.md` 수동 대조 PASS, `cargo run --quiet --bin check_contract_drift` 및 `python scripts/check_contract_drift.py --spec docs/openapi.yaml --spec docs/swagger/openapi.yaml --report artifacts/contracts/local/contract-drift-report.json` 재검증 PASS.
     - [ ] 계약 드리프트 점검 항목(주간 점검/CI 정적 점검)이 활성 상태다.
     - [x] 문서 경로 파라미터 명칭 통일(`GET /jobs/{job_id}`) 체크포인트를 통과했다.
 


### PR DESCRIPTION
### Motivation
- Mark the WBS 1.2 re-completion condition that requires a 1:1 mapping between implementation routes/parameters and OpenAPI path/query/path-params as verified, and record the evidence in the TODO checklist.

### Description
- Updated `TODO/TODO.md` to change the WBS 1.2 item `구현 라우트/파라미터와 OpenAPI path/query/path-param의 1:1 매핑 확인` to checked (`- [x]`) and added explicit evidence referencing the manual checklist and automated contract checks.

### Testing
- Ran the Rust contract checker with `cargo run --quiet --bin check_contract_drift` and it passed for `docs/openapi.yaml` and `docs/swagger/openapi.yaml`.
- Ran the Python contract script `python scripts/check_contract_drift.py --spec docs/openapi.yaml --spec docs/swagger/openapi.yaml --report artifacts/contracts/local/contract-drift-report.json` and it produced a PASS report at `artifacts/contracts/local/contract-drift-report.json`.
- Executed a local markdown link/structure sanity check script against the edited TODO file and it returned OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2909fccb4832ea7e5b35beaf393d7)