### PR TITLE
docs: mark WBS 1.2 route/parameter 1:1 mapping check as complete

### DIFF
--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -20,7 +20,7 @@
 - [x] 1.2 OpenAPI/API 계약을 Rust 목표 엔드포인트 기준으로 재정렬 (재검토)
   - 재완료 조건:
     - [x] `docs/openapi.yaml`, `docs/swagger/openapi.yaml`에 Rust 목표 엔드포인트가 동일하게 반영되어 있다.
-    - [ ] 구현 라우트/파라미터와 OpenAPI path/query/path-param의 ***1:1 매핑 확인*** 체크를 통과했다.
+    - [x] 구현 라우트/파라미터와 OpenAPI path/query/path-param의 ***1:1 매핑 확인*** 체크를 통과했다.
     - [ ] 계약 드리프트 점검 항목(주간 점검/CI 정적 점검)이 활성 상태다.
     - [x] 문서 경로 파라미터 명칭 통일(`GET /jobs/{job_id}`) 체크포인트를 통과했다.
 


### PR DESCRIPTION
### Motivation
- Reflect that the WBS 1.2 sub-check verifying a 1:1 mapping between implementation routes/params and the OpenAPI path/query/path-param has been validated and should be recorded in the WBS tracker, after performing RTD Steps 1–4 to confirm minimal-scope change is appropriate.

### Description
- Update `TODO/TODO.md` to mark the item "구현 라우트/파라미터와 OpenAPI path/query/path-param의 1:1 매핑 확인" as completed, with no code or API changes.

### Testing
- Ran the contract-drift checks `cargo run --quiet --bin check_contract_drift` and `python scripts/check_contract_drift.py --spec docs/openapi.yaml --spec docs/swagger/openapi.yaml --report artifacts/contracts/local/contract-drift-report.json`, both of which passed and produced the verification report.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2b8b1db94832eb24670111fa638e4)