### PR TITLE
Enhance one-line summary generation with stricter prompt, error class and logging; make workflow tolerate title-summary failures

### DIFF
--- a/sttEngine/http_api/registry.py
+++ b/sttEngine/http_api/registry.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import uuid
 from datetime import datetime
 from pathlib import Path
 
-from ..one_line_summary import generate_one_line_summary
+from ..one_line_summary import OneLineSummaryError, generate_one_line_summary
 from .history import load_upload_history, save_upload_history
 from .paths import FILE_REGISTRY_FILE, normalize_record_path, resolve_record_path
 
@@ -229,19 +230,33 @@ def update_filename(record_id: str, new_filename: str) -> None:
     save_upload_history(history)
 
 
+LOGGER = logging.getLogger(__name__)
+
+
 def generate_and_store_title_summary(
     record_id: str,
     file_path: Path,
     model: str | None = None,
     provider_name: str | None = None,
-) -> None:
+) -> str:
     """Generate one-line summary and store it."""
     try:
         summary = generate_one_line_summary(
             file_path,
             model=model,
             provider_name=provider_name,
-        )
+        ).strip()
+        if not summary:
+            raise OneLineSummaryError("한줄요약 결과가 비어 있습니다.")
         update_title_summary(record_id, summary)
+        return summary
     except Exception as e:
-        print(f"One-line summary generation failed: {e}")
+        LOGGER.warning(
+            "One-line summary generation failed: record_id=%s file_path=%s provider=%s model=%s error=%s",
+            record_id,
+            file_path,
+            provider_name,
+            model,
+            e,
+        )
+        raise

--- a/sttEngine/http_api/workflow.py
+++ b/sttEngine/http_api/workflow.py
@@ -736,12 +736,20 @@ def run_workflow(
                 file_path_str = to_record_path(summary_file)
                 update_task_completion(record_id, "summary", file_path_str)
                 if source_text_path:
-                    generate_and_store_title_summary(
-                        record_id,
-                        source_text_path,
-                        summarize_model,
-                        (model_settings or {}).get("provider") or (model_settings or {}).get("llm_provider"),
-                    )
+                    try:
+                        generate_and_store_title_summary(
+                            record_id,
+                            source_text_path,
+                            summarize_model,
+                            (model_settings or {}).get("provider") or (model_settings or {}).get("llm_provider"),
+                        )
+                    except Exception as title_summary_error:
+                        if task_id:
+                            update_task_progress(
+                                task_id,
+                                f"한줄요약 생성 실패(요약 결과는 저장됨): {title_summary_error}",
+                                stage=TaskStage.SUMMARY,
+                            )
             record_step_metric("summary", "completed", summary_started_at)
 
     except Exception as exc:  # pragma: no cover

--- a/sttEngine/one_line_summary.py
+++ b/sttEngine/one_line_summary.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any, Dict
 
-from .llm_provider import map_llm_options, normalize_provider_name
-from .providers.factory import get_llm_provider
+from .llm_provider import chat_completion, map_llm_options, normalize_provider_name
 from .workflow.summarize import DEFAULT_MODEL, read_text_with_fallback
+
+LOGGER = logging.getLogger(__name__)
+_MAX_SOURCE_CHARS = 4000
+
+
+class OneLineSummaryError(RuntimeError):
+    """Raised when the one-line summary could not be generated."""
 
 
 def _extract_summary_line(response: Dict[str, Any]) -> str:
@@ -27,10 +34,31 @@ def _extract_summary_line(response: Dict[str, Any]) -> str:
         return ""
 
     for line in raw_text.strip().splitlines():
-        stripped = line.strip()
-        if stripped:
+        stripped = line.strip().lstrip("-*•0123456789. ")
+        if stripped and not stripped.lower().startswith("요약:"):
             return stripped
+        if stripped:
+            return stripped.removeprefix("요약:").strip()
     return ""
+
+
+def build_one_line_summary_prompt(text: str) -> str:
+    """Build a compact prompt tailored for list-title summaries."""
+    source = (text or "").strip()
+    if not source:
+        raise OneLineSummaryError("한줄요약 입력 텍스트가 비어 있습니다.")
+
+    return (
+        "당신은 문서 목록에 표시할 제목형 한줄요약을 작성합니다.\n"
+        "규칙:\n"
+        "- 반드시 한국어 한 줄만 출력합니다.\n"
+        "- 30~60자 내외로 작성합니다.\n"
+        "- 불렛, 번호, 따옴표, 접두어(예: 요약:)를 쓰지 않습니다.\n"
+        "- 핵심 주제를 제목처럼 간결하게 표현합니다.\n\n"
+        "원문:\n"
+        f"{source[:_MAX_SOURCE_CHARS]}"
+    )
+
 
 
 def generate_one_line_summary(file_path: Path, model: str | None = None, provider_name: str | None = None) -> str:
@@ -42,18 +70,31 @@ def generate_one_line_summary(file_path: Path, model: str | None = None, provide
         provider_name: Optional provider override (`ollama`/`llamacpp`).
 
     Returns:
-        A one-line summary string. Returns empty string when provider response is empty.
+        A one-line summary string.
+
+    Raises:
+        OneLineSummaryError: When the provider response is empty or malformed.
     """
     text = read_text_with_fallback(file_path)
-    prompt = "다음 텍스트를 한 줄로 한국어로 요약해 주세요:\n" + text[:4000]
+    prompt = build_one_line_summary_prompt(text)
 
     resolved_provider = normalize_provider_name(provider_name)
-    provider = get_llm_provider(resolved_provider)
-    options = map_llm_options({"temperature": 0}, provider_name=resolved_provider)
-
-    response = provider.generate(
-        model=model or DEFAULT_MODEL,
-        prompt=prompt,
-        options=options,
+    options = map_llm_options(
+        {
+            "temperature": 0,
+            "max_tokens": 120,
+        },
+        provider_name=resolved_provider,
     )
-    return _extract_summary_line(response)
+
+    response = chat_completion(
+        model=model or DEFAULT_MODEL,
+        messages=[{"role": "user", "content": prompt}],
+        options=options,
+        provider_name=resolved_provider,
+    )
+    summary_line = _extract_summary_line(response)
+    if not summary_line:
+        LOGGER.warning("한줄요약 응답이 비어 있습니다: provider=%s model=%s", resolved_provider, model or DEFAULT_MODEL)
+        raise OneLineSummaryError("한줄요약 응답이 비어 있습니다.")
+    return summary_line

--- a/tests/http_api/test_workflow.py
+++ b/tests/http_api/test_workflow.py
@@ -86,6 +86,80 @@ def test_workflow_passes_provider_to_correct_and_summary(monkeypatch, tmp_path: 
     assert called["summary"]["provider_name"] == "llamacpp"
 
 
+
+
+def test_workflow_summary_generates_title_summary_as_byproduct(monkeypatch, tmp_path: Path, temp_workflow_dirs):
+    upload_dir = tmp_path / "uploads" / "task-title-summary"
+    upload_dir.mkdir(parents=True)
+    source = upload_dir / "note.txt"
+    source.write_text("테스트 텍스트", encoding="utf-8")
+
+    history_state = [{"id": "record-1", "title_summary": "", "completed_tasks": {}, "download_links": {}}]
+
+    monkeypatch.setattr("sttEngine.http_api.workflow.summarize_text_mapreduce", lambda **_kwargs: "구조화 요약 결과")
+    monkeypatch.setattr("sttEngine.http_api.workflow.save_output", lambda content, path, as_json=False: path.write_text(content, encoding="utf-8"))
+    monkeypatch.setattr("sttEngine.http_api.workflow.send_summary_to_obsidian_sync", lambda **_kwargs: {"success": False, "message": "disabled"})
+    monkeypatch.setattr("sttEngine.http_api.workflow.update_task_progress", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("sttEngine.http_api.workflow.clear_task_progress", lambda _id: None)
+    monkeypatch.setattr("sttEngine.http_api.workflow.is_task_cancelled", lambda _id: False)
+    monkeypatch.setattr("sttEngine.http_api.workflow.load_upload_history", lambda: history_state)
+
+    stored: dict[str, object] = {}
+
+    def fake_generate_and_store_title_summary(record_id, file_path, model=None, provider_name=None):
+        stored["record_id"] = record_id
+        stored["file_path"] = file_path
+        stored["model"] = model
+        stored["provider_name"] = provider_name
+        history_state[0]["title_summary"] = "후처리 한줄요약"
+        return "후처리 한줄요약"
+
+    monkeypatch.setattr("sttEngine.http_api.workflow.generate_and_store_title_summary", fake_generate_and_store_title_summary)
+    monkeypatch.setattr("sttEngine.http_api.workflow.update_task_completion", lambda *_args, **_kwargs: "file-uuid")
+
+    result = run_workflow(
+        source,
+        ["summary"],
+        record_id="record-1",
+        task_id="task-title-summary",
+        model_settings={"provider": "llamacpp", "summarize": "model.gguf"},
+    )
+
+    assert result["summary"].endswith("note.summary.md")
+    assert stored["record_id"] == "record-1"
+    assert stored["file_path"].name == "note.md"
+    assert "whisper_output" in str(stored["file_path"])
+    assert stored["model"] == "model.gguf"
+    assert stored["provider_name"] == "llamacpp"
+    assert history_state[0]["title_summary"] == "후처리 한줄요약"
+
+
+def test_workflow_title_summary_failure_keeps_summary_success(monkeypatch, tmp_path: Path, temp_workflow_dirs):
+    upload_dir = tmp_path / "uploads" / "task-title-summary-fail"
+    upload_dir.mkdir(parents=True)
+    source = upload_dir / "note.txt"
+    source.write_text("테스트 텍스트", encoding="utf-8")
+
+    progress_messages: list[str] = []
+
+    monkeypatch.setattr("sttEngine.http_api.workflow.summarize_text_mapreduce", lambda **_kwargs: "구조화 요약 결과")
+    monkeypatch.setattr("sttEngine.http_api.workflow.save_output", lambda content, path, as_json=False: path.write_text(content, encoding="utf-8"))
+    monkeypatch.setattr("sttEngine.http_api.workflow.send_summary_to_obsidian_sync", lambda **_kwargs: {"success": False, "message": "disabled"})
+    monkeypatch.setattr("sttEngine.http_api.workflow.update_task_progress", lambda _id, msg, **_kwargs: progress_messages.append(msg))
+    monkeypatch.setattr("sttEngine.http_api.workflow.clear_task_progress", lambda _id: None)
+    monkeypatch.setattr("sttEngine.http_api.workflow.is_task_cancelled", lambda _id: False)
+    monkeypatch.setattr("sttEngine.http_api.workflow.update_task_completion", lambda *_args, **_kwargs: "file-uuid")
+    monkeypatch.setattr(
+        "sttEngine.http_api.workflow.generate_and_store_title_summary",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("llm timeout")),
+    )
+
+    result = run_workflow(source, ["summary"], record_id="record-2", task_id="task-title-summary-fail")
+
+    assert result["summary"].endswith("note.summary.md")
+    assert not any(msg.startswith("요약 생성 실패:") for msg in progress_messages)
+    assert any("한줄요약 생성 실패(요약 결과는 저장됨): llm timeout" == msg for msg in progress_messages)
+
 def test_workflow_diarization_failure_contract_returns_standard_error_fields(monkeypatch):
     progress_payloads: list[dict[str, object]] = []
 

--- a/tests/test_one_line_summary.py
+++ b/tests/test_one_line_summary.py
@@ -2,17 +2,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from sttEngine.one_line_summary import _extract_summary_line, generate_one_line_summary
+import pytest
 
-
-class _DummyProvider:
-    def __init__(self, payload):
-        self.payload = payload
-        self.calls = []
-
-    def generate(self, *, model: str, prompt: str, options: dict):
-        self.calls.append({"model": model, "prompt": prompt, "options": options})
-        return self.payload
+from sttEngine.one_line_summary import (
+    OneLineSummaryError,
+    _extract_summary_line,
+    build_one_line_summary_prompt,
+    generate_one_line_summary,
+)
 
 
 def test_extract_summary_line_supports_generate_response() -> None:
@@ -23,16 +20,47 @@ def test_extract_summary_line_supports_chat_shape() -> None:
     assert _extract_summary_line({"message": {"content": "요약 결과"}}) == "요약 결과"
 
 
-def test_generate_one_line_summary_uses_provider_contract(monkeypatch, tmp_path: Path) -> None:
+def test_extract_summary_line_normalizes_prefixes_and_bullets() -> None:
+    assert _extract_summary_line({"message": {"content": "- 요약: 핵심 논의 정리"}}) == "핵심 논의 정리"
+
+
+def test_build_one_line_summary_prompt_contains_ui_constraints() -> None:
+    prompt = build_one_line_summary_prompt("긴 본문")
+
+    assert "반드시 한국어 한 줄만 출력합니다" in prompt
+    assert "30~60자 내외" in prompt
+    assert prompt.endswith("긴 본문")
+
+
+def test_generate_one_line_summary_uses_chat_completion_contract(monkeypatch, tmp_path: Path) -> None:
     source = tmp_path / "sample.txt"
     source.write_text("테스트 본문", encoding="utf-8")
 
-    provider = _DummyProvider({"response": "요약 한 줄"})
-    monkeypatch.setattr("sttEngine.one_line_summary.get_llm_provider", lambda *_args, **_kwargs: provider)
+    called: dict[str, object] = {}
+
+    def fake_chat_completion(**kwargs):
+        called.update(kwargs)
+        return {"message": {"content": "요약 한 줄"}}
+
+    monkeypatch.setattr("sttEngine.one_line_summary.chat_completion", fake_chat_completion)
 
     summary = generate_one_line_summary(source, model="demo", provider_name="llamacpp")
 
     assert summary == "요약 한 줄"
-    assert provider.calls
-    assert provider.calls[0]["model"] == "demo"
-    assert provider.calls[0]["options"]["temperature"] == 0
+    assert called["model"] == "demo"
+    assert called["provider_name"] == "llamacpp"
+    assert called["options"]["temperature"] == 0
+    assert called["options"]["num_predict"] == 120
+
+
+def test_generate_one_line_summary_raises_for_empty_response(monkeypatch, tmp_path: Path) -> None:
+    source = tmp_path / "sample.txt"
+    source.write_text("테스트 본문", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "sttEngine.one_line_summary.chat_completion",
+        lambda **_kwargs: {"message": {"content": "   \n  "}},
+    )
+
+    with pytest.raises(OneLineSummaryError):
+        generate_one_line_summary(source, model="demo", provider_name="ollama")


### PR DESCRIPTION
### Motivation

- Improve robustness and quality of the one-line (title) summary generation by enforcing a compact, rule-driven prompt and stronger validation of provider responses.
- Surface and log errors more clearly during summary post-processing and avoid failing the overall workflow when title-summary generation fails.

### Description

- Introduced `OneLineSummaryError` and stricter response validation to `generate_one_line_summary`, raising when the provider response is empty or malformed, and added logging warnings for empty responses.
- Replaced the old prompt with `build_one_line_summary_prompt` that encodes UI constraints (Korean-only, 30–60 chars, no bullets/prefixes) and limits source size with `_MAX_SOURCE_CHARS`.
- Switched to the `chat_completion` contract for calling LLMs, set deterministic options (`temperature: 0`, token limit) via `map_llm_options`, and normalized extracted lines (strip bullets/prefixes and `요약:`).
- Added `LOGGER` and improved error handling in `generate_and_store_title_summary` to log failures and re-raise, and updated workflow to catch title-summary errors so the main `summary` step still succeeds while recording a non-fatal progress message.

### Testing

- Ran `tests/test_one_line_summary.py` which includes tests for `_extract_summary_line`, `build_one_line_summary_prompt`, `generate_one_line_summary` call contract, and the empty-response error path; all tests passed.
- Ran `tests/http_api/test_workflow.py` updates that validate title-summary generation as a byproduct and that title-summary failures do not mark the main summary step as failed; these tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d60218cc832e8b95ee559071d690)