### PR TITLE
Use semaphore to track engine saturation for accurate 429 rejection reasons

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use std::{
 
 use serde::Serialize;
 use serde_json::{json, Value};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Semaphore};
 use tracing_subscriber::{fmt as tracing_fmt, EnvFilter};
 
 mod audio;
@@ -43,6 +43,11 @@ pub(crate) struct EngineDispatcher {
     pub(crate) queue_depth: Arc<AtomicUsize>,
     pub(crate) queue_capacity: usize,
     pub(crate) worker_count: usize,
+    /// Semaphore with `worker_count` permits. Each worker acquires one permit
+    /// before calling the engine and releases it when done. `available_permits() == 0`
+    /// means all engine slots are busy (`engine_full`); any available permits mean
+    /// the queue is the binding constraint (`queue_full`).
+    pub(crate) engine_semaphore: Arc<Semaphore>,
 }
 
 #[derive(Debug)]
@@ -70,6 +75,8 @@ struct EngineMetrics {
     queue_capacity: usize,
     worker_count: usize,
     running: usize,
+    /// Number of workers currently holding an engine semaphore permit (active engine calls).
+    engine_active: usize,
 }
 
 #[derive(Serialize)]
@@ -451,6 +458,9 @@ fn route_request_with_body(request_line: &str, body: &[u8], state: &AppState) ->
                             queue_capacity: dispatcher.queue_capacity,
                             worker_count: dispatcher.worker_count,
                             running: state.jobs.running_count(*engine),
+                            engine_active: dispatcher.worker_count.saturating_sub(
+                                dispatcher.engine_semaphore.available_permits(),
+                            ),
                         })
                 })
                 .collect();
@@ -532,7 +542,7 @@ fn route_request_with_body(request_line: &str, body: &[u8], state: &AppState) ->
                 }
                 Err(QueueEnqueueError::Full) => {
                     state.degraded.store(true, Ordering::Relaxed);
-                    let reason = rejection_reason_for_full(engine, dispatcher, &state.jobs);
+                    let reason = rejection_reason_for_full(dispatcher);
                     let rejection_count = state.rejection_metrics.increment(engine, reason);
                     state
                         .jobs
@@ -697,13 +707,14 @@ fn query_u64(query: &str, key: &str) -> Option<u64> {
         .and_then(|v| v.parse::<u64>().ok())
 }
 
-fn rejection_reason_for_full(
-    engine: EngineKind,
-    dispatcher: &EngineDispatcher,
-    jobs: &JobStore,
-) -> &'static str {
-    let running = jobs.running_count(engine);
-    if running >= dispatcher.worker_count {
+/// Determines whether a 429 rejection is due to the engine being saturated
+/// (`engine_full`) or the bounded queue being full (`queue_full`).
+///
+/// Uses the per-engine semaphore as the authoritative source: if no permits
+/// are available, all workers are actively executing engine calls (`engine_full`);
+/// otherwise the queue is the binding constraint (`queue_full`).
+fn rejection_reason_for_full(dispatcher: &EngineDispatcher) -> &'static str {
+    if dispatcher.engine_semaphore.available_permits() == 0 {
         "engine_full"
     } else {
         "queue_full"
@@ -1365,28 +1376,26 @@ mod tests {
 
     #[test]
     fn full_rejection_reason_distinguishes_queue_vs_engine_pressure() {
-        let jobs = JobStore::new();
-        let queued_job = jobs.create_queued_job(EngineKind::Stt);
-
+        // Semaphore has available permits → queue is the binding constraint.
         let queue_pressure_dispatcher = EngineDispatcher {
             sender: tokio::sync::mpsc::channel(1).0,
             queue_depth: Arc::new(AtomicUsize::new(1)),
             queue_capacity: 1,
             worker_count: 2,
+            engine_semaphore: Arc::new(Semaphore::new(2)),
         };
-        let queue_reason =
-            rejection_reason_for_full(EngineKind::Stt, &queue_pressure_dispatcher, &jobs);
+        let queue_reason = rejection_reason_for_full(&queue_pressure_dispatcher);
         assert_eq!(queue_reason, "queue_full");
 
-        jobs.mark_running(&queued_job.job_id);
+        // Semaphore has 0 available permits → all engine slots are busy.
         let engine_pressure_dispatcher = EngineDispatcher {
             sender: tokio::sync::mpsc::channel(1).0,
             queue_depth: Arc::new(AtomicUsize::new(1)),
             queue_capacity: 1,
             worker_count: 1,
+            engine_semaphore: Arc::new(Semaphore::new(0)),
         };
-        let engine_reason =
-            rejection_reason_for_full(EngineKind::Stt, &engine_pressure_dispatcher, &jobs);
+        let engine_reason = rejection_reason_for_full(&engine_pressure_dispatcher);
         assert_eq!(engine_reason, "engine_full");
     }
 

--- a/src/workers.rs
+++ b/src/workers.rs
@@ -9,7 +9,7 @@ use std::{
 use std::time::Duration;
 
 use tokio::{
-    sync::{mpsc, Mutex},
+    sync::{mpsc, Mutex, Semaphore},
     time::timeout,
 };
 
@@ -25,16 +25,19 @@ pub fn build_dispatchers(
     let mut dispatchers = HashMap::new();
 
     for engine in [EngineKind::Stt, EngineKind::Summarize, EngineKind::Embed] {
+        let concurrency = config.concurrency(engine).max(1);
         let (sender, receiver) = mpsc::channel(config.queue_capacity(engine));
         let queue_depth = Arc::new(AtomicUsize::new(0));
+        let engine_semaphore = Arc::new(Semaphore::new(concurrency));
 
         spawn_worker_pool(
             engine,
             receiver,
-            config.concurrency(engine).max(1),
+            concurrency,
             jobs.clone(),
             engine_client.clone(),
             Duration::from_secs(config.job_timeout_secs),
+            engine_semaphore.clone(),
         );
 
         dispatchers.insert(
@@ -43,7 +46,8 @@ pub fn build_dispatchers(
                 sender,
                 queue_depth,
                 queue_capacity: config.queue_capacity(engine),
-                worker_count: config.concurrency(engine).max(1),
+                worker_count: concurrency,
+                engine_semaphore,
             },
         );
     }
@@ -58,6 +62,7 @@ pub fn spawn_worker_pool(
     jobs: Arc<JobStore>,
     engine_client: Arc<dyn EngineClient>,
     _job_timeout: Duration,
+    engine_semaphore: Arc<Semaphore>,
 ) {
     let receiver = Arc::new(Mutex::new(receiver));
 
@@ -65,6 +70,7 @@ pub fn spawn_worker_pool(
         let receiver = receiver.clone();
         let jobs = jobs.clone();
         let engine_client = engine_client.clone();
+        let engine_semaphore = engine_semaphore.clone();
 
         tokio::spawn(async move {
             loop {
@@ -83,6 +89,16 @@ pub fn spawn_worker_pool(
                 };
 
                 let _queue_depth_guard: Option<QueueDepthGuard> = request.queue_depth_guard;
+
+                // Acquire an engine semaphore permit before calling the engine.
+                // Holding this permit marks the worker as active; `available_permits() == 0`
+                // signals `engine_full` to the 429 rejection path.
+                // The permit is released automatically when `_permit` is dropped at the
+                // end of this loop iteration.
+                let _permit = engine_semaphore
+                    .acquire()
+                    .await
+                    .expect("engine semaphore should not be closed");
 
                 let start = std::time::Instant::now();
                 jobs.mark_running(&request.job_id);
@@ -149,6 +165,7 @@ pub fn spawn_worker_pool(
                         );
                     }
                 }
+                // _permit dropped here → semaphore slot released
             }
         });
     }


### PR DESCRIPTION
## Summary
Replace the indirect method of determining engine saturation (comparing running job count to worker count) with a direct semaphore-based approach. This provides an authoritative signal for distinguishing between queue-full and engine-full rejection scenarios.

## Key Changes
- **Add `engine_semaphore` to `EngineDispatcher`**: A new `Arc<Semaphore>` with `worker_count` permits tracks active engine calls. Each worker acquires a permit before calling the engine and releases it when done.
- **Simplify `rejection_reason_for_full()` function**: Now takes only the dispatcher as a parameter and uses `engine_semaphore.available_permits() == 0` as the authoritative indicator of engine saturation, eliminating the need to query job state.
- **Update worker pool initialization**: Create the semaphore in `build_dispatchers()` and pass it to `spawn_worker_pool()` for each worker to use.
- **Add permit acquisition in worker loop**: Each worker acquires a permit before executing engine calls, held for the duration of the request processing.
- **Add `engine_active` metric**: Track the number of workers currently holding engine permits in `EngineMetrics` for observability.

## Implementation Details
- The semaphore permit is acquired after dequeueing but before calling the engine, ensuring accurate tracking of active engine slots.
- The permit is automatically released when dropped at the end of each loop iteration, providing clean resource management.
- This approach is more reliable than counting running jobs, as it directly reflects which workers are actively executing engine calls versus waiting in the queue.
- Tests updated to use the semaphore directly rather than manipulating job state.

https://claude.ai/code/session_01BRL9yif6qeRDX1ihmnzh6Y