### PR TITLE
Fix ownership errors when marking jobs completed/failed

### DIFF
--- a/rust/src/index.rs
+++ b/rust/src/index.rs
@@ -133,7 +133,7 @@ impl JobRecord {
 
     pub fn mark_completed(&mut self, finished_at: String, outputs: JobOutputs) {
         self.status = JobStatus::Completed;
-        self.finished_at = Some(finished_at);
+        self.finished_at = Some(finished_at.clone());
         self.outputs = outputs;
         self.error_message = None;
         self.update_task(
@@ -146,7 +146,7 @@ impl JobRecord {
 
     pub fn mark_failed(&mut self, finished_at: String, error_message: String) {
         self.status = JobStatus::Failed;
-        self.finished_at = Some(finished_at);
+        self.finished_at = Some(finished_at.clone());
         self.error_message = Some(error_message);
         self.update_task(
             TaskType::Ffmpeg,


### PR DESCRIPTION
### Motivation
- Resolve Rust compile errors `E0382` caused by using `finished_at` after it was moved. 
- Ensure `finished_at` can be stored on the `JobRecord` while still being passed to `update_task`.

### Description
- In `rust/src/index.rs`, modify `JobRecord::mark_completed` to store `self.finished_at = Some(finished_at.clone())` so the original `finished_at` value remains available.
- Apply the same change in `JobRecord::mark_failed` by cloning `finished_at` before assigning to `self.finished_at`.
- This prevents use-after-move of the `String` when calling `update_task` with `Some(finished_at)`.

### Testing
- Ran `cargo test` in `rust/`, which failed due to network errors when downloading crates from `crates.io` (CONNECT tunnel failed, response 403).
- Ran `cargo check --locked --offline` in `rust/`, which failed because required crates are not available in the local cache (e.g., `dotenvy`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c383e57a34832e91b722e2714d4225)