### PR TITLE
Fix one-line summary provider handling and llama.cpp runtime configuration

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(cmd.exe //c \"python3 --version\")",
+      "Bash(echo \"exit: $?\")",
+      "Bash(cmd.exe //c \"python --version\")",
+      "Bash(cmd.exe //c \"py -3 --version\")",
+      "Bash(cmd.exe //c \"setlocal EnableDelayedExpansion && set \"\"CURRENT_PY_VER=\"\" && for /f \"\"delims=\"\" %V in \\(''python3 --version 2^>^&1''\\) do set \"\"CURRENT_PY_VER=%V\"\" && echo CURRENT_PY_VER=[!CURRENT_PY_VER!] && echo !CURRENT_PY_VER! | findstr /r \"\"^Python [0-9]\"\" >nul 2>&1 && echo findstr matched || echo findstr did NOT match\")",
+      "Bash(/tmp/test_pydetect2.bat:*)"
+    ]
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@
 # 레거시 Ollama 엔드포인트(권장하지 않음: Provider별 설정 사용 권장)
 # OLLAMA_BASE_URL=http://localhost:11434
 
+# Ollama keep-alive(유휴 모델 유지 시간). 기본값 1m로 설정(요약/교정 작업 완료 후 1분 유휴 시 언로드)
+# OLLAMA_KEEP_ALIVE=1m
+
 # llama.cpp in-process 설정
 # 기본 모델 경로: ./models/default_model.gguf
 # LLAMA_CPP_MODEL_PATH=./models/default_model.gguf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,12 @@
   - 백엔드: `Dockerfile.backend`
   - 프론트엔드: `Dockerfile.frontend`
 - 핵심 HTTP 라우팅: `sttEngine/http_api/handler.py` + 라우트 모듈(`sttEngine/http_api/routes/*`)
+  - `/process`, `/history`, `/progress`는 `sttEngine/server/routes/*` 계층에서 처리
   - 파일/정적 서빙: `sttEngine/http_api/routes/file_routes.py`
   - 유사문서 응답 조합: `sttEngine/http_api/routes/similar_documents.py`
 - 워크플로우 실행: `sttEngine/http_api/workflow.py`
+- `/process` payload 정규화/검증: `sttEngine/server/services/file_service.py`
+- 작업 큐 실행: `sttEngine/server/tasks/queue.py`
 - Provider 추상화: `sttEngine/providers/*` + 호환 래퍼 `sttEngine/llm_provider.py`
 - 프론트엔드: React + Vite (`frontend/src/*`)
 - 레거시 UI: `frontend/legacy/*` (프론트 빌드 실패 시 fallback)
@@ -82,7 +85,7 @@ GET
   - `/api/similarity-graph`는 `min_similarity/max_neighbors/max_nodes/sampling/neighbor_strategy(auto|exact|lsh)` + 필터(`doc_types`, `start_date`, `end_date`, `keyword`)를 지원
   - 응답 `meta`는 `sampling`, `neighbor_strategy(requested/effective)`, `filters`, `incremental(...)` 진단 정보를 포함
 - `/similar/<uuid_or_path>`, `/models`
-  - `/models` 응답은 `models`(요청 provider 기준) + `models_by_provider` + `provider_status` + `default.provider`를 포함
+  - `/models` 응답은 `models`(요청 provider 기준) + `models_by_provider` + `provider_status` + `models_by_task(summary|embedding)` + `default.provider`를 포함
   - 선택 쿼리: `provider=ollama|llamacpp` (미지정 시 `LLM_PROVIDER` 기준)
 - `/cache/stats`, `/cache/cleanup`, `/metrics/workflow`
 
@@ -119,8 +122,10 @@ POST
 
 주의:
 - 백엔드 기준 요약 step 키는 `summary`
+- `summarize` step 입력은 서버에서 `summary`로 alias 정규화됩니다.
 - STT 모델 키는 `whisper`
 - `steps`는 서버에서 소문자/중복 제거 정규화 후 처리됨(순서 유지)
+- 재시도 제어 필드 `retry_mode`(기본 `new_task`)와 `retry_of_task_id`를 전달할 수 있습니다.
 - `model_settings.provider`(또는 `llm_provider`)로 교정/요약 LLM provider 선택 가능 (`ollama` 기본, `llamacpp` 지원)
 - `model_settings.diarization_provider` 기본값은 `pyannote`이며 미지정/빈 값이면 자동 적용됩니다.
 - `model_settings.num_speakers`, `min_speakers`, `max_speakers`는 정수(1~20)만 허용되며 `min_speakers <= max_speakers` 제약을 검증합니다.
@@ -134,6 +139,7 @@ POST
 
 ## 6. 수정 시 우선 확인할 파일
 - 라우트/핸들러: `sttEngine/http_api/handler.py`, `sttEngine/http_api/routes/file_routes.py`
+- 서버 라우트/서비스: `sttEngine/server/routes/process.py`, `sttEngine/server/routes/history.py`, `sttEngine/server/routes/progress.py`, `sttEngine/server/services/file_service.py`
 - 워크플로우: `sttEngine/http_api/workflow.py`
 - Provider: `sttEngine/providers/*`, `sttEngine/llm_provider.py`
 - 에러 매핑: `sttEngine/server/services/errors.py`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,8 @@
    - 공통: `TODO/TODO.md`
    - 트랙별: `TODO/GUI.md`, `TODO/llama-migration.md`, `TODO/rust-migration.md`, `TODO/DOCKER_OPENAPI_DEPLOY_PLAN.md`
 4. 이후 변경 범위에 따라 다음 파일을 우선 확인합니다.
-   - 백엔드 라우팅: `sttEngine/http_api/handler.py`
-   - 워크플로우: `sttEngine/http_api/workflow.py`
+   - 백엔드 라우팅: `sttEngine/http_api/handler.py`, `sttEngine/server/routes/process.py`, `sttEngine/server/routes/history.py`, `sttEngine/server/routes/progress.py`
+   - 워크플로우/요청 검증: `sttEngine/http_api/workflow.py`, `sttEngine/server/services/file_service.py`
    - 프론트 API 연동: `frontend/src/api/client.ts`, `frontend/src/api/types.ts`
 
 ## 문서 점검
@@ -30,6 +30,9 @@
 - 서버 엔트리는 `sttEngine/http_api/app.py`이며, `sttEngine/server.py`는 래퍼입니다.
 - 프론트 주 코드베이스는 `frontend/src`입니다. `frontend/legacy`는 fallback 용도입니다.
 - API/스키마 변경 시 `AGENTS.md`도 함께 갱신해 문서와 코드 드리프트를 막습니다.
+- `/process`의 `steps`는 소문자/중복 제거 정규화가 적용되며 `summarize`는 `summary`로 alias 처리됩니다.
+- `/process`는 `retry_mode`(기본 `new_task`)와 `retry_of_task_id`를 지원합니다.
+- `/models` 응답에는 `models_by_task(summary|embedding)`가 포함됩니다.
 
 - llama.cpp provider는 `llama-cpp-python` in-process 모드가 기본입니다.
 - `LLAMA_CPP_MODEL_PATH` 기본값은 `./models/default_model.gguf`이며, `LLM_BASE_URL`/`EMBEDDING_BASE_URL`/`LLAMA_CPP_COMMAND`는 하위 호환용으로만 유지됩니다.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -7,7 +7,7 @@
 - 구조/실행/API/테스트 기준: `AGENTS.md`
 - 사용자/운영 문서: `README.md`
 - 작업 백로그: `TODO/TODO.md`, `TODO/GUI.md`, `TODO/llama-migration.md`, `TODO/rust-migration.md`, `TODO/DOCKER_OPENAPI_DEPLOY_PLAN.md`
-- 백엔드 핵심: `sttEngine/http_api/handler.py`, `sttEngine/http_api/workflow.py`
+- 백엔드 핵심: `sttEngine/http_api/handler.py`, `sttEngine/server/routes/process.py`, `sttEngine/server/routes/history.py`, `sttEngine/server/routes/progress.py`, `sttEngine/http_api/workflow.py`, `sttEngine/server/services/file_service.py`
 - 프론트 핵심: `frontend/src/*`
 
 ## 문서 점검
@@ -21,6 +21,8 @@
 1. 백엔드 라우트/스키마 변경 시 `frontend/src/api/client.ts`와 `frontend/src/api/types.ts` 동기화
 2. 경로 처리 시 `sttEngine/http_api/paths.py` 유틸 사용
 3. 실패 응답은 `error`, `error_code`, `retryable`, `failed_step` 규약 유지
+4. `/process` step 입력의 `summarize`는 서버에서 `summary`로 정규화되며, `retry_mode`/`retry_of_task_id`를 지원
+5. `/models` 응답의 `models_by_task(summary|embedding)` 필드까지 함께 확인
 
 ## 권장 검증
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,12 @@ services:
     profiles: ["ollama"]
     ports:
       - "11434:11434"
+    environment:
+      OLLAMA_KEEP_ALIVE: ${OLLAMA_KEEP_ALIVE:-}
+    command:
+      - sh
+      - -lc
+      - if [ -z "$OLLAMA_KEEP_ALIVE" ]; then export OLLAMA_KEEP_ALIVE=1m; fi; exec ollama serve
     volumes:
       - ollama_data:/root/.ollama
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -18,6 +18,8 @@ fi
 
 if [ "${START_OLLAMA:-0}" = "1" ]; then
   if command -v ollama >/dev/null 2>&1; then
+    : "${OLLAMA_KEEP_ALIVE:=1m}"
+    export OLLAMA_KEEP_ALIVE
     echo "[docker] ollama serve를 백그라운드로 시작합니다."
     nohup ollama serve >/tmp/ollama.log 2>&1 &
   else

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -204,6 +204,10 @@ export interface ModelsResponse {
     embedding: string;
     provider?: 'ollama' | 'llamacpp';
   };
+  models_by_task?: {
+    summary: string[];
+    embedding: string[];
+  };
   models_by_provider?: Partial<Record<'ollama' | 'llamacpp', string[]>>;
   provider_status?: Partial<Record<'ollama' | 'llamacpp', { ok: boolean; message: string }>>;
 }

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -20,6 +20,8 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   const [localSettings, setLocalSettings] = useState(modelSettings);
   const [darkMode, setDarkMode] = useState(theme === 'dark');
   const [availableModels, setAvailableModels] = useState<string[]>([]);
+  const [summaryModels, setSummaryModels] = useState<string[]>([]);
+  const [embeddingModels, setEmbeddingModels] = useState<string[]>([]);
   const [defaults, setDefaults] = useState<{ whisper: string; summarize: string; embedding: string; provider?: 'ollama' | 'llamacpp' } | null>(null);
 
   const selectedProvider = (localSettings?.provider || localSettings?.llm_provider || defaults?.provider || 'ollama') as 'ollama' | 'llamacpp';
@@ -31,24 +33,33 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
       setDarkMode(theme === 'dark');
       api.getModels(requestedProvider).then(data => {
         const models = data.models || [];
+        const modelsByTask = data.models_by_task || {};
+        const dedup = (items: string[]) => Array.from(new Set((items || []).filter(Boolean)));
         const fetchedDefaults = data.default;
         setAvailableModels(models);
+        setSummaryModels(dedup(modelsByTask.summary || models));
+        setEmbeddingModels(dedup(modelsByTask.embedding || models));
         setDefaults(fetchedDefaults);
         setLocalSettings(prev => {
           if (!prev) {
             return prev;
           }
+          const summaryDefault = dedup(modelsByTask.summary || models)[0] || models[0] || '';
+          const embeddingDefault = dedup(modelsByTask.embedding || models)[0] || models[0] || '';
           return {
             ...prev,
             provider: prev.provider || prev.llm_provider || fetchedDefaults?.provider,
             llm_provider: prev.llm_provider || prev.provider || fetchedDefaults?.provider,
-            summarize: prev.summarize || fetchedDefaults?.summarize || models[0] || '',
-            embedding: prev.embedding || fetchedDefaults?.embedding || models[0] || '',
+            summarize: prev.summarize || fetchedDefaults?.summarize || summaryDefault,
+            embedding: prev.embedding || fetchedDefaults?.embedding || embeddingDefault,
           };
         });
       }).catch(() => { });
     }
   }, [open, modelSettings, theme, requestedProvider]);
+
+  const summarySelectModels = summaryModels.length ? summaryModels : availableModels;
+  const embeddingSelectModels = embeddingModels.length ? embeddingModels : availableModels;
 
   const handleSave = () => {
     setTheme(darkMode ? 'dark' : 'light');
@@ -126,7 +137,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                 <SelectValue placeholder="모델 선택..." />
               </SelectTrigger>
               <SelectContent className={theme === 'dark' ? 'bg-slate-800 border-slate-700' : ''}>
-                {availableModels.map(m => (
+                {summarySelectModels.map(m => (
                   <SelectItem key={m} value={m}>{m}{m === defaults?.summarize ? ' (기본값)' : ''}</SelectItem>
                 ))}
               </SelectContent>
@@ -140,7 +151,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                 <SelectValue placeholder="모델 선택..." />
               </SelectTrigger>
               <SelectContent className={theme === 'dark' ? 'bg-slate-800 border-slate-700' : ''}>
-                {availableModels.map(m => (
+                {embeddingSelectModels.map(m => (
                   <SelectItem key={m} value={m}>{m}{m === defaults?.embedding ? ' (기본값)' : ''}</SelectItem>
                 ))}
               </SelectContent>

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -33,7 +33,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
       setDarkMode(theme === 'dark');
       api.getModels(requestedProvider).then(data => {
         const models = data.models || [];
-        const modelsByTask = data.models_by_task || {};
+        const modelsByTask = data.models_by_task || { summary: [], embedding: [] };
         const dedup = (items: string[]) => Array.from(new Set((items || []).filter(Boolean)));
         const fetchedDefaults = data.default;
         setAvailableModels(models);

--- a/run.bat
+++ b/run.bat
@@ -14,7 +14,11 @@ if exist "%SCRIPT_DIR%\.env" (
     for /f "usebackq eol=# delims=" %%a in ("%SCRIPT_DIR%\.env") do (
         set "line=%%a"
         if /i "!line:~0,7!"=="export " set "line=!line:~7!"
-        if not "!line!"=="" set "!line!"
+        if not "!line!"=="" (
+            for /f "tokens=1* delims==" %%b in ("!line!") do (
+                if not "%%c"=="" set "%%b=%%c"
+            )
+        )
     )
     echo [DEBUG] PYANNOTE_TOKEN이 로드되었습니다.
 )
@@ -45,14 +49,6 @@ set "DEFAULT_TRANSCRIBE_MODEL=large-v3-turbo"
 set "DEFAULT_SUMMARY_MODEL=gpt-oss:20b"
 set "DEFAULT_EMBEDDING_MODEL=bge-m3:latest"
 
-if exist "%VENV_PYTHON%" if exist "%SCRIPT_DIR%\sttEngine\config.py" (
-    for /f "tokens=1,2,3 delims=|" %%a in ('"%VENV_PYTHON%" -c "from sttEngine.config import get_default_model; print('|'.join([get_default_model('TRANSCRIBE'), get_default_model('SUMMARY'), get_default_model('EMBEDDING')]))"') do (
-        set "DEFAULT_TRANSCRIBE_MODEL=%%a"
-        set "DEFAULT_SUMMARY_MODEL=%%b"
-        set "DEFAULT_EMBEDDING_MODEL=%%c"
-    )
-)
-
 call set "SUMMARY_MODEL_RESOLVED=%%%SUMMARY_MODEL_KEY%%%"
 if "%SUMMARY_MODEL_RESOLVED%"=="" (
     call set "SUMMARY_MODEL_RESOLVED=%%SUMMARY_MODEL%%"
@@ -71,38 +67,21 @@ if "%EMBEDDING_MODEL_RESOLVED%"=="" (
 
 REM 가상환경 존재 확인
 if not exist "%VENV_PYTHON%" (
-    echo 오류: 가상환경(venv)을 찾을 수 없습니다.
+    echo 오류: 가상환경 venv 를 찾을 수 없습니다.
     echo 먼저 setup.bat 스크립트를 실행하여 가상환경을 설정하세요.
     exit /b 1
 )
 
 REM 의존성 확인 및 설치
 set "REQUIREMENTS_FILE=%SCRIPT_DIR%\sttEngine\requirements.txt"
-set "REQUIREMENTS_STATE_FILE=%SCRIPT_DIR%\venv\.requirements_hash"
 
 if exist "%REQUIREMENTS_FILE%" (
     echo 필요한 파이썬 패키지를 확인합니다...
-
-    "%VENV_PYTHON%" -c "import hashlib, pathlib, sys; print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())" "%REQUIREMENTS_FILE%" > "%TEMP%\req_hash.tmp"
-    set /p REQ_HASH=<"%TEMP%\req_hash.tmp"
-    del "%TEMP%\req_hash.tmp"
-
-    set "INSTALLED_HASH="
-    if exist "%REQUIREMENTS_STATE_FILE%" (
-        set /p INSTALLED_HASH=<"%REQUIREMENTS_STATE_FILE%"
-    )
-
-    if not "!REQ_HASH!"=="!INSTALLED_HASH!" (
-        echo 의존성을 설치/업데이트합니다...
-        "%VENV_PYTHON%" -m pip install -r "%REQUIREMENTS_FILE%"
-        if !ERRORLEVEL! equ 0 (
-            echo !REQ_HASH!> "%REQUIREMENTS_STATE_FILE%"
-            echo 필요한 패키지가 준비되었습니다.
-        ) else (
-            echo 경고: 의존성 설치에 실패했습니다. 설치 로그를 확인하고 다시 시도하세요.
-        )
+    "%VENV_PYTHON%" -m pip install -r "%REQUIREMENTS_FILE%" > nul 2>&1
+    if !ERRORLEVEL! equ 0 (
+        echo 필요한 패키지가 준비되었습니다.
     ) else (
-        echo 필요한 파이썬 패키지가 이미 설치되어 있습니다.
+        echo 경고: 의존성 설치에 실패했습니다. 설치 로그를 확인하고 다시 시도하세요.
     )
 ) else (
     echo 경고: requirements.txt 파일을 찾을 수 없습니다.
@@ -133,31 +112,7 @@ if /i "%NEED_OLLAMA%"=="true" if exist "%OLLAMA_REQ_FILE%" (
 )
 
 REM PyTorch CUDA 버전 확인 및 설치
-echo PyTorch 상태를 확인합니다...
-
-"%VENV_PYTHON%" -c "import torch; print('Torch:', torch.__version__); print('CUDA available:', torch.cuda.is_available())" > nul 2>&1
-if !ERRORLEVEL! neq 0 (
-    echo PyTorch가 설치되지 않았습니다. CUDA 빌드를 설치합니다 (cu124)...
-    "%VENV_PYTHON%" -m pip install --upgrade --index-url https://download.pytorch.org/whl/cu124 torch torchvision torchaudio 2>nul
-    if !ERRORLEVEL! neq 0 (
-        "%VENV_PYTHON%" -m pip install --upgrade torch torchvision torchaudio
-    )
-) else (
-    "%VENV_PYTHON%" -c "import torch; exit(0 if '+cpu' in torch.__version__ else 1)" 2>nul
-    if !ERRORLEVEL! equ 0 (
-        echo CPU 빌드 PyTorch 감지 → CUDA 빌드로 교체합니다 (cu124)...
-        "%VENV_PYTHON%" -m pip uninstall -y torch torchvision torchaudio > nul 2>&1
-        "%VENV_PYTHON%" -m pip install --upgrade --index-url https://download.pytorch.org/whl/cu124 torch torchvision torchaudio 2>nul
-        if !ERRORLEVEL! neq 0 (
-            "%VENV_PYTHON%" -m pip install --upgrade torch torchvision torchaudio
-        )
-    ) else (
-        echo PyTorch CUDA 빌드 또는 호환 빌드가 감지되었습니다.
-    )
-)
-
-echo PyTorch 상태 확인:
-"%VENV_PYTHON%" -c "import torch; print('Torch:', torch.__version__); print('CUDA available:', torch.cuda.is_available())" 2>nul || echo (PyTorch 정보를 가져올 수 없습니다)
+echo PyTorch 런타임 점검은 건너뜁니다. 필요 시 setup.bat를 실행하세요.
 
 REM Ollama 서버 상태 확인 및 시작 (provider가 ollama인 경우에만)
 if /i "%NEED_OLLAMA%"=="true" (
@@ -172,14 +127,13 @@ if /i "%NEED_OLLAMA%"=="true" (
     call :trim_trailing_slash OLLAMA_HOST_NORMALIZED
 
     if /i "%OLLAMA_HOST_NORMALIZED%" neq "%OLLAMA_BASE_URL_NORMALIZED%" (
-        echo 경고: OLLAMA_HOST(%OLLAMA_HOST_NORMALIZED%)와 OLLAMA_BASE_URL(%OLLAMA_BASE_URL_NORMALIZED%)가 다릅니다.
-        echo Ollama 통신은 OLLAMA_BASE_URL(%OLLAMA_BASE_URL_NORMALIZED%) 기준으로 고정합니다.
+        echo 경고: OLLAMA_HOST=%OLLAMA_HOST_NORMALIZED% 와 OLLAMA_BASE_URL=%OLLAMA_BASE_URL_NORMALIZED% 가 다릅니다.
+        echo Ollama 통신은 OLLAMA_BASE_URL=%OLLAMA_BASE_URL_NORMALIZED% 기준으로 고정합니다.
     )
     set "OLLAMA_HOST=%OLLAMA_BASE_URL_NORMALIZED%"
-    set "OLLAMA_VERSION_URL=%OLLAMA_BASE_URL_NORMALIZED%/api/version"
 
     echo Ollama provider가 활성화되어 서버 상태를 확인합니다...
-    curl -s "%OLLAMA_VERSION_URL%" > nul 2>&1
+    ollama list > nul 2>&1
     if !ERRORLEVEL! neq 0 (
         echo Ollama 서버가 실행되지 않았습니다. 자동으로 시작합니다...
         where ollama > nul 2>&1
@@ -188,7 +142,7 @@ if /i "%NEED_OLLAMA%"=="true" (
             echo Ollama 서버를 시작했습니다.
             echo 서버 시작을 기다리는 중...
             timeout /t 3 /nobreak > nul
-            curl -s "%OLLAMA_VERSION_URL%" > nul 2>&1
+            ollama list > nul 2>&1
             if !ERRORLEVEL! equ 0 (
                 echo Ollama 서버가 성공적으로 시작되었습니다.
             ) else (
@@ -214,7 +168,7 @@ if /i "%NEED_OLLAMA%"=="true" (
     call :check_ollama_models %OLLAMA_CHECK_MODELS%
     if !ERRORLEVEL! neq 0 (
         echo 필수 Ollama 모델이 준비되지 않았습니다. 서버를 시작하지 않고 종료합니다.
-        echo 설치 명령: ollama pull <모델명>
+        echo 설치 명령 예시: ollama pull 모델명
         exit /b 1
     )
 )
@@ -260,7 +214,7 @@ if /i "%TUNNEL_ENABLED%"=="true" (
         )
     )
 ) else (
-    echo Cloudflare Tunnel이 비활성화되어 있습니다. (TUNNEL_ENABLED=false)
+    echo Cloudflare Tunnel이 비활성화되어 있습니다. TUNNEL_ENABLED=false
 )
 echo.
 
@@ -284,20 +238,41 @@ if not exist "%SCRIPT_DIR%\frontend\dist" (
     )
 )
 
+set "PORT_FALLBACK_ALLOWED=false"
+set "START_PORT=%PORT%"
+if not defined START_PORT (
+    set "START_PORT=8080"
+    set "PORT_FALLBACK_ALLOWED=true"
+) else if "%START_PORT%"=="8080" (
+    set "PORT_FALLBACK_ALLOWED=true"
+)
+set "PORT=%START_PORT%"
+
 echo 가상환경의 파이썬으로 웹서버를 실행합니다...
-echo 서버 URL: http://localhost:8080
-echo (웹브라우저에서 http://localhost:8080 에 접속하세요)
+echo 서버 URL: http://localhost:!PORT!
+echo 웹브라우저에서 http://localhost:!PORT! 에 접속하세요.
 echo.
 
 cd /d "%SCRIPT_DIR%"
 "%VENV_PYTHON%" -m sttEngine.server
 set EXIT_CODE=!ERRORLEVEL!
 
+if !EXIT_CODE! neq 0 if /i "%PORT_FALLBACK_ALLOWED%"=="true" if "%PORT%"=="8080" (
+    echo.
+    echo 포트 8080 바인딩에 실패했습니다. 포트 18080으로 재시도합니다.
+    set "PORT=18080"
+    echo 서버 URL: http://localhost:!PORT!
+    echo 웹브라우저에서 http://localhost:!PORT! 에 접속하세요.
+    echo.
+    "%VENV_PYTHON%" -m sttEngine.server
+    set EXIT_CODE=!ERRORLEVEL!
+)
+
 echo.
 if !EXIT_CODE! equ 0 (
     echo 서버가 정상적으로 종료되었습니다.
 ) else (
-    echo 서버가 오류와 함께 종료되었습니다. (오류코드: !EXIT_CODE!)
+    echo 서버가 오류와 함께 종료되었습니다. 오류코드: !EXIT_CODE!
     echo 오류 상세 내용을 확인하세요.
 )
 

--- a/run.bat
+++ b/run.bat
@@ -1,25 +1,20 @@
 @echo off
 chcp 65001 > nul
-setlocal enabledelayedexpansion
+setlocal EnableExtensions EnableDelayedExpansion
 
 REM RecordRoute 웹서버 실행 스크립트 (Windows)
 
 REM 스크립트 디렉토리 설정
 set "SCRIPT_DIR=%~dp0"
-set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
+if "%SCRIPT_DIR:~-1%"=="\" set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
 
 REM .env 파일에서 환경변수 로드
 if exist "%SCRIPT_DIR%\.env" (
     echo .env 파일에서 환경변수를 로드합니다.
-    for /f "usebackq tokens=*" %%a in ("%SCRIPT_DIR%\.env") do (
+    for /f "usebackq eol=# delims=" %%a in ("%SCRIPT_DIR%\.env") do (
         set "line=%%a"
-        REM 주석 라인 제외
-        if not "!line:~0,1!"=="#" (
-            REM 빈 라인 제외
-            if not "!line!"=="" (
-                set "%%a"
-            )
-        )
+        if /i "!line:~0,7!"=="export " set "line=!line:~7!"
+        if not "!line!"=="" set "!line!"
     )
     echo [DEBUG] PYANNOTE_TOKEN이 로드되었습니다.
 )
@@ -27,36 +22,57 @@ if exist "%SCRIPT_DIR%\.env" (
 if not defined OLLAMA_KEEP_ALIVE set "OLLAMA_KEEP_ALIVE=1m"
 
 REM Provider 설정 정규화
-set "LLM_PROVIDER_VALUE=!LLM_PROVIDER!"
-if "!LLM_PROVIDER_VALUE!"=="" set "LLM_PROVIDER_VALUE=ollama"
-set "EMBEDDING_PROVIDER_VALUE=!EMBEDDING_PROVIDER!"
-if "!EMBEDDING_PROVIDER_VALUE!"=="" set "EMBEDDING_PROVIDER_VALUE=!LLM_PROVIDER_VALUE!"
-if /i "!LLM_PROVIDER_VALUE!"=="ollama" (
+set "LLM_PROVIDER_VALUE=%LLM_PROVIDER%"
+if "%LLM_PROVIDER_VALUE%"=="" set "LLM_PROVIDER_VALUE=ollama"
+set "EMBEDDING_PROVIDER_VALUE=%EMBEDDING_PROVIDER%"
+if "%EMBEDDING_PROVIDER_VALUE%"=="" set "EMBEDDING_PROVIDER_VALUE=%LLM_PROVIDER_VALUE%"
+if /i "%LLM_PROVIDER_VALUE%"=="ollama" (
     set "NEED_OLLAMA=true"
-) else if /i "!EMBEDDING_PROVIDER_VALUE!"=="ollama" (
+) else if /i "%EMBEDDING_PROVIDER_VALUE%"=="ollama" (
     set "NEED_OLLAMA=true"
 ) else (
     set "NEED_OLLAMA=false"
 )
 
-REM 가상환경의 Python 실행 파일 경로
 set "VENV_PYTHON=%SCRIPT_DIR%\venv\Scripts\python.exe"
 
-REM 웹서버 스크립트 경로
-set "WEB_SERVER=%SCRIPT_DIR%\sttEngine\server.py"
+set "PLATFORM_SUFFIX=WINDOWS"
+set "TRANSCRIBE_MODEL_KEY=TRANSCRIBE_MODEL_%PLATFORM_SUFFIX%"
+set "SUMMARY_MODEL_KEY=SUMMARY_MODEL_%PLATFORM_SUFFIX%"
+set "EMBEDDING_MODEL_KEY=EMBEDDING_MODEL_%PLATFORM_SUFFIX%"
+
+set "DEFAULT_TRANSCRIBE_MODEL=large-v3-turbo"
+set "DEFAULT_SUMMARY_MODEL=gpt-oss:20b"
+set "DEFAULT_EMBEDDING_MODEL=bge-m3:latest"
+
+if exist "%VENV_PYTHON%" if exist "%SCRIPT_DIR%\sttEngine\config.py" (
+    for /f "tokens=1,2,3 delims=|" %%a in ('"%VENV_PYTHON%" -c "from sttEngine.config import get_default_model; print('|'.join([get_default_model('TRANSCRIBE'), get_default_model('SUMMARY'), get_default_model('EMBEDDING')]))"') do (
+        set "DEFAULT_TRANSCRIBE_MODEL=%%a"
+        set "DEFAULT_SUMMARY_MODEL=%%b"
+        set "DEFAULT_EMBEDDING_MODEL=%%c"
+    )
+)
+
+call set "SUMMARY_MODEL_RESOLVED=%%%SUMMARY_MODEL_KEY%%%"
+if "%SUMMARY_MODEL_RESOLVED%"=="" (
+    call set "SUMMARY_MODEL_RESOLVED=%%SUMMARY_MODEL%%"
+    if "%SUMMARY_MODEL_RESOLVED%"=="" (
+        set "SUMMARY_MODEL_RESOLVED=%DEFAULT_SUMMARY_MODEL%"
+    )
+)
+
+call set "EMBEDDING_MODEL_RESOLVED=%%%EMBEDDING_MODEL_KEY%%%"
+if "%EMBEDDING_MODEL_RESOLVED%"=="" (
+    call set "EMBEDDING_MODEL_RESOLVED=%%EMBEDDING_MODEL%%"
+    if "%EMBEDDING_MODEL_RESOLVED%"=="" (
+        set "EMBEDDING_MODEL_RESOLVED=%DEFAULT_EMBEDDING_MODEL%"
+    )
+)
 
 REM 가상환경 존재 확인
 if not exist "%VENV_PYTHON%" (
-    echo 오류: 가상환경^(venv^)을 찾을 수 없습니다.
+    echo 오류: 가상환경(venv)을 찾을 수 없습니다.
     echo 먼저 setup.bat 스크립트를 실행하여 가상환경을 설정하세요.
-    pause
-    exit /b 1
-)
-
-REM 웹서버 스크립트 존재 확인
-if not exist "%WEB_SERVER%" (
-    echo 오류: 웹서버 스크립트^(server.py^)를 찾을 수 없습니다.
-    pause
     exit /b 1
 )
 
@@ -66,19 +82,16 @@ set "REQUIREMENTS_STATE_FILE=%SCRIPT_DIR%\venv\.requirements_hash"
 
 if exist "%REQUIREMENTS_FILE%" (
     echo 필요한 파이썬 패키지를 확인합니다...
-    
-    REM 현재 requirements.txt 해시 계산
+
     "%VENV_PYTHON%" -c "import hashlib, pathlib, sys; print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())" "%REQUIREMENTS_FILE%" > "%TEMP%\req_hash.tmp"
     set /p REQ_HASH=<"%TEMP%\req_hash.tmp"
     del "%TEMP%\req_hash.tmp"
-    
-    REM 기존 해시 읽기
+
     set "INSTALLED_HASH="
     if exist "%REQUIREMENTS_STATE_FILE%" (
         set /p INSTALLED_HASH=<"%REQUIREMENTS_STATE_FILE%"
     )
-    
-    REM 해시 비교 및 설치
+
     if not "!REQ_HASH!"=="!INSTALLED_HASH!" (
         echo 의존성을 설치/업데이트합니다...
         "%VENV_PYTHON%" -m pip install -r "%REQUIREMENTS_FILE%"
@@ -107,11 +120,11 @@ if exist "%ROOT_REQ_FILE%" (
     )
 )
 
-REM Ollama optional requirements 확인
+REM Ollama optional requirements 설치
 set "OLLAMA_REQ_FILE=%SCRIPT_DIR%\requirements-ollama.txt"
-if /i "!NEED_OLLAMA!"=="true" if exist "!OLLAMA_REQ_FILE!" (
+if /i "%NEED_OLLAMA%"=="true" if exist "%OLLAMA_REQ_FILE%" (
     echo Ollama provider가 활성화되어 선택 의존성을 확인합니다...
-    "%VENV_PYTHON%" -m pip install -r "!OLLAMA_REQ_FILE!" > nul 2>&1
+    "%VENV_PYTHON%" -m pip install -r "%OLLAMA_REQ_FILE%" > nul 2>&1
     if !ERRORLEVEL! equ 0 (
         echo Ollama 선택 의존성 확인 완료.
     ) else (
@@ -122,19 +135,17 @@ if /i "!NEED_OLLAMA!"=="true" if exist "!OLLAMA_REQ_FILE!" (
 REM PyTorch CUDA 버전 확인 및 설치
 echo PyTorch 상태를 확인합니다...
 
-REM PyTorch가 설치되어 있는지 확인
-"%VENV_PYTHON%" -c "import torch" > nul 2>&1
+"%VENV_PYTHON%" -c "import torch; print('Torch:', torch.__version__); print('CUDA available:', torch.cuda.is_available())" > nul 2>&1
 if !ERRORLEVEL! neq 0 (
-    echo PyTorch가 설치되지 않았습니다. CUDA 빌드를 설치합니다 ^(cu124^)...
+    echo PyTorch가 설치되지 않았습니다. CUDA 빌드를 설치합니다 (cu124)...
     "%VENV_PYTHON%" -m pip install --upgrade --index-url https://download.pytorch.org/whl/cu124 torch torchvision torchaudio 2>nul
     if !ERRORLEVEL! neq 0 (
         "%VENV_PYTHON%" -m pip install --upgrade torch torchvision torchaudio
     )
 ) else (
-    REM CPU 빌드 확인
     "%VENV_PYTHON%" -c "import torch; exit(0 if '+cpu' in torch.__version__ else 1)" 2>nul
     if !ERRORLEVEL! equ 0 (
-        echo CPU 빌드 PyTorch 감지 → CUDA 빌드로 교체합니다 ^(cu124^)...
+        echo CPU 빌드 PyTorch 감지 → CUDA 빌드로 교체합니다 (cu124)...
         "%VENV_PYTHON%" -m pip uninstall -y torch torchvision torchaudio > nul 2>&1
         "%VENV_PYTHON%" -m pip install --upgrade --index-url https://download.pytorch.org/whl/cu124 torch torchvision torchaudio 2>nul
         if !ERRORLEVEL! neq 0 (
@@ -145,19 +156,30 @@ if !ERRORLEVEL! neq 0 (
     )
 )
 
-REM PyTorch 버전 정보 출력
 echo PyTorch 상태 확인:
-"%VENV_PYTHON%" -c "import torch; print('Torch:', torch.__version__); print('CUDA available:', torch.cuda.is_available())" 2>nul
-if !ERRORLEVEL! neq 0 (
-    echo ^(PyTorch 정보를 가져올 수 없습니다^)
-)
+"%VENV_PYTHON%" -c "import torch; print('Torch:', torch.__version__); print('CUDA available:', torch.cuda.is_available())" 2>nul || echo (PyTorch 정보를 가져올 수 없습니다)
 
 REM Ollama 서버 상태 확인 및 시작 (provider가 ollama인 경우에만)
-if /i "!NEED_OLLAMA!"=="true" (
-    set "OLLAMA_BASE_URL_VALUE=!OLLAMA_BASE_URL!"
-    if "!OLLAMA_BASE_URL_VALUE!"=="" set "OLLAMA_BASE_URL_VALUE=http://localhost:11434"
+if /i "%NEED_OLLAMA%"=="true" (
+    set "OLLAMA_BASE_URL_VALUE=%OLLAMA_BASE_URL%"
+    if "%OLLAMA_BASE_URL_VALUE%"=="" set "OLLAMA_BASE_URL_VALUE=http://localhost:11434"
+    set "OLLAMA_HOST_VALUE=%OLLAMA_HOST%"
+    if "%OLLAMA_HOST_VALUE%"=="" set "OLLAMA_HOST_VALUE=%OLLAMA_BASE_URL_VALUE%"
+
+    set "OLLAMA_BASE_URL_NORMALIZED=%OLLAMA_BASE_URL_VALUE%"
+    set "OLLAMA_HOST_NORMALIZED=%OLLAMA_HOST_VALUE%"
+    call :trim_trailing_slash OLLAMA_BASE_URL_NORMALIZED
+    call :trim_trailing_slash OLLAMA_HOST_NORMALIZED
+
+    if /i "%OLLAMA_HOST_NORMALIZED%" neq "%OLLAMA_BASE_URL_NORMALIZED%" (
+        echo 경고: OLLAMA_HOST(%OLLAMA_HOST_NORMALIZED%)와 OLLAMA_BASE_URL(%OLLAMA_BASE_URL_NORMALIZED%)가 다릅니다.
+        echo Ollama 통신은 OLLAMA_BASE_URL(%OLLAMA_BASE_URL_NORMALIZED%) 기준으로 고정합니다.
+    )
+    set "OLLAMA_HOST=%OLLAMA_BASE_URL_NORMALIZED%"
+    set "OLLAMA_VERSION_URL=%OLLAMA_BASE_URL_NORMALIZED%/api/version"
+
     echo Ollama provider가 활성화되어 서버 상태를 확인합니다...
-    curl -s !OLLAMA_BASE_URL_VALUE!/api/version > nul 2>&1
+    curl -s "%OLLAMA_VERSION_URL%" > nul 2>&1
     if !ERRORLEVEL! neq 0 (
         echo Ollama 서버가 실행되지 않았습니다. 자동으로 시작합니다...
         where ollama > nul 2>&1
@@ -166,7 +188,7 @@ if /i "!NEED_OLLAMA!"=="true" (
             echo Ollama 서버를 시작했습니다.
             echo 서버 시작을 기다리는 중...
             timeout /t 3 /nobreak > nul
-            curl -s !OLLAMA_BASE_URL_VALUE!/api/version > nul 2>&1
+            curl -s "%OLLAMA_VERSION_URL%" > nul 2>&1
             if !ERRORLEVEL! equ 0 (
                 echo Ollama 서버가 성공적으로 시작되었습니다.
             ) else (
@@ -183,10 +205,24 @@ if /i "!NEED_OLLAMA!"=="true" (
     echo Ollama provider가 비활성화되어 서버 자동 시작을 건너뜁니다.
 )
 
+if /i "%NEED_OLLAMA%"=="true" (
+    echo Ollama 필수 모델 존재 여부를 확인합니다...
+    set "OLLAMA_CHECK_MODELS="
+    if /i "%LLM_PROVIDER_VALUE%"=="ollama" if defined SUMMARY_MODEL_RESOLVED if not "%SUMMARY_MODEL_RESOLVED%"=="" set "OLLAMA_CHECK_MODELS=%OLLAMA_CHECK_MODELS% %SUMMARY_MODEL_RESOLVED%"
+    if /i "%EMBEDDING_PROVIDER_VALUE%"=="ollama" if defined EMBEDDING_MODEL_RESOLVED if not "%EMBEDDING_MODEL_RESOLVED%"=="" set "OLLAMA_CHECK_MODELS=%OLLAMA_CHECK_MODELS% %EMBEDDING_MODEL_RESOLVED%"
+
+    call :check_ollama_models %OLLAMA_CHECK_MODELS%
+    if !ERRORLEVEL! neq 0 (
+        echo 필수 Ollama 모델이 준비되지 않았습니다. 서버를 시작하지 않고 종료합니다.
+        echo 설치 명령: ollama pull <모델명>
+        exit /b 1
+    )
+)
+
 REM Cloudflare Tunnel 상태 확인 및 시작
-if /i "!TUNNEL_ENABLED!"=="true" (
+if /i "%TUNNEL_ENABLED%"=="true" (
     echo Cloudflare Tunnel이 활성화되어 있습니다. 상태를 확인합니다...
-    
+
     REM cloudflared 설치 확인
     where cloudflared > nul 2>&1
     if !ERRORLEVEL! neq 0 (
@@ -196,7 +232,7 @@ if /i "!TUNNEL_ENABLED!"=="true" (
         echo.
     ) else (
         REM 터널 토큰 확인
-        if "!CLOUDFLARE_TUNNEL_TOKEN!"=="" (
+        if "%CLOUDFLARE_TUNNEL_TOKEN%"=="" (
             echo 경고: CLOUDFLARE_TUNNEL_TOKEN이 설정되지 않았습니다.
             echo .env 파일에 CLOUDFLARE_TUNNEL_TOKEN을 설정해주세요.
             echo.
@@ -207,18 +243,11 @@ if /i "!TUNNEL_ENABLED!"=="true" (
                 echo Cloudflare Tunnel이 이미 실행 중입니다.
             ) else (
                 echo Cloudflare Tunnel을 시작합니다...
-                
-                REM .cloudflared 디렉토리 생성
                 if not exist "%SCRIPT_DIR%\.cloudflared" mkdir "%SCRIPT_DIR%\.cloudflared"
-                
-                REM 백그라운드에서 cloudflared 실행
-                start /B cloudflared tunnel --config "%SCRIPT_DIR%\.cloudflared\config.yml" run --token "!CLOUDFLARE_TUNNEL_TOKEN!" > "%SCRIPT_DIR%\.cloudflared\tunnel.log" 2>&1
+                start /B cloudflared tunnel --config "%SCRIPT_DIR%\.cloudflared\config.yml" run --token "%CLOUDFLARE_TUNNEL_TOKEN%" > "%SCRIPT_DIR%\.cloudflared\tunnel.log" 2>&1
                 echo Cloudflare Tunnel을 시작했습니다.
-                
-                REM 터널 시작을 위해 잠시 대기
+
                 timeout /t 2 /nobreak > nul
-                
-                REM 터널 시작 확인
                 tasklist /FI "IMAGENAME eq cloudflared.exe" 2>nul | find /I "cloudflared.exe" > nul
                 if !ERRORLEVEL! equ 0 (
                     echo ✓ Cloudflare Tunnel이 성공적으로 시작되었습니다.
@@ -231,7 +260,7 @@ if /i "!TUNNEL_ENABLED!"=="true" (
         )
     )
 ) else (
-    echo Cloudflare Tunnel이 비활성화되어 있습니다. ^(TUNNEL_ENABLED=false^)
+    echo Cloudflare Tunnel이 비활성화되어 있습니다. (TUNNEL_ENABLED=false)
 )
 echo.
 
@@ -255,30 +284,9 @@ if not exist "%SCRIPT_DIR%\frontend\dist" (
     )
 )
 
-REM 웹서버 실행
 echo 가상환경의 파이썬으로 웹서버를 실행합니다...
-REM HOST/PORT는 실행 안정성을 위해 안전 기본값으로 고정
-set "HOST=127.0.0.1"
-set "PORT=8080"
-
-REM 기본 포트 사용 가능 여부 확인 (권한/예약/점유 충돌 시 18080으로 대체)
-powershell -NoProfile -ExecutionPolicy Bypass -Command "$port=8080; $listener=[System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Parse('127.0.0.1'),$port); try { $listener.Start(); $listener.Stop(); exit 0 } catch { exit 1 }" > nul 2>&1
-if !ERRORLEVEL! neq 0 (
-    echo 경고: 포트 8080을 사용할 수 없어 포트 18080으로 대체합니다.
-    set "PORT=18080"
-    powershell -NoProfile -ExecutionPolicy Bypass -Command "$port=18080; $listener=[System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Parse('127.0.0.1'),$port); try { $listener.Start(); $listener.Stop(); exit 0 } catch { exit 1 }" > nul 2>&1
-    if !ERRORLEVEL! neq 0 (
-        echo 오류: 포트 8080과 18080 모두 사용할 수 없습니다.
-        echo 사용 가능한 포트를 확인한 뒤 다시 실행하세요.
-        pause
-        exit /b 1
-    )
-)
-
-set "SERVER_URL=http://localhost:!PORT!"
-
-echo 서버 URL: !SERVER_URL!
-echo ^(웹브라우저에서 !SERVER_URL! 에 접속하세요^)
+echo 서버 URL: http://localhost:8080
+echo (웹브라우저에서 http://localhost:8080 에 접속하세요)
 echo.
 
 cd /d "%SCRIPT_DIR%"
@@ -289,9 +297,79 @@ echo.
 if !EXIT_CODE! equ 0 (
     echo 서버가 정상적으로 종료되었습니다.
 ) else (
-    echo 서버가 오류와 함께 종료되었습니다. ^(오류코드: !EXIT_CODE!^)
+    echo 서버가 오류와 함께 종료되었습니다. (오류코드: !EXIT_CODE!)
     echo 오류 상세 내용을 확인하세요.
 )
 
-pause
+exit /b !EXIT_CODE!
 endlocal
+
+:trim_trailing_slash
+set "trim_name=%~1"
+set "trim_value=!%trim_name%!"
+
+:trim_trailing_slash_loop
+if "%trim_value:~-1%"=="/" (
+    set "trim_value=%trim_value:~0,-1%"
+    goto trim_trailing_slash_loop
+)
+
+set "%trim_name%=%trim_value%"
+exit /b 0
+
+:check_ollama_models
+setlocal EnableExtensions EnableDelayedExpansion
+set "models=%*"
+
+if "%models%"=="" (
+    endlocal
+    exit /b 0
+)
+
+where ollama > nul 2>&1
+if !ERRORLEVEL! neq 0 (
+    echo 오류: ollama 명령어를 찾을 수 없습니다.
+    endlocal
+    exit /b 1
+)
+
+set "installed_models="
+for /f "skip=1 tokens=1" %%m in ('ollama list 2^>nul') do (
+    set "installed_models=!installed_models!;%%m;"
+)
+
+if "%installed_models%"=="" (
+    echo 오류: Ollama 모델 목록을 읽지 못했습니다. Ollama 서버가 실행 중인지 확인하세요.
+    endlocal
+    exit /b 1
+)
+
+set "missing=0"
+set "seen="
+for %%m in (%models%) do (
+    set "model=%%m"
+    if "!model!"=="" (
+        echo 오류: 필요 모델명이 비어 있습니다. .env에서 SUMMARY_MODEL 또는 EMBEDDING_MODEL 값을 확인하세요.
+        set "missing=1"
+    ) else (
+        echo !seen! | findstr /L /C:";!model!;" > nul
+        if !ERRORLEVEL! neq 0 (
+            set "seen=!seen!;!model!;"
+            echo !installed_models! | findstr /L /C:";!model!;" > nul
+            if !ERRORLEVEL! equ 0 (
+                echo ✓ Ollama 모델 확인됨: !model!
+            ) else (
+                echo 오류: Ollama에 모델이 없습니다: !model!
+                set "missing=1"
+            )
+        )
+    )
+)
+
+if "!missing!"=="1" (
+    endlocal
+    exit /b 1
+)
+
+endlocal
+exit /b 0

--- a/run.bat
+++ b/run.bat
@@ -24,6 +24,8 @@ if exist "%SCRIPT_DIR%\.env" (
     echo [DEBUG] PYANNOTE_TOKEN이 로드되었습니다.
 )
 
+if not defined OLLAMA_KEEP_ALIVE set "OLLAMA_KEEP_ALIVE=1m"
+
 REM Provider 설정 정규화
 set "LLM_PROVIDER_VALUE=!LLM_PROVIDER!"
 if "!LLM_PROVIDER_VALUE!"=="" set "LLM_PROVIDER_VALUE=ollama"

--- a/run.sh
+++ b/run.sh
@@ -15,6 +15,14 @@ if [ -f "$SCRIPT_DIR/.env" ]; then
     echo "[DEBUG] PYANNOTE_TOKEN이 로드되었습니다."
 fi
 
+# Ollama 기본 keep-alive(환경변수 미설정 시 기본값 1m 적용)
+if [ -z "${OLLAMA_KEEP_ALIVE:-}" ]; then
+    OLLAMA_KEEP_ALIVE="1m"
+else
+    OLLAMA_KEEP_ALIVE="${OLLAMA_KEEP_ALIVE}"
+fi
+export OLLAMA_KEEP_ALIVE
+
 # Provider 설정 정규화
 LLM_PROVIDER_VALUE="${LLM_PROVIDER:-ollama}"
 EMBEDDING_PROVIDER_VALUE="${EMBEDDING_PROVIDER:-$LLM_PROVIDER_VALUE}"

--- a/run.sh
+++ b/run.sh
@@ -220,6 +220,16 @@ echo "PyTorch 상태 확인:"
 # Ollama 서버 상태 확인 및 시작 (provider가 ollama인 경우에만)
 if [ "$NEED_OLLAMA" = "true" ]; then
     OLLAMA_BASE_URL_VALUE="${OLLAMA_BASE_URL:-http://localhost:11434}"
+    OLLAMA_HOST_VALUE="${OLLAMA_HOST:-$OLLAMA_BASE_URL_VALUE}"
+    OLLAMA_BASE_URL_NORMALIZED="${OLLAMA_BASE_URL_VALUE%/}"
+    OLLAMA_HOST_NORMALIZED="${OLLAMA_HOST_VALUE%/}"
+
+    if [ "$OLLAMA_HOST_NORMALIZED" != "$OLLAMA_BASE_URL_NORMALIZED" ]; then
+        echo "경고: OLLAMA_HOST(${OLLAMA_HOST_NORMALIZED})와 OLLAMA_BASE_URL(${OLLAMA_BASE_URL_NORMALIZED})가 다릅니다."
+        echo "Ollama 통신은 OLLAMA_BASE_URL(${OLLAMA_BASE_URL_NORMALIZED}) 기준으로 고정합니다."
+    fi
+    export OLLAMA_HOST="$OLLAMA_BASE_URL_NORMALIZED"
+
     OLLAMA_VERSION_URL="${OLLAMA_BASE_URL_VALUE%/}/api/version"
     echo "Ollama provider가 활성화되어 서버 상태를 확인합니다..."
     if ! curl -s "$OLLAMA_VERSION_URL" > /dev/null 2>&1; then

--- a/run.sh
+++ b/run.sh
@@ -36,6 +36,105 @@ fi
 # 가상환경의 Python 실행 파일 경로
 VENV_PYTHON="$SCRIPT_DIR/venv/bin/python"
 
+trim_space() {
+    printf '%s' "$1" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
+}
+
+PLATFORM_SUFFIX="UNIX"
+case "$(uname -s)" in
+    *MINGW*|*MSYS*|*CYGWIN*|*Windows*)
+        PLATFORM_SUFFIX="WINDOWS"
+        ;;
+esac
+
+TRANSCRIBE_MODEL_KEY="TRANSCRIBE_MODEL_${PLATFORM_SUFFIX}"
+SUMMARY_MODEL_KEY="SUMMARY_MODEL_${PLATFORM_SUFFIX}"
+EMBEDDING_MODEL_KEY="EMBEDDING_MODEL_${PLATFORM_SUFFIX}"
+
+if [ -f "$VENV_PYTHON" ] && [ -f "$SCRIPT_DIR/sttEngine/config.py" ]; then
+    IFS='|' read -r DEFAULT_TRANSCRIBE_MODEL DEFAULT_SUMMARY_MODEL DEFAULT_EMBEDDING_MODEL < <(
+        "$VENV_PYTHON" - <<'PY'
+from sttEngine.config import get_default_model
+
+print(f"{get_default_model('TRANSCRIBE')}|{get_default_model('SUMMARY')}|{get_default_model('EMBEDDING')}")
+PY
+    )
+else
+    DEFAULT_TRANSCRIBE_MODEL="large-v3-turbo"
+    DEFAULT_SUMMARY_MODEL="gpt-oss:20b"
+    DEFAULT_EMBEDDING_MODEL="bge-m3:latest"
+fi
+
+get_env_model() {
+    local os_key="$1"
+    local legacy_key="$2"
+    local fallback="$3"
+
+    local v="${!os_key}"
+    if [ -n "${!os_key+x}" ] && [ -n "$(trim_space "$v")" ]; then
+        echo "$(trim_space "$v")"
+        return
+    fi
+
+    if [ -n "$legacy_key" ] && [ -n "${!legacy_key+x}" ] && [ -n "$(trim_space "${!legacy_key}")" ]; then
+        echo "$(trim_space "${!legacy_key}")"
+        return
+    fi
+
+    if [ -n "$fallback" ]; then
+        echo "$fallback"
+    fi
+}
+
+SUMMARY_MODEL_RESOLVED="$(get_env_model "$SUMMARY_MODEL_KEY" "SUMMARY_MODEL" "$DEFAULT_SUMMARY_MODEL")"
+EMBEDDING_MODEL_RESOLVED="$(get_env_model "$EMBEDDING_MODEL_KEY" "EMBEDDING_MODEL" "$DEFAULT_EMBEDDING_MODEL")"
+
+check_ollama_models() {
+    local models=()
+    models=("$@")
+
+    if [ "${#models[@]}" -eq 0 ]; then
+        return 0
+    fi
+
+    if ! command -v ollama > /dev/null 2>&1; then
+        echo "오류: ollama 명령어를 찾을 수 없습니다."
+        return 1
+    fi
+
+    local installed
+    installed="$(ollama list 2>/dev/null | awk 'NR>1 {print $1}')"
+    if [ -z "$installed" ]; then
+        echo "오류: Ollama 모델 목록을 읽지 못했습니다. Ollama 서버가 실행 중인지 확인하세요."
+        return 1
+    fi
+
+    local missing=0
+    local seen=""
+
+    for model in "${models[@]}"; do
+        if [ -z "$model" ]; then
+            echo "오류: 필요 모델명이 비어 있습니다. .env에서 SUMMARY_MODEL 또는 EMBEDDING_MODEL 값을 확인하세요."
+            missing=1
+            continue
+        fi
+
+        if printf '%s\n' "$seen" | grep -Fxq "$model"; then
+            continue
+        fi
+        seen="${seen}$model\n"
+
+        if printf '%s\n' "$installed" | grep -Fxq "$model"; then
+            echo "✓ Ollama 모델 확인됨: $model"
+        else
+            echo "오류: Ollama에 모델이 없습니다: $model"
+            missing=1
+        fi
+    done
+
+    [ "$missing" -eq 0 ]
+}
+
 # 가상환경 존재 확인
 if [ ! -f "$VENV_PYTHON" ]; then
     echo "오류: 가상환경(venv)을 찾을 수 없습니다."
@@ -145,6 +244,24 @@ if [ "$NEED_OLLAMA" = "true" ]; then
     fi
 else
     echo "Ollama provider가 비활성화되어 서버 자동 시작을 건너뜁니다."
+fi
+
+if [ "$NEED_OLLAMA" = "true" ]; then
+    echo "Ollama 필수 모델 존재 여부를 확인합니다..."
+    OLLAMA_CHECK_MODELS=()
+
+    if [ "$LLM_PROVIDER_VALUE" = "ollama" ] && [ -n "$SUMMARY_MODEL_RESOLVED" ]; then
+        OLLAMA_CHECK_MODELS+=("$SUMMARY_MODEL_RESOLVED")
+    fi
+    if [ "$EMBEDDING_PROVIDER_VALUE" = "ollama" ] && [ -n "$EMBEDDING_MODEL_RESOLVED" ]; then
+        OLLAMA_CHECK_MODELS+=("$EMBEDDING_MODEL_RESOLVED")
+    fi
+
+    if ! check_ollama_models "${OLLAMA_CHECK_MODELS[@]}"; then
+        echo "필수 Ollama 모델이 준비되지 않았습니다. 서버를 시작하지 않고 종료합니다."
+        echo "설치 명령: ollama pull <모델명>"
+        exit 1
+    fi
 fi
 
 # Cloudflare Tunnel 상태 확인 및 시작

--- a/setup.bat
+++ b/setup.bat
@@ -1,20 +1,24 @@
 @echo off
+chcp 65001 >nul
 REM RecordRoute Setup Script for Windows
 REM ======================================
 
-setlocal enabledelayedexpansion
+setlocal EnableExtensions
+setlocal EnableDelayedExpansion
 
 REM Set directory to where the script is
-cd /d "%~dp0" || exit /b 1
-set SCRIPT_DIR=%cd%
+set "SCRIPT_DIR=%~dp0"
+if "%SCRIPT_DIR:~-1%"=="\" set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
 
-REM Provider 설정 정규화(.env 기준)
+REM Load .env and apply provider values
 if exist "%SCRIPT_DIR%\.env" (
-    for /f "usebackq tokens=*" %%a in ("%SCRIPT_DIR%\.env") do (
-        set "line=%%a"
-        if not "!line:~0,1!"=="#" if not "!line!"=="" set "%%a"
+    for /f "usebackq eol=# delims=" %%L in ("%SCRIPT_DIR%\.env") do (
+        set "line=%%L"
+        if /i "!line:~0,7!"=="export " set "line=!line:~7!"
+        if not "!line!"=="" set "!line!"
     )
 )
+
 set "LLM_PROVIDER_VALUE=!LLM_PROVIDER!"
 if "!LLM_PROVIDER_VALUE!"=="" set "LLM_PROVIDER_VALUE=ollama"
 set "EMBEDDING_PROVIDER_VALUE=!EMBEDDING_PROVIDER!"
@@ -37,13 +41,40 @@ REM 1. Check Python
 echo Step 0: Checking Python installation...
 
 set PY_CMD=
-where python3 >nul 2>&1
-if !errorlevel! equ 0 (
-    set "PY_CMD=python3"
-) else (
-    where python >nul 2>&1
+set PY_VER=
+set CURRENT_PY_VER=
+
+set CURRENT_PY_VER=
+for /f "delims=" %%V in ('python3 --version 2^>^&1') do set "CURRENT_PY_VER=%%V"
+if not "!CURRENT_PY_VER!"=="" (
+    echo !CURRENT_PY_VER! | findstr /r /c:"^Python [0-9]" >nul 2>&1
     if !errorlevel! equ 0 (
-        set "PY_CMD=python"
+        set "PY_CMD=python3"
+        set "PY_VER=!CURRENT_PY_VER!"
+    )
+)
+
+if not defined PY_CMD (
+    set CURRENT_PY_VER=
+    for /f "delims=" %%V in ('python --version 2^>^&1') do set "CURRENT_PY_VER=%%V"
+    if not "!CURRENT_PY_VER!"=="" (
+        echo !CURRENT_PY_VER! | findstr /r /c:"^Python [0-9]" >nul 2>&1
+        if !errorlevel! equ 0 (
+            set "PY_CMD=python"
+            set "PY_VER=!CURRENT_PY_VER!"
+        )
+    )
+)
+
+if not defined PY_CMD (
+    set CURRENT_PY_VER=
+    for /f "delims=" %%V in ('py -3 --version 2^>^&1') do set "CURRENT_PY_VER=%%V"
+    if not "!CURRENT_PY_VER!"=="" (
+        echo !CURRENT_PY_VER! | findstr /r /c:"^Python [0-9]" >nul 2>&1
+        if !errorlevel! equ 0 (
+            set "PY_CMD=py -3"
+            set "PY_VER=!CURRENT_PY_VER!"
+        )
     )
 )
 
@@ -58,7 +89,11 @@ if "!PY_CMD!"=="" (
 )
 
 echo Python 버전:
-!PY_CMD! --version
+if defined PY_VER (
+    echo !PY_VER!
+) else (
+    !PY_CMD! --version
+)
 echo.
 
 REM 2. Virtual Environment
@@ -67,9 +102,7 @@ echo.
 
 if exist "%SCRIPT_DIR%\venv" (
     echo 기존 가상환경이 발견되었습니다.
-    setlocal disableDelayedExpansion
     set /p response="기존 가상환경을 삭제하고 다시 생성하시겠습니까? (y/n): "
-    setlocal enabledelayedexpansion
     
     if /i "!response!"=="y" (
         echo 기존 venv를 삭제하고 있습니다...
@@ -181,7 +214,8 @@ echo Step 2.5: Verifying PyTorch...
 
 if "%OS%"=="Windows_NT" (
     echo PyTorch는 현재 Windows 환경에서 자동 설치를 수행하지 않습니다.
-    "!VENV_PYTHON!" -c "import torch; print('PyTorch: ' + torch.__version__); print('CUDA available: ' + str(torch.cuda.is_available() if hasattr(torch, 'cuda') else False))" 2>nul || echo [경고] PyTorch 확인에 실패했거나 설치되지 않았습니다.
+    "!VENV_PYTHON!" -c "import torch; print('PyTorch: ' + torch.__version__); print('CUDA available: ' + str(torch.cuda.is_available() if hasattr(torch, 'cuda') else False))" 2>nul
+    if !errorlevel! neq 0 echo [경고] PyTorch 확인에 실패했거나 설치되지 않았습니다.
 ) else (
     set "TORCH_CUDA_AVAILABLE="
     "!VENV_PYTHON!" -c "import torch; print(f'PyTorch: {torch.__version__}'); torch.cuda.is_available() and print('CUDA available')" >"%TEMP%\recordroute_torch_check.txt" 2>nul
@@ -197,7 +231,8 @@ if "%OS%"=="Windows_NT" (
         )
     )
     del /q "%TEMP%\recordroute_torch_check.txt" 2>nul
-    "!VENV_PYTHON!" -c "import torch; print('PyTorch: ' + torch.__version__); print('CUDA available: ' + str(torch.cuda.is_available() if hasattr(torch, 'cuda') else False))" 2>nul || echo [경고] PyTorch 확인에 실패했거나 설치되지 않았습니다.
+    "!VENV_PYTHON!" -c "import torch; print('PyTorch: ' + torch.__version__); print('CUDA available: ' + str(torch.cuda.is_available() if hasattr(torch, 'cuda') else False))" 2>nul
+    if !errorlevel! neq 0 echo [경고] PyTorch 확인에 실패했거나 설치되지 않았습니다.
 )
 echo.
 

--- a/setup.bat
+++ b/setup.bat
@@ -37,18 +37,13 @@ REM 1. Check Python
 echo Step 0: Checking Python installation...
 
 set PY_CMD=
-where py >nul 2>&1
+where python3 >nul 2>&1
 if !errorlevel! equ 0 (
-    set "PY_CMD=py -3"
+    set "PY_CMD=python3"
 ) else (
     where python >nul 2>&1
     if !errorlevel! equ 0 (
-        set PY_CMD=python
-    ) else (
-        where python3 >nul 2>&1
-        if !errorlevel! equ 0 (
-            set PY_CMD=python3
-        )
+        set "PY_CMD=python"
     )
 )
 
@@ -81,7 +76,7 @@ if exist "%SCRIPT_DIR%\venv" (
         rmdir /s /q "%SCRIPT_DIR%\venv"
 
         if exist "%SCRIPT_DIR%\venv" (
-            echo venv 사용 중인 Python 프로세스를 종료한 뒤 삭제를 재시도합니다...
+        echo venv 사용 중인 Python 프로세스를 종료한 뒤 삭제를 재시도합니다...
             powershell -NoProfile -ExecutionPolicy Bypass -Command "$venv=(Resolve-Path '%SCRIPT_DIR%\venv').Path; Get-CimInstance Win32_Process | Where-Object { $_.ExecutablePath -and $_.ExecutablePath.StartsWith($venv, [System.StringComparison]::OrdinalIgnoreCase) } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }" >nul 2>&1
             timeout /t 1 /nobreak >nul
             rmdir /s /q "%SCRIPT_DIR%\venv"
@@ -140,14 +135,6 @@ if not exist "%SCRIPT_DIR%\venv\Scripts\python.exe" (
     exit /b 1
 )
 
-if not exist "%SCRIPT_DIR%\venv\pyvenv.cfg" (
-    echo.
-    echo [오류] pyvenv.cfg를 찾을 수 없습니다. 가상환경이 손상되었을 수 있습니다.
-    echo.
-    pause
-    exit /b 1
-)
-
 set VENV_PYTHON=%SCRIPT_DIR%\venv\Scripts\python.exe
 
 echo 가상환경이 성공적으로 생성되었습니다.
@@ -192,22 +179,26 @@ if /i "!NEED_OLLAMA!"=="true" if exist "%SCRIPT_DIR%\requirements-ollama.txt" (
 REM 3.5 PyTorch Verification
 echo Step 2.5: Verifying PyTorch...
 
-"!VENV_PYTHON!" -c "import torch; print('PyTorch: ' + torch.__version__); print('CUDA available: ' + str(torch.cuda.is_available()))" >nul 2>&1
-
-if !errorlevel! equ 0 (
-    echo PyTorch가 설치되어 있습니다.
+if "%OS%"=="Windows_NT" (
+    echo PyTorch는 현재 Windows 환경에서 자동 설치를 수행하지 않습니다.
+    "!VENV_PYTHON!" -c "import torch; print('PyTorch: ' + torch.__version__); print('CUDA available: ' + str(torch.cuda.is_available() if hasattr(torch, 'cuda') else False))" 2>nul || echo [경고] PyTorch 확인에 실패했거나 설치되지 않았습니다.
 ) else (
-    echo PyTorch가 설치되지 않았거나 CUDA 지원이 없습니다.
-    echo CUDA 지원을 포함한 PyTorch를 설치하고 있습니다...
-    "!VENV_PYTHON!" -m pip install --upgrade --index-url https://download.pytorch.org/whl/cu124 torch torchvision torchaudio
-    
+    set "TORCH_CUDA_AVAILABLE="
+    "!VENV_PYTHON!" -c "import torch; print(f'PyTorch: {torch.__version__}'); torch.cuda.is_available() and print('CUDA available')" >"%TEMP%\recordroute_torch_check.txt" 2>nul
     if !errorlevel! neq 0 (
-        echo [경고] CUDA 빌드 설치에 실패했습니다. 기본 빌드를 설치합니다...
-        "!VENV_PYTHON!" -m pip install --upgrade torch torchvision torchaudio
+        echo CUDA available not detected. Attempting to install PyTorch with CUDA support...
+        "!VENV_PYTHON!" -m pip install --upgrade --index-url https://download.pytorch.org/whl/cu118 torch torchvision torchaudio
+    ) else (
+        findstr /r "CUDA available" "%TEMP%\recordroute_torch_check.txt" >nul
+        if !errorlevel! neq 0 (
+            echo CUDA not available or PyTorch not installed with CUDA support.
+            echo Attempting to install PyTorch with CUDA support...
+            "!VENV_PYTHON!" -m pip install --upgrade --index-url https://download.pytorch.org/whl/cu118 torch torchvision torchaudio
+        )
     )
+    del /q "%TEMP%\recordroute_torch_check.txt" 2>nul
+    "!VENV_PYTHON!" -c "import torch; print('PyTorch: ' + torch.__version__); print('CUDA available: ' + str(torch.cuda.is_available() if hasattr(torch, 'cuda') else False))" 2>nul || echo [경고] PyTorch 확인에 실패했거나 설치되지 않았습니다.
 )
-
-"!VENV_PYTHON!" -c "import torch; print('PyTorch: ' + torch.__version__); print('CUDA available: ' + str(torch.cuda.is_available()))" 2>nul || echo [경고] PyTorch 확인에 실패했거나 설치되지 않았습니다.
 echo.
 
 REM 4. Ollama Check
@@ -298,4 +289,3 @@ echo run.bat를 실행하여 서버를 시작할 수 있습니다.
 echo.
 
 endlocal
-pause

--- a/sttEngine/config.py
+++ b/sttEngine/config.py
@@ -137,8 +137,19 @@ def _resolve_db_path(path_value: str, base_dir: Path) -> Optional[Path]:
 
 
 def _normalize_db_folder_env(path_value: str) -> str:
-    """DB_FOLDER_PATH 값의 앞뒤 공백만 제거하고 따옴표는 보존."""
-    return path_value.strip() if path_value else path_value
+    """환경변수로 받은 DB 폴더 경로에서 외부 인용부호만 제거."""
+    if not path_value:
+        return path_value
+
+    normalized = path_value.strip()
+
+    while len(normalized) >= 2 and (
+        (normalized[0] == normalized[-1] == '"')
+        or (normalized[0] == normalized[-1] == "'")
+    ):
+        normalized = normalized[1:-1].strip()
+
+    return normalized
 
 
 def _ensure_directory_accessible(path: Path, *, create_if_missing: bool = True) -> bool:

--- a/sttEngine/config.py
+++ b/sttEngine/config.py
@@ -136,6 +136,11 @@ def _resolve_db_path(path_value: str, base_dir: Path) -> Optional[Path]:
         return None
 
 
+def _normalize_db_folder_env(path_value: str) -> str:
+    """DB_FOLDER_PATH 값의 앞뒤 공백만 제거하고 따옴표는 보존."""
+    return path_value.strip() if path_value else path_value
+
+
 def _ensure_directory_accessible(path: Path, *, create_if_missing: bool = True) -> bool:
     """경로가 디렉터리로 접근 가능한지 확인
 
@@ -160,13 +165,15 @@ def _ensure_directory_accessible(path: Path, *, create_if_missing: bool = True) 
 
 def get_db_base_path(base_dir: Optional[Path] = None) -> Path:
     """환경변수 기반 DB 폴더 경로 반환 (접근 불가 시 기본값 생성 후 사용)"""
+    project_root = get_project_root()
     if base_dir is None:
-        base_dir = get_project_root()
+        base_dir = project_root
 
-    env_value = os.getenv("DB_FOLDER_PATH")
+    env_value = _normalize_db_folder_env(os.getenv("DB_FOLDER_PATH") or "")
 
     if env_value:
-        env_path = _resolve_db_path(env_value, base_dir)
+        # DB_FOLDER_PATH 환경변수 값은 프로젝트 코드베이스 기준 상대 경로로 해석.
+        env_path = _resolve_db_path(env_value, project_root)
         if env_path:
             if _ensure_directory_accessible(env_path, create_if_missing=False):
                 return env_path

--- a/sttEngine/http_api/registry.py
+++ b/sttEngine/http_api/registry.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import uuid
 from datetime import datetime
 from pathlib import Path
 
-from ..one_line_summary import generate_one_line_summary
+from ..one_line_summary import OneLineSummaryError, generate_one_line_summary
 from .history import load_upload_history, save_upload_history
 from .paths import FILE_REGISTRY_FILE, normalize_record_path, resolve_record_path
 
@@ -229,19 +230,33 @@ def update_filename(record_id: str, new_filename: str) -> None:
     save_upload_history(history)
 
 
+LOGGER = logging.getLogger(__name__)
+
+
 def generate_and_store_title_summary(
     record_id: str,
     file_path: Path,
     model: str | None = None,
     provider_name: str | None = None,
-) -> None:
+) -> str:
     """Generate one-line summary and store it."""
     try:
         summary = generate_one_line_summary(
             file_path,
             model=model,
             provider_name=provider_name,
-        )
+        ).strip()
+        if not summary:
+            raise OneLineSummaryError("한줄요약 결과가 비어 있습니다.")
         update_title_summary(record_id, summary)
+        return summary
     except Exception as e:
-        print(f"One-line summary generation failed: {e}")
+        LOGGER.warning(
+            "One-line summary generation failed: record_id=%s file_path=%s provider=%s model=%s error=%s",
+            record_id,
+            file_path,
+            provider_name,
+            model,
+            e,
+        )
+        raise

--- a/sttEngine/http_api/registry.py
+++ b/sttEngine/http_api/registry.py
@@ -229,10 +229,19 @@ def update_filename(record_id: str, new_filename: str) -> None:
     save_upload_history(history)
 
 
-def generate_and_store_title_summary(record_id: str, file_path: Path, model: str | None = None) -> None:
+def generate_and_store_title_summary(
+    record_id: str,
+    file_path: Path,
+    model: str | None = None,
+    provider_name: str | None = None,
+) -> None:
     """Generate one-line summary and store it."""
     try:
-        summary = generate_one_line_summary(file_path, model=model)
+        summary = generate_one_line_summary(
+            file_path,
+            model=model,
+            provider_name=provider_name,
+        )
         update_title_summary(record_id, summary)
     except Exception as e:
         print(f"One-line summary generation failed: {e}")

--- a/sttEngine/http_api/routes/admin_routes.py
+++ b/sttEngine/http_api/routes/admin_routes.py
@@ -10,6 +10,24 @@ from ...providers.factory import get_llm_provider
 from ..destructive_guard import check_destructive_api_access, reject_destructive_api_request
 
 
+EMBEDDING_NAME_HINTS = (
+    "bge",
+    "embed",
+    "embedding",
+    "e5",
+    "jina",
+    "gte",
+    "mxbai",
+    "nomic",
+    "sentence",
+)
+
+
+def _is_embedding_like_model(model_name: str) -> bool:
+    lowered = (model_name or "").lower()
+    return any(hint in lowered for hint in EMBEDDING_NAME_HINTS)
+
+
 def _serve_available_models(handler, provider_name: str | None = None) -> None:
     try:
         provider_aliases = {
@@ -42,6 +60,20 @@ def _serve_available_models(handler, provider_name: str | None = None) -> None:
                 provider_status[resolved_provider] = {'ok': False, 'message': str(provider_exc)}
 
         models = provider_models.get(requested_provider, [])
+        models_by_task = {
+            "summary": list(dict.fromkeys(models)),
+            "embedding": list(dict.fromkeys(models)),
+        }
+
+        if requested_provider == "ollama" and models:
+            embedding_hint = [m for m in models if _is_embedding_like_model(m)]
+            if embedding_hint:
+                models_by_task["embedding"] = list(dict.fromkeys(embedding_hint))
+                summary_hint = [m for m in models if m not in models_by_task["embedding"]]
+                if summary_hint:
+                    models_by_task["summary"] = list(dict.fromkeys(summary_hint))
+                elif models_by_task["summary"]:
+                    models_by_task["summary"] = models_by_task["summary"]
 
         from ...workflow.summarize import DEFAULT_MODEL
         from ...config import get_default_model
@@ -50,6 +82,7 @@ def _serve_available_models(handler, provider_name: str | None = None) -> None:
             'models': models,
             'models_by_provider': provider_models,
             'provider_status': provider_status,
+            'models_by_task': models_by_task,
             'default': {
                 'whisper': 'large-v3-turbo',
                 'summarize': DEFAULT_MODEL,

--- a/sttEngine/http_api/workflow.py
+++ b/sttEngine/http_api/workflow.py
@@ -736,12 +736,20 @@ def run_workflow(
                 file_path_str = to_record_path(summary_file)
                 update_task_completion(record_id, "summary", file_path_str)
                 if source_text_path:
-                    generate_and_store_title_summary(
-                        record_id,
-                        source_text_path,
-                        summarize_model,
-                        (model_settings or {}).get("provider") or (model_settings or {}).get("llm_provider"),
-                    )
+                    try:
+                        generate_and_store_title_summary(
+                            record_id,
+                            source_text_path,
+                            summarize_model,
+                            (model_settings or {}).get("provider") or (model_settings or {}).get("llm_provider"),
+                        )
+                    except Exception as title_summary_error:
+                        if task_id:
+                            update_task_progress(
+                                task_id,
+                                f"한줄요약 생성 실패(요약 결과는 저장됨): {title_summary_error}",
+                                stage=TaskStage.SUMMARY,
+                            )
             record_step_metric("summary", "completed", summary_started_at)
 
     except Exception as exc:  # pragma: no cover

--- a/sttEngine/http_api/workflow.py
+++ b/sttEngine/http_api/workflow.py
@@ -736,7 +736,12 @@ def run_workflow(
                 file_path_str = to_record_path(summary_file)
                 update_task_completion(record_id, "summary", file_path_str)
                 if source_text_path:
-                    generate_and_store_title_summary(record_id, source_text_path, summarize_model)
+                    generate_and_store_title_summary(
+                        record_id,
+                        source_text_path,
+                        summarize_model,
+                        (model_settings or {}).get("provider") or (model_settings or {}).get("llm_provider"),
+                    )
             record_step_metric("summary", "completed", summary_started_at)
 
     except Exception as exc:  # pragma: no cover

--- a/sttEngine/obsidian_mcp.py
+++ b/sttEngine/obsidian_mcp.py
@@ -8,7 +8,9 @@ STT 및 요약 텍스트를 Obsidian Vault에 자동으로 전송하는 기능 �
 
 import asyncio
 import os
+import shlex
 from datetime import datetime
+import shutil
 from pathlib import Path
 from typing import Optional, Dict, Any
 from mcp import ClientSession, StdioServerParameters
@@ -34,7 +36,7 @@ class ObsidianMCPIntegration:
         self.enabled = requested_enabled
         self.server_path = os.getenv("OBSIDIAN_MCP_SERVER_PATH")
         self.api_key = os.getenv("OBSIDIAN_API_KEY")
-        self.vault_folder = os.getenv("OBSIDIAN_VAULT_FOLDER", "RecordRoute")
+        self.vault_folder = self._normalize_vault_folder(os.getenv("OBSIDIAN_VAULT_FOLDER", "RecordRoute"))
 
         # 설정 검증
         if self.enabled:
@@ -44,6 +46,70 @@ class ObsidianMCPIntegration:
             if not self.api_key:
                 print("[Obsidian MCP] WARNING: OBSIDIAN_API_KEY가 설정되지 않았습니다.")
                 self.enabled = False
+
+        # 경로 정규화 결과 로그
+        if self.enabled and self.server_path:
+            resolved = self._resolve_server_path(self.server_path)
+            if resolved:
+                if Path(resolved).is_file() and os.access(resolved, os.X_OK):
+                    print(f"[Obsidian MCP] server_path resolved: {resolved}")
+                else:
+                    print(f"[Obsidian MCP] WARNING: MCP 서버 경로 접근 또는 실행 권한 문제: {self.server_path}")
+                    self.enabled = False
+            else:
+                print(f"[Obsidian MCP] WARNING: MCP 서버 경로를 해석할 수 없습니다: {self.server_path}")
+                self.enabled = False
+
+    @staticmethod
+    def _normalize_server_path(raw_path: str) -> str:
+        """환경변수에 들어온 MCP 경로 문자열을 정규화합니다."""
+        if raw_path is None:
+            return ""
+        return os.path.expanduser(os.path.expandvars(raw_path.strip().strip("'").strip('"')))
+
+    @staticmethod
+    def _normalize_vault_folder(raw_folder: str) -> str:
+        if not raw_folder:
+            return "RecordRoute"
+        return os.path.expanduser(os.path.expandvars(str(raw_folder).strip().strip("'").strip('"')))
+
+    @staticmethod
+    def _resolve_server_path(raw_path: str) -> str:
+        """
+        MCP 실행 파일 경로를 해석합니다.
+        - 환경변수 확장/사용자 홈 확장
+        - shlex split로 명령+인자 분리 시 첫 토큰만 해석
+        - 상대 경로를 현재 작업 디렉터리와 프로젝트 루트에서 보정
+        - PATH 탐색(명령만 지정한 경우) 지원
+        """
+        base_dir = Path(__file__).resolve().parents[1]
+        parts = shlex.split(raw_path)
+        if not parts:
+            return ""
+
+        command = ObsidianMCPIntegration._normalize_server_path(parts[0])
+        candidate_paths = [Path(command)]
+
+        if not candidate_paths[0].is_absolute():
+            candidate_paths.append((Path.cwd() / command).resolve())
+            candidate_paths.append((base_dir / command).resolve())
+
+        for candidate in candidate_paths:
+            if candidate.exists():
+                return str(candidate)
+
+        which_path = shutil.which(command)
+        return which_path or ""
+
+    @staticmethod
+    def _split_server_command(raw_path: str) -> tuple[str, list[str]]:
+        """
+        MCP 서버 경로/명령어를 실제 command/args로 분리합니다.
+        """
+        parts = shlex.split(raw_path.strip())
+        if not parts:
+            return "", []
+        return parts[0], parts[1:]
 
     def _generate_frontmatter(self, filename: str, uuid: str, created_at: datetime) -> str:
         """
@@ -75,18 +141,29 @@ aliases:
         """MCP 서버 파라미터 생성"""
         # Windows 경로 정규화
         import platform
-        server_path = self.server_path
+        command, args = self._split_server_command(self.server_path or "")
+        server_path = self._resolve_server_path(command)
+
+        if not server_path:
+            raise FileNotFoundError(f"MCP 서버 경로를 찾을 수 없습니다: {self.server_path}")
+
+        if not Path(server_path).is_file():
+            raise FileNotFoundError(f"MCP 서버 실행 파일이 아닙니다: {server_path}")
+        if not os.access(server_path, os.X_OK):
+            raise PermissionError(f"MCP 서버 실행 권한이 없습니다: {server_path}")
+
         if platform.system() == "Windows":
             # Windows 경로를 정규화 (백슬래시 유지)
             server_path = os.path.normpath(server_path)
 
         return StdioServerParameters(
             command=server_path,
-            args=[],
+            args=args,
             env={
                 "OBSIDIAN_API_KEY": self.api_key,
                 "PATH": os.getenv("PATH", "")
-            }
+            },
+            cwd=Path(server_path).parent
         )
 
     async def _file_exists(self, session: ClientSession, original_filename: str) -> bool:
@@ -102,7 +179,7 @@ aliases:
         """
         # 원본 파일명에서 확장자 제거하고 .md 추가
         filename_without_ext = Path(original_filename).stem
-        filename = f"{self.vault_folder}/{filename_without_ext}.md"
+        filename = str(Path(self.vault_folder) / f"{filename_without_ext}.md")
         try:
             await session.call_tool("get_vault_file", {"filename": filename})
             return True
@@ -143,7 +220,7 @@ aliases:
 
         # 원본 파일명에서 확장자 제거하고 .md 추가
         filename_without_ext = Path(original_filename).stem
-        filename = f"{self.vault_folder}/{filename_without_ext}.md"
+        filename = str(Path(self.vault_folder) / f"{filename_without_ext}.md")
 
         try:
             server_params = await self._get_server_params()
@@ -188,6 +265,14 @@ aliases:
             error_msg = f"MCP 서버를 찾을 수 없습니다: {self.server_path}"
             print(f"[Obsidian MCP] ✗ {error_msg}")
             print(f"[Obsidian MCP] 힌트: OBSIDIAN_MCP_SERVER_PATH 환경변수를 확인하세요.")
+            return {
+                "success": False,
+                "message": error_msg,
+                "action": "failed"
+            }
+        except PermissionError as e:
+            error_msg = f"MCP 서버 실행 권한이 없습니다: {self.server_path} ({str(e)})"
+            print(f"[Obsidian MCP] ✗ {error_msg}")
             return {
                 "success": False,
                 "message": error_msg,
@@ -241,7 +326,7 @@ aliases:
 
         # 원본 파일명에서 확장자 제거하고 .md 추가
         filename_without_ext = Path(original_filename).stem
-        filename = f"{self.vault_folder}/{filename_without_ext}.md"
+        filename = str(Path(self.vault_folder) / f"{filename_without_ext}.md")
 
         try:
             server_params = await self._get_server_params()
@@ -287,6 +372,14 @@ aliases:
             error_msg = f"MCP 서버를 찾을 수 없습니다: {self.server_path}"
             print(f"[Obsidian MCP] ✗ {error_msg}")
             print(f"[Obsidian MCP] 힌트: OBSIDIAN_MCP_SERVER_PATH 환경변수를 확인하세요.")
+            return {
+                "success": False,
+                "message": error_msg,
+                "action": "failed"
+            }
+        except PermissionError as e:
+            error_msg = f"MCP 서버 실행 권한이 없습니다: {self.server_path} ({str(e)})"
+            print(f"[Obsidian MCP] ✗ {error_msg}")
             return {
                 "success": False,
                 "message": error_msg,

--- a/sttEngine/obsidian_mcp.py
+++ b/sttEngine/obsidian_mcp.py
@@ -19,10 +19,6 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-# MCP 동작 방향성 재정렬 전까지는 전역 비활성화 상태를 유지한다.
-_MCP_TEMPORARILY_DISABLED = True
-
-
 class ObsidianMCPIntegration:
     """Obsidian MCP 서버와 통신하여 파일을 생성/업데이트하는 클래스"""
 
@@ -35,13 +31,10 @@ class ObsidianMCPIntegration:
         - OBSIDIAN_VAULT_FOLDER: Vault 내 저장 폴더 경로
         """
         requested_enabled = os.getenv("OBSIDIAN_MCP_ENABLED", "false").lower() == "true"
-        self.enabled = requested_enabled and not _MCP_TEMPORARILY_DISABLED
+        self.enabled = requested_enabled
         self.server_path = os.getenv("OBSIDIAN_MCP_SERVER_PATH")
         self.api_key = os.getenv("OBSIDIAN_API_KEY")
         self.vault_folder = os.getenv("OBSIDIAN_VAULT_FOLDER", "RecordRoute")
-
-        if requested_enabled and _MCP_TEMPORARILY_DISABLED:
-            print("[Obsidian MCP] INFO: 임시 비활성화 상태입니다. TODO 항목 완료 전까지 전송을 건너뜁니다.")
 
         # 설정 검증
         if self.enabled:
@@ -141,7 +134,7 @@ aliases:
         if not self.enabled:
             return {
                 "success": False,
-                "message": "Obsidian MCP가 임시 비활성화되어 있습니다.",
+                "message": "Obsidian MCP가 비활성화되어 있습니다.",
                 "action": "skipped"
             }
 
@@ -239,7 +232,7 @@ aliases:
         if not self.enabled:
             return {
                 "success": False,
-                "message": "Obsidian MCP가 임시 비활성화되어 있습니다.",
+                "message": "Obsidian MCP가 비활성화되어 있습니다.",
                 "action": "skipped"
             }
 

--- a/sttEngine/one_line_summary.py
+++ b/sttEngine/one_line_summary.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any, Dict
 
-from .llm_provider import map_llm_options, normalize_provider_name
-from .providers.factory import get_llm_provider
+from .llm_provider import chat_completion, map_llm_options, normalize_provider_name
 from .workflow.summarize import DEFAULT_MODEL, read_text_with_fallback
+
+LOGGER = logging.getLogger(__name__)
+_MAX_SOURCE_CHARS = 4000
+
+
+class OneLineSummaryError(RuntimeError):
+    """Raised when the one-line summary could not be generated."""
 
 
 def _extract_summary_line(response: Dict[str, Any]) -> str:
@@ -27,10 +34,31 @@ def _extract_summary_line(response: Dict[str, Any]) -> str:
         return ""
 
     for line in raw_text.strip().splitlines():
-        stripped = line.strip()
-        if stripped:
+        stripped = line.strip().lstrip("-*•0123456789. ")
+        if stripped and not stripped.lower().startswith("요약:"):
             return stripped
+        if stripped:
+            return stripped.removeprefix("요약:").strip()
     return ""
+
+
+def build_one_line_summary_prompt(text: str) -> str:
+    """Build a compact prompt tailored for list-title summaries."""
+    source = (text or "").strip()
+    if not source:
+        raise OneLineSummaryError("한줄요약 입력 텍스트가 비어 있습니다.")
+
+    return (
+        "당신은 문서 목록에 표시할 제목형 한줄요약을 작성합니다.\n"
+        "규칙:\n"
+        "- 반드시 한국어 한 줄만 출력합니다.\n"
+        "- 30~60자 내외로 작성합니다.\n"
+        "- 불렛, 번호, 따옴표, 접두어(예: 요약:)를 쓰지 않습니다.\n"
+        "- 핵심 주제를 제목처럼 간결하게 표현합니다.\n\n"
+        "원문:\n"
+        f"{source[:_MAX_SOURCE_CHARS]}"
+    )
+
 
 
 def generate_one_line_summary(file_path: Path, model: str | None = None, provider_name: str | None = None) -> str:
@@ -42,18 +70,31 @@ def generate_one_line_summary(file_path: Path, model: str | None = None, provide
         provider_name: Optional provider override (`ollama`/`llamacpp`).
 
     Returns:
-        A one-line summary string. Returns empty string when provider response is empty.
+        A one-line summary string.
+
+    Raises:
+        OneLineSummaryError: When the provider response is empty or malformed.
     """
     text = read_text_with_fallback(file_path)
-    prompt = "다음 텍스트를 한 줄로 한국어로 요약해 주세요:\n" + text[:4000]
+    prompt = build_one_line_summary_prompt(text)
 
     resolved_provider = normalize_provider_name(provider_name)
-    provider = get_llm_provider(resolved_provider)
-    options = map_llm_options({"temperature": 0}, provider_name=resolved_provider)
-
-    response = provider.generate(
-        model=model or DEFAULT_MODEL,
-        prompt=prompt,
-        options=options,
+    options = map_llm_options(
+        {
+            "temperature": 0,
+            "max_tokens": 120,
+        },
+        provider_name=resolved_provider,
     )
-    return _extract_summary_line(response)
+
+    response = chat_completion(
+        model=model or DEFAULT_MODEL,
+        messages=[{"role": "user", "content": prompt}],
+        options=options,
+        provider_name=resolved_provider,
+    )
+    summary_line = _extract_summary_line(response)
+    if not summary_line:
+        LOGGER.warning("한줄요약 응답이 비어 있습니다: provider=%s model=%s", resolved_provider, model or DEFAULT_MODEL)
+        raise OneLineSummaryError("한줄요약 응답이 비어 있습니다.")
+    return summary_line

--- a/sttEngine/providers/ollama_provider.py
+++ b/sttEngine/providers/ollama_provider.py
@@ -59,13 +59,32 @@ class OllamaLLMProvider(BaseLLMProvider):
     def list_models(self) -> List[str]:
         ollama = self._load_ollama()
         models = safe_ollama_call(ollama.list)
-        items = models.get("models", []) if isinstance(models, dict) else []
+        payload: Any = models
+        if hasattr(payload, "model_dump"):
+            payload = payload.model_dump()
+
+        if isinstance(payload, Mapping):
+            payload = dict(payload)
+            items = payload.get("models", [])
+        else:
+            items = getattr(payload, "models", [])
+
         names: list[str] = []
         for model in items:
-            if isinstance(model, dict):
-                name = model.get("name")
-                if name:
-                    names.append(name)
+            name = None
+            if isinstance(model, str):
+                name = model
+            elif isinstance(model, Mapping):
+                name = model.get("name") or model.get("model")
+            elif hasattr(model, "name"):
+                name = getattr(model, "name")
+            elif hasattr(model, "model"):
+                name = getattr(model, "model")
+            else:
+                name = None
+
+            if name:
+                names.append(str(name))
         return names
 
     def healthcheck(self) -> tuple[bool, str]:

--- a/sttEngine/providers/ollama_provider.py
+++ b/sttEngine/providers/ollama_provider.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, Dict, List, Optional, Sequence
 
+import logging
 import numpy as np
 
-from ..ollama_utils import ensure_ollama_server, safe_ollama_call
+from ..ollama_utils import ensure_ollama_server, get_ollama_base_url, safe_ollama_call
 from .base import ProviderRequestError
 from .embedding_provider import BaseEmbeddingProvider
 from .llm_provider import BaseLLMProvider
@@ -17,7 +18,7 @@ class OllamaLLMProvider(BaseLLMProvider):
             import ollama
         except ImportError as exc:
             raise ProviderRequestError("ollama 패키지가 설치되지 않았습니다.") from exc
-        return ollama
+        return ollama.Client(host=get_ollama_base_url())
 
     def chat(
         self,
@@ -77,7 +78,7 @@ class OllamaEmbeddingProvider(BaseEmbeddingProvider):
             import ollama
         except ImportError as exc:
             raise ProviderRequestError("ollama 패키지가 설치되지 않았습니다.") from exc
-        return ollama
+        return ollama.Client(host=get_ollama_base_url())
 
     def embed(self, text: str, *, model: str) -> np.ndarray:
         ollama = self._load_ollama()
@@ -90,10 +91,20 @@ class OllamaEmbeddingProvider(BaseEmbeddingProvider):
         return np.array(embedding, dtype=np.float32)
 
     def _request_embedding(self, ollama: Any, *, text: str, model: str) -> Any:
+        if hasattr(ollama, "embeddings"):
+            try:
+                return safe_ollama_call(ollama.embeddings, model=model, prompt=text)
+            except Exception as exc:
+                # 일부 환경에서는 /api/embeddings 대신 /api/embed를 사용하는 클라이언트/서버 조합이 있습니다.
+                # 먼저 /api/embeddings로 시도하고 실패하면 /api/embed로 폴백합니다.
+                if hasattr(ollama, "embed"):
+                    logging.getLogger(__name__).warning(
+                        "Ollama embeddings 호출 실패, embed API로 폴백합니다: %s", exc
+                    )
+                    return safe_ollama_call(ollama.embed, model=model, input=text)
+                raise
         if hasattr(ollama, "embed"):
             return safe_ollama_call(ollama.embed, model=model, input=text)
-        if hasattr(ollama, "embeddings"):
-            return safe_ollama_call(ollama.embeddings, model=model, prompt=text)
         raise ProviderRequestError("현재 ollama 클라이언트에서 임베딩 API를 찾을 수 없습니다.")
 
     @staticmethod

--- a/sttEngine/run.bat
+++ b/sttEngine/run.bat
@@ -17,6 +17,8 @@ if exist ".env" (
     echo [DEBUG] 환경변수가 로드되었습니다.
 )
 
+if not defined OLLAMA_KEEP_ALIVE set "OLLAMA_KEEP_ALIVE=1m"
+
 REM 가상환경의 Python 실행 파일 경로
 set "VENV_PYTHON=%SCRIPT_DIR%venv\Scripts\python.exe"
 

--- a/tests/http_api/test_workflow.py
+++ b/tests/http_api/test_workflow.py
@@ -86,6 +86,80 @@ def test_workflow_passes_provider_to_correct_and_summary(monkeypatch, tmp_path: 
     assert called["summary"]["provider_name"] == "llamacpp"
 
 
+
+
+def test_workflow_summary_generates_title_summary_as_byproduct(monkeypatch, tmp_path: Path, temp_workflow_dirs):
+    upload_dir = tmp_path / "uploads" / "task-title-summary"
+    upload_dir.mkdir(parents=True)
+    source = upload_dir / "note.txt"
+    source.write_text("테스트 텍스트", encoding="utf-8")
+
+    history_state = [{"id": "record-1", "title_summary": "", "completed_tasks": {}, "download_links": {}}]
+
+    monkeypatch.setattr("sttEngine.http_api.workflow.summarize_text_mapreduce", lambda **_kwargs: "구조화 요약 결과")
+    monkeypatch.setattr("sttEngine.http_api.workflow.save_output", lambda content, path, as_json=False: path.write_text(content, encoding="utf-8"))
+    monkeypatch.setattr("sttEngine.http_api.workflow.send_summary_to_obsidian_sync", lambda **_kwargs: {"success": False, "message": "disabled"})
+    monkeypatch.setattr("sttEngine.http_api.workflow.update_task_progress", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("sttEngine.http_api.workflow.clear_task_progress", lambda _id: None)
+    monkeypatch.setattr("sttEngine.http_api.workflow.is_task_cancelled", lambda _id: False)
+    monkeypatch.setattr("sttEngine.http_api.workflow.load_upload_history", lambda: history_state)
+
+    stored: dict[str, object] = {}
+
+    def fake_generate_and_store_title_summary(record_id, file_path, model=None, provider_name=None):
+        stored["record_id"] = record_id
+        stored["file_path"] = file_path
+        stored["model"] = model
+        stored["provider_name"] = provider_name
+        history_state[0]["title_summary"] = "후처리 한줄요약"
+        return "후처리 한줄요약"
+
+    monkeypatch.setattr("sttEngine.http_api.workflow.generate_and_store_title_summary", fake_generate_and_store_title_summary)
+    monkeypatch.setattr("sttEngine.http_api.workflow.update_task_completion", lambda *_args, **_kwargs: "file-uuid")
+
+    result = run_workflow(
+        source,
+        ["summary"],
+        record_id="record-1",
+        task_id="task-title-summary",
+        model_settings={"provider": "llamacpp", "summarize": "model.gguf"},
+    )
+
+    assert result["summary"].endswith("note.summary.md")
+    assert stored["record_id"] == "record-1"
+    assert stored["file_path"].name == "note.md"
+    assert "whisper_output" in str(stored["file_path"])
+    assert stored["model"] == "model.gguf"
+    assert stored["provider_name"] == "llamacpp"
+    assert history_state[0]["title_summary"] == "후처리 한줄요약"
+
+
+def test_workflow_title_summary_failure_keeps_summary_success(monkeypatch, tmp_path: Path, temp_workflow_dirs):
+    upload_dir = tmp_path / "uploads" / "task-title-summary-fail"
+    upload_dir.mkdir(parents=True)
+    source = upload_dir / "note.txt"
+    source.write_text("테스트 텍스트", encoding="utf-8")
+
+    progress_messages: list[str] = []
+
+    monkeypatch.setattr("sttEngine.http_api.workflow.summarize_text_mapreduce", lambda **_kwargs: "구조화 요약 결과")
+    monkeypatch.setattr("sttEngine.http_api.workflow.save_output", lambda content, path, as_json=False: path.write_text(content, encoding="utf-8"))
+    monkeypatch.setattr("sttEngine.http_api.workflow.send_summary_to_obsidian_sync", lambda **_kwargs: {"success": False, "message": "disabled"})
+    monkeypatch.setattr("sttEngine.http_api.workflow.update_task_progress", lambda _id, msg, **_kwargs: progress_messages.append(msg))
+    monkeypatch.setattr("sttEngine.http_api.workflow.clear_task_progress", lambda _id: None)
+    monkeypatch.setattr("sttEngine.http_api.workflow.is_task_cancelled", lambda _id: False)
+    monkeypatch.setattr("sttEngine.http_api.workflow.update_task_completion", lambda *_args, **_kwargs: "file-uuid")
+    monkeypatch.setattr(
+        "sttEngine.http_api.workflow.generate_and_store_title_summary",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("llm timeout")),
+    )
+
+    result = run_workflow(source, ["summary"], record_id="record-2", task_id="task-title-summary-fail")
+
+    assert result["summary"].endswith("note.summary.md")
+    assert not any(msg.startswith("요약 생성 실패:") for msg in progress_messages)
+    assert any("한줄요약 생성 실패(요약 결과는 저장됨): llm timeout" == msg for msg in progress_messages)
+
 def test_workflow_diarization_failure_contract_returns_standard_error_fields(monkeypatch):
     progress_payloads: list[dict[str, object]] = []
 

--- a/tests/test_one_line_summary.py
+++ b/tests/test_one_line_summary.py
@@ -2,17 +2,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from sttEngine.one_line_summary import _extract_summary_line, generate_one_line_summary
+import pytest
 
-
-class _DummyProvider:
-    def __init__(self, payload):
-        self.payload = payload
-        self.calls = []
-
-    def generate(self, *, model: str, prompt: str, options: dict):
-        self.calls.append({"model": model, "prompt": prompt, "options": options})
-        return self.payload
+from sttEngine.one_line_summary import (
+    OneLineSummaryError,
+    _extract_summary_line,
+    build_one_line_summary_prompt,
+    generate_one_line_summary,
+)
 
 
 def test_extract_summary_line_supports_generate_response() -> None:
@@ -23,16 +20,47 @@ def test_extract_summary_line_supports_chat_shape() -> None:
     assert _extract_summary_line({"message": {"content": "요약 결과"}}) == "요약 결과"
 
 
-def test_generate_one_line_summary_uses_provider_contract(monkeypatch, tmp_path: Path) -> None:
+def test_extract_summary_line_normalizes_prefixes_and_bullets() -> None:
+    assert _extract_summary_line({"message": {"content": "- 요약: 핵심 논의 정리"}}) == "핵심 논의 정리"
+
+
+def test_build_one_line_summary_prompt_contains_ui_constraints() -> None:
+    prompt = build_one_line_summary_prompt("긴 본문")
+
+    assert "반드시 한국어 한 줄만 출력합니다" in prompt
+    assert "30~60자 내외" in prompt
+    assert prompt.endswith("긴 본문")
+
+
+def test_generate_one_line_summary_uses_chat_completion_contract(monkeypatch, tmp_path: Path) -> None:
     source = tmp_path / "sample.txt"
     source.write_text("테스트 본문", encoding="utf-8")
 
-    provider = _DummyProvider({"response": "요약 한 줄"})
-    monkeypatch.setattr("sttEngine.one_line_summary.get_llm_provider", lambda *_args, **_kwargs: provider)
+    called: dict[str, object] = {}
+
+    def fake_chat_completion(**kwargs):
+        called.update(kwargs)
+        return {"message": {"content": "요약 한 줄"}}
+
+    monkeypatch.setattr("sttEngine.one_line_summary.chat_completion", fake_chat_completion)
 
     summary = generate_one_line_summary(source, model="demo", provider_name="llamacpp")
 
     assert summary == "요약 한 줄"
-    assert provider.calls
-    assert provider.calls[0]["model"] == "demo"
-    assert provider.calls[0]["options"]["temperature"] == 0
+    assert called["model"] == "demo"
+    assert called["provider_name"] == "llamacpp"
+    assert called["options"]["temperature"] == 0
+    assert called["options"]["num_predict"] == 120
+
+
+def test_generate_one_line_summary_raises_for_empty_response(monkeypatch, tmp_path: Path) -> None:
+    source = tmp_path / "sample.txt"
+    source.write_text("테스트 본문", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "sttEngine.one_line_summary.chat_completion",
+        lambda **_kwargs: {"message": {"content": "   \n  "}},
+    )
+
+    with pytest.raises(OneLineSummaryError):
+        generate_one_line_summary(source, model="demo", provider_name="ollama")


### PR DESCRIPTION
## Summary
- normalize LLM provider responses to a consistent chat/generate shape across Ollama and llama.cpp
- route one-line summary generation through the shared provider contract and avoid overwriting existing titles with empty results
- keep summary completion non-blocking while logging structured warnings for title-summary failures
- update runtime/config docs and scripts for provider setup, model defaults, and launch behavior
- add coverage for one-line summary parsing, Ollama LLM response normalization, workflow title-summary handling, and Obsidian MCP behavior

## Testing
- Not run (not requested)