### PR TITLE
Add `mono_mix_only` option to STT API and validate audio subset selection

### DIFF
--- a/docs/API_TODO.md
+++ b/docs/API_TODO.md
@@ -310,8 +310,11 @@
   - 목적: 특정 job 폴더의 오디오 파일들에 대해 STT 실행
   - 요청 필드:
     - `audio_files` (선택)
+    - `mono_mix_only` (선택, 기본값 `false`)
   - 기본 동작:
     - 지정이 없으면 job 디렉터리의 지원 오디오 파일 전체 처리
+    - `mono_mix_only=true`면 `mono_mix.wav`만 처리
+    - `mono_mix_only=true`와 `audio_files` 동시 지정은 허용하지 않음
   - 응답 필드:
     - `job_id`
     - `status`

--- a/rust/src/server.rs
+++ b/rust/src/server.rs
@@ -49,6 +49,8 @@ struct SummaryRequest {
 struct SttRequest {
     #[serde(default)]
     audio_files: Vec<String>,
+    #[serde(default)]
+    mono_mix_only: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -227,8 +229,10 @@ async fn post_stt(
     payload: Result<Json<SttRequest>, JsonRejection>,
 ) -> Response {
     let subset = match payload {
-        Ok(Json(request)) if !request.audio_files.is_empty() => Some(request.audio_files),
-        Ok(_) => None,
+        Ok(Json(request)) => match resolve_stt_subset(request) {
+            Ok(subset) => subset,
+            Err(error) => return error_response(StatusCode::BAD_REQUEST, error),
+        },
         Err(_) => {
             return (
                 StatusCode::BAD_REQUEST,
@@ -282,6 +286,19 @@ async fn post_stt(
         task,
     };
     (StatusCode::ACCEPTED, Json(body)).into_response()
+}
+
+fn resolve_stt_subset(request: SttRequest) -> Result<Option<Vec<String>>, String> {
+    if request.mono_mix_only && !request.audio_files.is_empty() {
+        return Err("audio_files cannot be combined with mono_mix_only".to_string());
+    }
+    if request.mono_mix_only {
+        return Ok(Some(vec!["mono_mix.wav".to_string()]));
+    }
+    if request.audio_files.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(request.audio_files))
 }
 
 async fn get_stt(State(state): State<AppState>, AxumPath(job_id): AxumPath<String>) -> Response {
@@ -586,6 +603,36 @@ mod tests {
     use std::time::{Duration, Instant};
     use tower::util::ServiceExt;
     use uuid::Uuid;
+
+    #[test]
+    fn resolve_stt_subset_defaults_to_all_audio_files() {
+        let subset = resolve_stt_subset(SttRequest {
+            audio_files: Vec::new(),
+            mono_mix_only: false,
+        })
+        .expect("subset");
+        assert_eq!(subset, None);
+    }
+
+    #[test]
+    fn resolve_stt_subset_supports_mono_mix_only_mode() {
+        let subset = resolve_stt_subset(SttRequest {
+            audio_files: Vec::new(),
+            mono_mix_only: true,
+        })
+        .expect("subset");
+        assert_eq!(subset, Some(vec!["mono_mix.wav".to_string()]));
+    }
+
+    #[test]
+    fn resolve_stt_subset_rejects_mixed_modes() {
+        let error = resolve_stt_subset(SttRequest {
+            audio_files: vec!["channel_01.wav".to_string()],
+            mono_mix_only: true,
+        })
+        .expect_err("mixed mode should fail");
+        assert!(error.contains("audio_files cannot be combined with mono_mix_only"));
+    }
 
     #[tokio::test]
     async fn ping_returns_expected_success_payload() {


### PR DESCRIPTION
### Motivation

- Introduce an API-level toggle to only run STT on the single `mono_mix.wav` mix instead of enumerating all audio files. 
- Prevent ambiguous or invalid request combinations by forbidding simultaneous use of `audio_files` and `mono_mix_only`.

### Description

- Update documentation in `docs/API_TODO.md` to document the `mono_mix_only` boolean request field and its behavior. 
- Add `mono_mix_only: bool` to the `SttRequest` struct and wire request handling to a new `resolve_stt_subset` helper. 
- Implement `resolve_stt_subset` which returns the resolved optional list of audio files or a `BadRequest` error when `mono_mix_only` and `audio_files` are combined. 
- Integrate the resolver into `post_stt` to centralize validation and selection of STT target files.

### Testing

- Ran `cargo test` and executed unit tests covering `resolve_stt_subset` including default-all, `mono_mix_only` behavior, and rejection of mixed modes. 
- Ran the existing `ping_returns_expected_success_payload` integration test under `#[tokio::test]`. 
- All listed tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c37cfc2d54832e9d77480fa442038c)