### PR TITLE
Fix macOS whisper backend default to avoid Metal crash

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -310,6 +310,9 @@ flowchart LR
 - 모델 경로 우선순위:
   - `RECORDROUTE_WHISPER_MODEL`
   - 기본값 `models/whisper/ggml-base.bin`
+- 런타임 백엔드 설정:
+  - `RECORDROUTE_WHISPER_BACKEND` (`auto`/`cpu`/`gpu`)
+  - macOS 기본값은 `cpu`(Metal backend 비활성화)이며, 다른 OS 기본값은 `auto`다.
 - shorthand 지원:
   - `models/whisper/large-v3-turbo` 같은 값도 허용한다.
   - 이 경우 내부적으로 `models/whisper/ggml-large-v3-turbo.bin` 형태로 정규화해 해석한다.
@@ -355,6 +358,9 @@ whisper-cli \
   -otxt \
   -np \
   -of <output-prefix>
+
+# macOS 기본 동작 (CPU 강제)
+GGML_METAL=0 whisper-cli ...
 ```
 
 여기서 실제 결과 파일은 `<output-prefix>.txt`다.

--- a/rust/src/whisper.rs
+++ b/rust/src/whisper.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 pub const MODEL_ENV_VAR: &str = "RECORDROUTE_WHISPER_MODEL";
+pub const BACKEND_ENV_VAR: &str = "RECORDROUTE_WHISPER_BACKEND";
 const DEFAULT_MODEL_RELATIVE_PATH: &str = "models/whisper/ggml-base.bin";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -129,7 +130,8 @@ pub fn run_transcription(
     }
     let _ = fs::remove_file(output_text);
 
-    let output = Command::new(&toolchain.whisper_cli_path)
+    let mut command = Command::new(&toolchain.whisper_cli_path);
+    command
         .arg("-m")
         .arg(&toolchain.model_path)
         .arg("-f")
@@ -139,14 +141,15 @@ pub fn run_transcription(
         .arg("-otxt")
         .arg("-np")
         .arg("-of")
-        .arg(&output_prefix)
-        .output()
-        .map_err(|error| {
-            format!(
-                "failed to execute whisper-cli {}: {error}",
-                toolchain.whisper_cli_path.display()
-            )
-        })?;
+        .arg(&output_prefix);
+    configure_runtime_backend(&mut command);
+
+    let output = command.output().map_err(|error| {
+        format!(
+            "failed to execute whisper-cli {}: {error}",
+            toolchain.whisper_cli_path.display()
+        )
+    })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -180,6 +183,46 @@ fn resolve_model_path(repo_root: &Path) -> PathBuf {
             resolve_model_override_path(repo_root, PathBuf::from(path))
         }
         _ => repo_root.join(DEFAULT_MODEL_RELATIVE_PATH),
+    }
+}
+
+fn configure_runtime_backend(command: &mut Command) {
+    match resolve_backend_mode() {
+        WhisperBackend::Cpu => {
+            command.env("GGML_METAL", "0");
+        }
+        WhisperBackend::Gpu | WhisperBackend::Auto => {}
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WhisperBackend {
+    Auto,
+    Cpu,
+    Gpu,
+}
+
+fn resolve_backend_mode() -> WhisperBackend {
+    match std::env::var(BACKEND_ENV_VAR) {
+        Ok(value) => parse_backend_mode(&value).unwrap_or(default_backend_mode()),
+        Err(_) => default_backend_mode(),
+    }
+}
+
+fn parse_backend_mode(value: &str) -> Option<WhisperBackend> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "auto" => Some(WhisperBackend::Auto),
+        "cpu" => Some(WhisperBackend::Cpu),
+        "gpu" => Some(WhisperBackend::Gpu),
+        _ => None,
+    }
+}
+
+fn default_backend_mode() -> WhisperBackend {
+    if cfg!(target_os = "macos") {
+        WhisperBackend::Cpu
+    } else {
+        WhisperBackend::Auto
     }
 }
 
@@ -305,6 +348,15 @@ mod tests {
             toolchain.whisper_cli_path,
             fake_whisper_cli_path(&build_bin)
         );
+    }
+
+    #[test]
+    fn parse_backend_mode_supports_known_values() {
+        assert_eq!(parse_backend_mode("auto"), Some(WhisperBackend::Auto));
+        assert_eq!(parse_backend_mode("cpu"), Some(WhisperBackend::Cpu));
+        assert_eq!(parse_backend_mode("gpu"), Some(WhisperBackend::Gpu));
+        assert_eq!(parse_backend_mode("CPU"), Some(WhisperBackend::Cpu));
+        assert_eq!(parse_backend_mode(" invalid "), None);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent Whisper/ggml Metal initialization assertion failures observed on macOS by forcing a safer default runtime backend. 
- Provide an explicit runtime override so operators can opt into GPU/Metal when desired.

### Description
- Add `RECORDROUTE_WHISPER_BACKEND` (`auto`/`cpu`/`gpu`) and wire it into `rust/src/whisper.rs` as `BACKEND_ENV_VAR` with parsing helpers and a `WhisperBackend` enum.
- Change `run_transcription()` to build a `Command`, call `configure_runtime_backend()` before execution, and set `GGML_METAL=0` when backend resolves to `cpu`.
- Default backend selection is `cpu` on macOS and `auto` on other platforms, and a unit test `parse_backend_mode_supports_known_values` was added.
- Update `docs/architecture.md` to document the new `RECORDROUTE_WHISPER_BACKEND` setting and note the macOS CPU-default (example showing `GGML_METAL=0 whisper-cli ...`).

### Testing
- Ran `cargo fmt -- --check` in the Rust workspace and it succeeded.
- Attempted `cargo test whisper:: -- --nocapture` but it was blocked by the environment network error fetching crates.io (HTTP 403) so tests could not complete here. 
- Unit coverage for backend parsing was added (`parse_backend_mode_supports_known_values`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c35bbd637c832ebbbc884acd87afeb)