### PR TITLE
Add `server` CLI mode and axum ping endpoint

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,8 +4,14 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+axum = "0.8"
 dotenvy = "0.15"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 time = { version = "0.3", features = ["formatting", "macros"] }
+tokio = { version = "1", features = ["macros", "net", "rt"] }
 uuid = { version = "1", features = ["serde", "v7"] }
+
+[dev-dependencies]
+http-body-util = "0.1"
+tower = { version = "0.5", features = ["util"] }

--- a/rust/src/app.rs
+++ b/rust/src/app.rs
@@ -4,6 +4,7 @@ use crate::ffmpeg::{
 };
 use crate::index::{IndexStore, JobOutputs, JobProbe, JobRecord, JobSplitOutput};
 use crate::llama::{Toolchain as LlamaToolchain, run_summary_generation};
+use crate::server;
 use crate::whisper::{Toolchain as WhisperToolchain, run_transcription};
 use std::ffi::{OsStr, OsString};
 use std::fs;
@@ -23,6 +24,7 @@ enum CliCommand {
     Stt,
     Summary,
     PrepareLlamaModel,
+    Server,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -99,6 +101,13 @@ pub fn main_cli() -> Result<(), String> {
         CliCommand::PrepareLlamaModel => {
             prepare_llama_model_with_repo_root(&repo_root)?;
         }
+        CliCommand::Server => {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_io()
+                .build()
+                .map_err(|error| format!("failed to create tokio runtime: {error}"))?;
+            runtime.block_on(server::serve())?;
+        }
     }
 
     Ok(())
@@ -127,11 +136,15 @@ fn resolve_cli_command(
         [mode, ..] if mode == OsStr::new("prepare-llama-model") => {
             Err("prepare-llama-model mode does not accept additional arguments".to_string())
         }
+        [mode] if mode == OsStr::new("server") => Ok(CliCommand::Server),
+        [mode, ..] if mode == OsStr::new("server") => {
+            Err("server mode does not accept additional arguments".to_string())
+        }
         [path] => Ok(CliCommand::Ffmpeg {
             input: Some(PathBuf::from(path)),
         }),
         _ => Err(
-            "usage: recordroute_rust [ffmpeg <input>|stt|summary|prepare-llama-model|<input>]"
+            "usage: recordroute_rust [ffmpeg <input>|stt|summary|prepare-llama-model|server|<input>]"
                 .to_string(),
         ),
     }
@@ -143,6 +156,7 @@ fn prompt_for_mode(reader: &mut dyn BufRead, writer: &mut dyn Write) -> Result<C
         writeln!(writer, "1. ffmpeg 작업").map_err(|error| error.to_string())?;
         writeln!(writer, "2. stt 작업").map_err(|error| error.to_string())?;
         writeln!(writer, "3. summary 작업").map_err(|error| error.to_string())?;
+        writeln!(writer, "4. server 작업").map_err(|error| error.to_string())?;
         write!(writer, "Enter number: ").map_err(|error| error.to_string())?;
         writer.flush().map_err(|error| error.to_string())?;
 
@@ -151,8 +165,9 @@ fn prompt_for_mode(reader: &mut dyn BufRead, writer: &mut dyn Write) -> Result<C
             "1" => return Ok(CliCommand::Ffmpeg { input: None }),
             "2" => return Ok(CliCommand::Stt),
             "3" => return Ok(CliCommand::Summary),
+            "4" => return Ok(CliCommand::Server),
             _ => {
-                writeln!(writer, "Invalid selection. Enter 1, 2, or 3.")
+                writeln!(writer, "Invalid selection. Enter 1, 2, 3, or 4.")
                     .map_err(|error| error.to_string())?;
             }
         }
@@ -915,7 +930,7 @@ mod tests {
         assert!(
             String::from_utf8(output)
                 .expect("utf8")
-                .contains("Invalid selection. Enter 1, 2, or 3.")
+                .contains("Invalid selection. Enter 1, 2, 3, or 4.")
         );
     }
 
@@ -950,6 +965,43 @@ mod tests {
         let command = resolve_cli_command(&args, &mut reader, &mut output).expect("command");
 
         assert_eq!(command, CliCommand::PrepareLlamaModel);
+    }
+
+    #[test]
+    fn resolves_server_command() {
+        let args = vec![OsString::from("server")];
+        let mut reader = Cursor::new(Vec::<u8>::new());
+        let mut output = Vec::new();
+
+        let command = resolve_cli_command(&args, &mut reader, &mut output).expect("command");
+
+        assert_eq!(command, CliCommand::Server);
+    }
+
+    #[test]
+    fn server_command_rejects_extra_arguments() {
+        let args = vec![OsString::from("server"), OsString::from("extra")];
+        let mut reader = Cursor::new(Vec::<u8>::new());
+        let mut output = Vec::new();
+
+        let error = resolve_cli_command(&args, &mut reader, &mut output).expect_err("should fail");
+
+        assert_eq!(error, "server mode does not accept additional arguments");
+    }
+
+    #[test]
+    fn prompts_for_server_mode_when_selected() {
+        let mut reader = Cursor::new(b"4\n".to_vec());
+        let mut output = Vec::new();
+
+        let command = resolve_cli_command(&[], &mut reader, &mut output).expect("command");
+
+        assert_eq!(command, CliCommand::Server);
+        assert!(
+            String::from_utf8(output)
+                .expect("utf8")
+                .contains("4. server 작업")
+        );
     }
 
     #[test]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,6 +2,7 @@ mod app;
 mod ffmpeg;
 mod index;
 mod llama;
+mod server;
 mod whisper;
 
 pub use app::main_cli;

--- a/rust/src/server.rs
+++ b/rust/src/server.rs
@@ -1,0 +1,191 @@
+use axum::extract::State;
+use axum::extract::rejection::JsonRejection;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+
+const SERVER_BIND: &str = "127.0.0.1:38080";
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PingRequest {
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PingResponse {
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone)]
+struct AppState {
+    invalid_request_body: PingResponse,
+}
+
+pub fn router() -> Router {
+    Router::new()
+        .route("/server/ping", post(post_server_ping))
+        .with_state(AppState {
+            invalid_request_body: PingResponse {
+                code: "400".to_string(),
+                message: "invalid request body".to_string(),
+            },
+        })
+}
+
+pub async fn serve() -> Result<(), String> {
+    let listener = tokio::net::TcpListener::bind(SERVER_BIND)
+        .await
+        .map_err(|error| format!("failed to bind {SERVER_BIND}: {error}"))?;
+
+    axum::serve(listener, router())
+        .await
+        .map_err(|error| format!("server error: {error}"))
+}
+
+async fn post_server_ping(
+    State(state): State<AppState>,
+    payload: Result<Json<PingRequest>, JsonRejection>,
+) -> Response {
+    match payload {
+        Ok(Json(request)) => {
+            let _request_code = request.code;
+            let response = PingResponse {
+                code: "200".to_string(),
+                message: format!("Welcome... The message you sent - {}", request.message),
+            };
+            (StatusCode::OK, Json(response)).into_response()
+        }
+        Err(_) => (
+            StatusCode::BAD_REQUEST,
+            Json(state.invalid_request_body.clone()),
+        )
+            .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Method, Request};
+    use http_body_util::BodyExt;
+    use tower::util::ServiceExt;
+
+    #[tokio::test]
+    async fn ping_returns_expected_success_payload() {
+        let app = router();
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/server/ping")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"code":"100","message":"ping test"}"#))
+            .expect("request");
+
+        let response = app.oneshot(request).await.expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("collect")
+            .to_bytes();
+        assert_eq!(
+            std::str::from_utf8(&body).expect("utf8"),
+            r#"{"code":"200","message":"Welcome... The message you sent - ping test"}"#
+        );
+    }
+
+    #[tokio::test]
+    async fn ping_returns_400_for_malformed_json() {
+        let app = router();
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/server/ping")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"code":"100","message":"ping test""#))
+            .expect("request");
+
+        let response = app.oneshot(request).await.expect("response");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("collect")
+            .to_bytes();
+        assert_eq!(
+            std::str::from_utf8(&body).expect("utf8"),
+            r#"{"code":"400","message":"invalid request body"}"#
+        );
+    }
+
+    #[tokio::test]
+    async fn ping_returns_400_when_message_is_missing() {
+        let app = router();
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/server/ping")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"code":"100"}"#))
+            .expect("request");
+
+        let response = app.oneshot(request).await.expect("response");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("collect")
+            .to_bytes();
+        assert_eq!(
+            std::str::from_utf8(&body).expect("utf8"),
+            r#"{"code":"400","message":"invalid request body"}"#
+        );
+    }
+
+    #[tokio::test]
+    async fn ping_returns_400_when_code_is_missing() {
+        let app = router();
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/server/ping")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"message":"ping test"}"#))
+            .expect("request");
+
+        let response = app.oneshot(request).await.expect("response");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("collect")
+            .to_bytes();
+        assert_eq!(
+            std::str::from_utf8(&body).expect("utf8"),
+            r#"{"code":"400","message":"invalid request body"}"#
+        );
+    }
+
+    #[tokio::test]
+    async fn ping_rejects_get_method() {
+        let app = router();
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri("/server/ping")
+            .body(Body::empty())
+            .expect("request");
+
+        let response = app.oneshot(request).await.expect("response");
+
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a simple HTTP V1 API alongside the existing CLI without changing existing ffmpeg/stt/summary flows.
- Expose a single `POST /server/ping` endpoint for basic local health/ping checks bound to `127.0.0.1:38080`.

### Description

- Added HTTP dependencies to `rust/Cargo.toml`: `axum`, `tokio` (with `macros/net/rt`), and minimal test helpers under `[dev-dependencies]` (`http-body-util`, `tower`).
- Introduced a new `server` CLI mode in `rust/src/app.rs` and wired it to spawn a Tokio runtime and run `server::serve()` via `block_on` so synchronous CLI behavior is preserved; updated usage and interactive prompt to include `server`.
- Implemented `rust/src/server.rs` with `router()` and `serve()` exposing `POST /server/ping`, request/response DTOs `PingRequest`/`PingResponse`, fixed bind `127.0.0.1:38080`, and unified 400 JSON error payload `{"code":"400","message":"invalid request body"}` for malformed/missing body cases.
- Registered `mod server;` in `rust/src/lib.rs` and added async router tests for successful ping, malformed JSON, missing fields, method 405, plus CLI parser regression tests for the `server` command.

### Testing

- Ran `cargo fmt --check` in `rust/` which passed.
- Ran `cargo test` in `rust/` but it failed to fetch new crates (e.g. `axum`) because the environment blocked access to the crates.io index (`CONNECT tunnel failed, response 403`), so tests that require fetching dependencies could not run to completion.
- Added unit tests for router behavior and CLI parsing (these tests are present under `rust/src/server.rs` and `rust/src/app.rs`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3684ce51c832e96c963cfde9ec8ec)