### PR TITLE
docs: add invalid_audio_payload to OpenAPI ErrorCode enum and update WBS

### DIFF
--- a/TODO/TODO.md
+++ b/TODO/TODO.md
@@ -36,8 +36,8 @@
   - 미완료: `timeout` 경로가 실제 전이로 사용되지 않으며, 현재 worker timeout은 `mark_canceled`로 수렴해 상태가 `canceled`/`job_canceled`로 종료됨 (`src/workers.rs:132-150`, `src/domain.rs:206-217`)
 - [ ] 4.2 타임아웃 계층 분리 (HTTP vs Job)
   - 미완료: job timeout 초과 시 상태/코드가 `timeout`/`job_timeout`로 표기되지 않고 `canceled`/`job_canceled`로 종료됨 (`src/workers.rs:132-150`, `src/main.rs:1396-1412`)
-- [ ] 4.3 에러 코드/응답 필드 계약 고정
-  - 미완료: 구현에서 발생하는 `invalid_audio_payload` 에러코드가 OpenAPI `ErrorCode` enum에 미포함 (`src/main.rs:614-623`, `docs/openapi.yaml:116-138`)
+- [x] 4.3 에러 코드/응답 필드 계약 고정
+  - 완료 근거: 구현 `invalid_audio_payload` 에러코드를 OpenAPI `ErrorCode` enum(`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)에 반영해 계약을 고정했습니다.
 
 ## 6.0 슈퍼비전/운영 안정성
 

--- a/TODO/completed-history.md
+++ b/TODO/completed-history.md
@@ -28,6 +28,7 @@
 - 4.2 타임아웃 계층 분리의 HTTP/job 예산 계산 분리 근거 항목
   - `engine_connect_timeout`, `engine_request_timeout`, `audio_ms` 기반 예산 계산 근거가 코드에 존재.
 - 4.3 에러 코드/응답 필드 계약 포맷 고정 (`ErrorBody { code, message }`) (`src/main.rs`, OpenAPI 스키마)
+- 4.3 추가 정합성: `invalid_audio_payload` 에러코드를 OpenAPI `ErrorCode` enum에 반영해 구현/문서 계약을 일치시킴 (`docs/openapi.yaml`, `docs/swagger/openapi.yaml`)
 
 ### 5.0 오디오 전처리/처리량 정책
 - 5.1 `symphonia` 기반 오디오 정규화 (16kHz/16-bit mono WAV)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -131,6 +131,7 @@ components:
         - engine_invalid_json
         - engine_not_configured
         - job_canceled
+        - invalid_audio_payload
         - invalid_job_id
         - job_not_found
         - not_found

--- a/docs/swagger/openapi.yaml
+++ b/docs/swagger/openapi.yaml
@@ -131,6 +131,7 @@ components:
         - engine_invalid_json
         - engine_not_configured
         - job_canceled
+        - invalid_audio_payload
         - invalid_job_id
         - job_not_found
         - not_found


### PR DESCRIPTION
### Motivation

- Align the documented OpenAPI `ErrorCode` enum with an existing runtime error `invalid_audio_payload` so the API contract matches implementation.
- Close WBS 4.3 (error-code/response-field contract) after the contract alignment to keep the TODO/WBS state consistent with the docs.

### Description

- Added `invalid_audio_payload` to the `ErrorCode` enum in both `docs/openapi.yaml` and `docs/swagger/openapi.yaml` to keep the two spec files synchronized.
- Marked WBS item 4.3 as completed in `TODO/TODO.md` and added a matching note to `TODO/completed-history.md` describing the contract alignment evidence.
- This change is documentation/contract-only and does not modify runtime behavior or source code paths.

### Testing

- Parsed both updated OpenAPI YAML files using the Ruby `YAML.load_file` loader to validate YAML syntax, and parsing succeeded.
- Verified repository diff/status and file-level changes to ensure both spec files and WBS docs were updated and kept in sync, and the checks passed.
- A Python `yaml.safe_load` attempt failed because the environment lacked the `PyYAML` module, which did not block validation because the Ruby YAML parse succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a386e0389c832eb25fefa198e3daad)