### PR TITLE
docs: synchronize agent guides with current backend routing and process schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,12 @@
   - 백엔드: `Dockerfile.backend`
   - 프론트엔드: `Dockerfile.frontend`
 - 핵심 HTTP 라우팅: `sttEngine/http_api/handler.py` + 라우트 모듈(`sttEngine/http_api/routes/*`)
+  - `/process`, `/history`, `/progress`는 `sttEngine/server/routes/*` 계층에서 처리
   - 파일/정적 서빙: `sttEngine/http_api/routes/file_routes.py`
   - 유사문서 응답 조합: `sttEngine/http_api/routes/similar_documents.py`
 - 워크플로우 실행: `sttEngine/http_api/workflow.py`
+- `/process` payload 정규화/검증: `sttEngine/server/services/file_service.py`
+- 작업 큐 실행: `sttEngine/server/tasks/queue.py`
 - Provider 추상화: `sttEngine/providers/*` + 호환 래퍼 `sttEngine/llm_provider.py`
 - 프론트엔드: React + Vite (`frontend/src/*`)
 - 레거시 UI: `frontend/legacy/*` (프론트 빌드 실패 시 fallback)
@@ -82,7 +85,7 @@ GET
   - `/api/similarity-graph`는 `min_similarity/max_neighbors/max_nodes/sampling/neighbor_strategy(auto|exact|lsh)` + 필터(`doc_types`, `start_date`, `end_date`, `keyword`)를 지원
   - 응답 `meta`는 `sampling`, `neighbor_strategy(requested/effective)`, `filters`, `incremental(...)` 진단 정보를 포함
 - `/similar/<uuid_or_path>`, `/models`
-  - `/models` 응답은 `models`(요청 provider 기준) + `models_by_provider` + `provider_status` + `default.provider`를 포함
+  - `/models` 응답은 `models`(요청 provider 기준) + `models_by_provider` + `provider_status` + `models_by_task(summary|embedding)` + `default.provider`를 포함
   - 선택 쿼리: `provider=ollama|llamacpp` (미지정 시 `LLM_PROVIDER` 기준)
 - `/cache/stats`, `/cache/cleanup`, `/metrics/workflow`
 
@@ -119,8 +122,10 @@ POST
 
 주의:
 - 백엔드 기준 요약 step 키는 `summary`
+- `summarize` step 입력은 서버에서 `summary`로 alias 정규화됩니다.
 - STT 모델 키는 `whisper`
 - `steps`는 서버에서 소문자/중복 제거 정규화 후 처리됨(순서 유지)
+- 재시도 제어 필드 `retry_mode`(기본 `new_task`)와 `retry_of_task_id`를 전달할 수 있습니다.
 - `model_settings.provider`(또는 `llm_provider`)로 교정/요약 LLM provider 선택 가능 (`ollama` 기본, `llamacpp` 지원)
 - `model_settings.diarization_provider` 기본값은 `pyannote`이며 미지정/빈 값이면 자동 적용됩니다.
 - `model_settings.num_speakers`, `min_speakers`, `max_speakers`는 정수(1~20)만 허용되며 `min_speakers <= max_speakers` 제약을 검증합니다.
@@ -134,6 +139,7 @@ POST
 
 ## 6. 수정 시 우선 확인할 파일
 - 라우트/핸들러: `sttEngine/http_api/handler.py`, `sttEngine/http_api/routes/file_routes.py`
+- 서버 라우트/서비스: `sttEngine/server/routes/process.py`, `sttEngine/server/routes/history.py`, `sttEngine/server/routes/progress.py`, `sttEngine/server/services/file_service.py`
 - 워크플로우: `sttEngine/http_api/workflow.py`
 - Provider: `sttEngine/providers/*`, `sttEngine/llm_provider.py`
 - 에러 매핑: `sttEngine/server/services/errors.py`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,8 @@
    - 공통: `TODO/TODO.md`
    - 트랙별: `TODO/GUI.md`, `TODO/llama-migration.md`, `TODO/rust-migration.md`, `TODO/DOCKER_OPENAPI_DEPLOY_PLAN.md`
 4. 이후 변경 범위에 따라 다음 파일을 우선 확인합니다.
-   - 백엔드 라우팅: `sttEngine/http_api/handler.py`
-   - 워크플로우: `sttEngine/http_api/workflow.py`
+   - 백엔드 라우팅: `sttEngine/http_api/handler.py`, `sttEngine/server/routes/process.py`, `sttEngine/server/routes/history.py`, `sttEngine/server/routes/progress.py`
+   - 워크플로우/요청 검증: `sttEngine/http_api/workflow.py`, `sttEngine/server/services/file_service.py`
    - 프론트 API 연동: `frontend/src/api/client.ts`, `frontend/src/api/types.ts`
 
 ## 문서 점검
@@ -30,6 +30,9 @@
 - 서버 엔트리는 `sttEngine/http_api/app.py`이며, `sttEngine/server.py`는 래퍼입니다.
 - 프론트 주 코드베이스는 `frontend/src`입니다. `frontend/legacy`는 fallback 용도입니다.
 - API/스키마 변경 시 `AGENTS.md`도 함께 갱신해 문서와 코드 드리프트를 막습니다.
+- `/process`의 `steps`는 소문자/중복 제거 정규화가 적용되며 `summarize`는 `summary`로 alias 처리됩니다.
+- `/process`는 `retry_mode`(기본 `new_task`)와 `retry_of_task_id`를 지원합니다.
+- `/models` 응답에는 `models_by_task(summary|embedding)`가 포함됩니다.
 
 - llama.cpp provider는 `llama-cpp-python` in-process 모드가 기본입니다.
 - `LLAMA_CPP_MODEL_PATH` 기본값은 `./models/default_model.gguf`이며, `LLM_BASE_URL`/`EMBEDDING_BASE_URL`/`LLAMA_CPP_COMMAND`는 하위 호환용으로만 유지됩니다.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -7,7 +7,7 @@
 - 구조/실행/API/테스트 기준: `AGENTS.md`
 - 사용자/운영 문서: `README.md`
 - 작업 백로그: `TODO/TODO.md`, `TODO/GUI.md`, `TODO/llama-migration.md`, `TODO/rust-migration.md`, `TODO/DOCKER_OPENAPI_DEPLOY_PLAN.md`
-- 백엔드 핵심: `sttEngine/http_api/handler.py`, `sttEngine/http_api/workflow.py`
+- 백엔드 핵심: `sttEngine/http_api/handler.py`, `sttEngine/server/routes/process.py`, `sttEngine/server/routes/history.py`, `sttEngine/server/routes/progress.py`, `sttEngine/http_api/workflow.py`, `sttEngine/server/services/file_service.py`
 - 프론트 핵심: `frontend/src/*`
 
 ## 문서 점검
@@ -21,6 +21,8 @@
 1. 백엔드 라우트/스키마 변경 시 `frontend/src/api/client.ts`와 `frontend/src/api/types.ts` 동기화
 2. 경로 처리 시 `sttEngine/http_api/paths.py` 유틸 사용
 3. 실패 응답은 `error`, `error_code`, `retryable`, `failed_step` 규약 유지
+4. `/process` step 입력의 `summarize`는 서버에서 `summary`로 정규화되며, `retry_mode`/`retry_of_task_id`를 지원
+5. `/models` 응답의 `models_by_task(summary|embedding)` 필드까지 함께 확인
 
 ## 권장 검증
 


### PR DESCRIPTION
### Motivation
- Ensure agent-facing docs reflect the actual request flow and validation logic in the codebase so agents consult correct files when modifying routes or `/process` behavior.
- Clarify the `/models` response contract and `/process` payload normalization to avoid implementation/documentation drift.

### Description
- Documented that `/process`, `/history`, and `/progress` endpoints are handled in `sttEngine/server/routes/*` and added `sttEngine/server/services/file_service.py` and `sttEngine/server/tasks/queue.py` to the agent checklist in `AGENTS.md`.
- Added `models_by_task(summary|embedding)` to `/models` response description and noted provider/model detection behavior in the docs.
- Recorded that `summarize` is normalized to `summary` on the server and that `retry_mode` (default `new_task`) and `retry_of_task_id` are accepted on `/process` payloads.
- Synchronized `CLAUDE.md` and `GEMINI.md` to match `AGENTS.md` so all three agent guides remain consistent.

### Testing
- Performed repository inspections and file reads using `rg`, `sed`, and `nl` to confirm the implementation locations and verify the updated doc fragments succeeded.
- Compared local file diffs to validate only documentation files were modified and that the new guidance appears in `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` with expected content.
- No runtime or unit test (`pytest`) changes were required and no test failures were observed during the documentation sync checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b50171a9b8832e8c1c46b85f27b3e4)