### PR TITLE
Remove timeout job status and job_timeout error code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ WBS 1.2 재완료 게이트(구현 라우트/파라미터 ↔ OpenAPI path/param
 - WBS `1.2 OpenAPI/API 계약 재정렬`은 구현 라우트/파라미터와 OpenAPI path/param 1:1 매핑 재검토 대상으로 관리합니다.
 - 운영 점검 정례화(7.4.1~7.4.4)에는 계약 드리프트 주간 점검(구현↔OpenAPI path/param 대조 + CI 정적 계약 점검 확인 + 경로 파라미터 명칭 일치 검증 + 기준 엔드포인트 세트 `/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}` 고정)을 포함합니다.
 - OpenAPI 계약(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)은 Rust 목표 엔드포인트 기준으로 유지합니다.
-- OpenAPI 잡 상태 enum은 `queued|running|completed|failed|timeout|canceled|rejected`를 단일 기준으로 유지합니다.
+- OpenAPI 잡 상태 enum은 `queued|running|completed|failed|canceled|rejected`를 단일 기준으로 유지합니다.
 1. 계약 안정성(API 응답 필드/에러 규약)
 2. 운영 안전성(타임아웃, 큐 포화, 헬스체크)
 3. 성능 최적화(검색/벡터/read-heavy 경로)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,11 +33,11 @@
 - 주간 점검에는 계약 드리프트 점검(구현↔OpenAPI path/param 대조, CI 정적 계약 점검 로그 확인 + 경로 파라미터 명칭 일치 여부 확인 + 기준 엔드포인트 세트 `/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}` 고정)을 필수 항목으로 포함하며, 회차 로그에는 CI 정적 점검 스크립트 산출물 링크/경로를 첨부합니다.
 
 - OpenAPI 계약(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)은 Rust 목표 엔드포인트(`/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}`) 기준으로 정렬되어 있습니다.
-- 상태 전이/에러 코드 설명은 OpenAPI enum을 단일 기준으로 유지합니다(상태: `queued|running|completed|failed|timeout|canceled|rejected`).
+- 상태 전이/에러 코드 설명은 OpenAPI enum을 단일 기준으로 유지합니다(상태: `queued|running|completed|failed|canceled|rejected`).
 - 루트에 Rust 실행 코드(`Cargo.toml`)가 존재하며, 백엔드 전환 구현이 진행 중입니다.
 - 운영 중 코드 기준은 `frontend/`(현행) + 루트 Rust 코드입니다.
 - 오디오 변환 기본 전략은 외부 `ffmpeg` 호출이 아니라 Rust `symphonia` 크레이트 사용입니다.
-- 잡 상태는 `queued|running|completed|failed|timeout|canceled|rejected`로 관리합니다.
+- 잡 상태는 `queued|running|completed|failed|canceled|rejected`로 관리합니다.
 - `POST /jobs` 과부하 응답은 `429(queue_full|engine_full)` 규약으로 구분되며 엔진/사유별 리젝션 카운트를 기록합니다.
 - `/readyz`는 수용량 압박 시 `503 degraded`로 응답하며, `/metrics`에서 readiness/queue/rejection 스냅샷(JSON)을 노출합니다.
 - STT는 `audio_ms` 길이 입력이 있을 때 처리율/버퍼/상하한 기반 timeout budget 산정식을 적용합니다.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -21,7 +21,7 @@
 - 주간 점검에는 계약 드리프트 점검(구현↔OpenAPI path/param 대조, CI 정적 계약 점검 로그 확인 + 경로 파라미터 명칭 일치 여부 확인 + 기준 엔드포인트 세트 `/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}` 고정)을 필수 항목으로 포함하며, 회차 로그에는 CI 정적 점검 스크립트 산출물 링크/경로를 첨부합니다.
 
 - OpenAPI 계약(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)은 Rust 목표 엔드포인트(`/healthz`, `/readyz`, `/metrics`, `POST /jobs`, `GET /jobs/{job_id}`) 기준으로 정렬되어 있습니다.
-- 상태 전이/에러 코드 설명은 OpenAPI enum을 단일 기준으로 유지합니다(상태: `queued|running|completed|failed|timeout|canceled|rejected`).
+- 상태 전이/에러 코드 설명은 OpenAPI enum을 단일 기준으로 유지합니다(상태: `queued|running|completed|failed|canceled|rejected`).
 - 저장소는 Rust 전환 진행 중이며, 레거시 Python 코드는 현 저장소에 포함되어 있지 않습니다.
 - 루트에는 Rust 실행 코드가 존재하며, 문서/프론트와 함께 Rust 구현 변경도 작업 대상입니다.
 - `POST /jobs` 과부하 응답은 `429(queue_full|engine_full)`로 구분되며, 리젝션은 엔진/사유 라벨 카운트로 관측합니다.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ RecordRoute는 음성/문서 처리 파이프라인을 **Rust 중심 아키텍�
 - `frontend/`: 현재 유지 중인 웹 프론트엔드
 - `docs/`: Rust 전환/설계 문서
 
-Rust 백엔드는 `/healthz`/`/readyz`/`/metrics` + `POST /jobs`/`GET /jobs/{job_id}`와 엔진별 bounded queue/worker 기반 처리 흐름(queued→running→completed|failed|timeout|canceled|rejected)까지 반영되어 있으며, 엔진 슈퍼비전/전처리/Swagger 분리 배포 구성을 단계적으로 이전합니다.
+Rust 백엔드는 `/healthz`/`/readyz`/`/metrics` + `POST /jobs`/`GET /jobs/{job_id}`와 엔진별 bounded queue/worker 기반 처리 흐름(queued→running→completed|failed|canceled|rejected)까지 반영되어 있으며, 엔진 슈퍼비전/전처리/Swagger 분리 배포 구성을 단계적으로 이전합니다.
 
 세부 구현 방식은 `docs/implementation-notes.md`에서 최신으로 관리합니다.
 
@@ -78,12 +78,12 @@ Rust 백엔드는 `/healthz`/`/readyz`/`/metrics` + `POST /jobs`/`GET /jobs/{job
 - Python 기반 구 구현은 현재 저장소에 포함되어 있지 않으며, 필요 시 별도 레거시 보관소를 참조합니다.
 - Rust 오케스트레이터 + C++(llama.cpp/whisper.cpp) 엔진 분리 아키텍처를 목표로 합니다.
 - 프론트엔드는 유지하되, 향후 Rust API 계약에 맞춰 점진적으로 연결합니다.
-- 상태 전이/에러 코드 설명은 OpenAPI enum을 단일 기준으로 유지합니다(상태: `queued|running|completed|failed|timeout|canceled|rejected`).
+- 상태 전이/에러 코드 설명은 OpenAPI enum을 단일 기준으로 유지합니다(상태: `queued|running|completed|failed|canceled|rejected`).
 
 ## 목표 상태 (문서/구현 고정 기준)
 
-- 상태 전이 설명은 OpenAPI 상태 enum을 단일 기준으로 유지합니다: `queued -> running -> completed|failed|timeout|canceled`, 예외 전이 `queued -> rejected`.
-- 에러 코드 설명은 OpenAPI ErrorCode enum을 단일 기준으로 유지합니다: `queue_full|engine_full|engine_dispatcher_closed|engine_dispatcher_unavailable|engine_connect_timeout|engine_request_timeout|engine_transport_error|engine_upstream_4xx|engine_upstream_5xx|engine_retry_exhausted|engine_endpoint_invalid|engine_invalid_http|engine_invalid_json|engine_not_configured|job_timeout|job_canceled|invalid_job_id|job_not_found|not_found|method_not_allowed`.
+- 상태 전이 설명은 OpenAPI 상태 enum을 단일 기준으로 유지합니다: `queued -> running -> completed|failed|canceled`, 예외 전이 `queued -> rejected`.
+- 에러 코드 설명은 OpenAPI ErrorCode enum을 단일 기준으로 유지합니다: `queue_full|engine_full|engine_dispatcher_closed|engine_dispatcher_unavailable|engine_connect_timeout|engine_request_timeout|engine_transport_error|engine_upstream_4xx|engine_upstream_5xx|engine_retry_exhausted|engine_endpoint_invalid|engine_invalid_http|engine_invalid_json|engine_not_configured|job_canceled|invalid_job_id|job_not_found|not_found|method_not_allowed`.
 
 ## 개발 시작
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -130,7 +130,6 @@ components:
         - engine_invalid_http
         - engine_invalid_json
         - engine_not_configured
-        - job_timeout
         - job_canceled
         - invalid_job_id
         - job_not_found
@@ -207,7 +206,7 @@ components:
           type: string
     JobStatus:
       type: string
-      enum: [queued, running, completed, failed, timeout, canceled, rejected]
+      enum: [queued, running, completed, failed, canceled, rejected]
     JobError:
       type: object
       required: [code, message]

--- a/docs/swagger/openapi.yaml
+++ b/docs/swagger/openapi.yaml
@@ -130,7 +130,6 @@ components:
         - engine_invalid_http
         - engine_invalid_json
         - engine_not_configured
-        - job_timeout
         - job_canceled
         - invalid_job_id
         - job_not_found
@@ -207,7 +206,7 @@ components:
           type: string
     JobStatus:
       type: string
-      enum: [queued, running, completed, failed, timeout, canceled, rejected]
+      enum: [queued, running, completed, failed, canceled, rejected]
     JobError:
       type: object
       required: [code, message]

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -42,7 +42,6 @@ pub(crate) enum JobStatus {
     Running,
     Completed,
     Failed,
-    Timeout,
     Canceled,
     Rejected,
 }
@@ -198,22 +197,6 @@ impl JobStore {
                 job.error = Some(JobError {
                     code,
                     message: format!("{} capacity exceeded ({code})", engine.as_str()),
-                });
-            }
-        });
-    }
-
-    pub(crate) fn mark_timeout(&self, job_id: &JobId, code: &'static str, message: String) {
-        self.transition(job_id, |job| {
-            if matches!(job.status, JobStatus::Queued | JobStatus::Running) {
-                job.status = JobStatus::Timeout;
-                if job.started_at_ms.is_none() {
-                    job.started_at_ms = Some(now_ms());
-                }
-                job.finished_at_ms = Some(now_ms());
-                job.error = Some(JobError {
-                    code,
-                    message: message.clone(),
                 });
             }
         });


### PR DESCRIPTION
## Summary
This PR removes the `Timeout` job status and `job_timeout` error code from the system, simplifying the job lifecycle to use only `completed`, `failed`, `canceled`, and `rejected` terminal states.

## Changes Made

### Source Code
- **src/domain.rs**: 
  - Removed `Timeout` variant from `JobStatus` enum
  - Removed `mark_timeout()` method from `JobStore` implementation

### API Contract (OpenAPI)
- **docs/openapi.yaml** and **docs/swagger/openapi.yaml**:
  - Updated `JobStatus` enum to remove `timeout` value
  - Removed `job_timeout` from `ErrorCode` enum

### Documentation
- **README.md**: Updated job state flow documentation to reflect `queued→running→completed|failed|canceled|rejected` (removed `timeout`)
- **CLAUDE.md**: Updated job status list and state transition descriptions
- **AGENTS.md**: Updated OpenAPI job status enum reference
- **GEMINI.md**: Updated job status documentation

## Implementation Details
The timeout handling is now consolidated into the `failed` status with appropriate error codes (e.g., `engine_request_timeout`, `engine_connect_timeout`) rather than using a dedicated timeout status. This simplifies the state machine while maintaining the ability to distinguish timeout-related failures through error codes.

All documentation and API contracts have been synchronized to reflect this change consistently across the codebase.

https://claude.ai/code/session_01PjA8d1apq1QYpSLyMATmcD