### PR TITLE
docs: rewrite top-level README with UX-focused onboarding and troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,106 @@
 # RecordRoute
-RecordRoute는 음성/문서 입력을 STT, 교정, 요약, 임베딩 검색으로 처리하는 워크플로우 서비스입니다.
 
-## 문서 안내
-- 설치/모델 설정/사용 방법: 이 문서(`README.md`)
-- 현재 코드베이스 구조/개발 참고: `docs/current-codebase-overview.md`
-- llama.cpp 실사용 가이드: `docs/llama-guide.md`
-- 코딩 에이전트 기준 문서: `AGENTS.md`
-- 에이전트 요약 문서: `CLAUDE.md`, `GEMINI.md`
+RecordRoute는 **음성/문서를 업로드하고, 텍스트 결과를 확인하고, 검색/재활용**하는 데 집중한 기록 정리 도구입니다.
 
-## 1) 빠른 설치 및 실행
+이 README는 아키텍처 설명 대신, 실제 사용자 관점에서 필요한 내용(기능/설정/사용/문제 해결)에 집중합니다.
 
-### macOS/Linux (권장)
+---
+
+## 무엇을 할 수 있나요? (UX 기준)
+
+### 1) 파일 업로드 후 자동 처리
+- 음성 파일 또는 문서를 업로드하고,
+- 처리 단계(STT, 교정, 요약 등)를 선택해 실행할 수 있습니다.
+- 작업은 백그라운드에서 진행되며 진행률과 예상 시간을 확인할 수 있습니다.
+
+### 2) 진행 상황 실시간 확인
+- 작업별 진행률(`progress_percent`)과 ETA(`eta_seconds`)를 확인할 수 있습니다.
+- 실패 시 표준화된 오류 정보(`error_code`, `failed_step`)를 받아 원인 파악이 쉽습니다.
+
+### 3) 결과 탐색과 재사용
+- 업로드/처리 히스토리를 조회할 수 있습니다.
+- 키워드/필터 기반 검색으로 원하는 기록을 빠르게 찾을 수 있습니다.
+- 유사 문서 탐색으로 관련 기록을 이어서 확인할 수 있습니다.
+- 원본/결과 파일 다운로드를 지원합니다.
+
+### 4) 안전한 관리 작업
+- 삭제/초기화처럼 파괴적인 API는 기본적으로 안전 모드가 켜져 있어,
+  토큰/세션 없이 실수로 실행되지 않도록 보호됩니다.
+
+---
+
+## 빠른 시작
+
+### macOS / Linux
 ```bash
 ./setup.sh
 ./run.sh
 ```
 
-### Windows (권장)
+### Windows
 ```bat
 setup.bat
 run.bat
 ```
 
-> `.env`에서 `LLM_PROVIDER`/`EMBEDDING_PROVIDER`를 `ollama`가 아닌 값으로 설정하면 setup/run 스크립트의 Ollama 점검/자동시작 단계는 자동으로 건너뜁니다.
+> 참고: Windows `run.bat`는 `8080` 포트 사용이 불가능하면 자동으로 `18080`을 시도합니다.
 
-## 2) 수동 설치
+실행 후 기본 접속:
+- API: `http://localhost:8080`
+- WebSocket: `ws://localhost:8765`
+- (Docker 분리 배포 시) 프론트: `http://localhost:3000`
 
-## 2-A) Docker 분리 배포 (backend + frontend)
+---
 
+## 기본 설정
+
+### 1) `.env` 준비
+- `.env.example`을 참고해 `.env`를 설정합니다.
+- 핵심은 **어떤 LLM/Embedding provider를 쓸지** 먼저 정하는 것입니다.
+
+주요 값:
+- `LLM_PROVIDER` : 교정/요약 모델 provider
+- `EMBEDDING_PROVIDER` : 임베딩 provider (미지정 시 LLM provider 상속)
+
+### 2) 모델 준비
+- Ollama 사용 시: 모델 pull + 서버 실행 필요
+- llama.cpp 사용 시: GGUF 경로 지정(또는 Hugging Face 자동 다운로드 설정)
+
+### 3) Ollama 체크 자동 스킵 조건
+- `.env`에서 `LLM_PROVIDER`/`EMBEDDING_PROVIDER`가 `ollama`가 아니면
+  setup/run의 Ollama 점검 단계는 자동으로 건너뜁니다.
+
+---
+
+## 사용 방법 (실무 흐름)
+
+### 1) 업로드
+- UI 또는 `/upload` API로 파일 업로드
+
+### 2) 처리 실행
+- `/process`로 단계 실행 (예: `stt → correct → summary`)
+- `model_settings`로 모델, 언어, provider 등을 지정
+
+### 3) 진행 확인
+- `GET /progress/<task_id>`
+- WebSocket 이벤트(`ws://localhost:8765`)
+
+### 4) 결과 확인/활용
+- `GET /history` : 처리 히스토리
+- `GET /search` : 통합 검색
+- `GET /similar/<uuid_or_path>` 또는 `POST /similar` : 유사 문서
+- `GET /download/<uuid_or_path>` : 결과 다운로드
+
+---
+
+## Docker로 실행
+
+기본(backend + frontend):
 ```bash
 docker compose up -d --build
 ```
 
-프로필 사용:
+옵션 프로필:
 ```bash
 # Ollama 포함
 docker compose --profile ollama up -d --build
@@ -41,125 +109,36 @@ docker compose --profile ollama up -d --build
 docker compose --profile llamacpp up -d --build
 ```
 
-기본 포트:
-- 프론트엔드: `http://localhost:3000`
-- 백엔드 API: `http://localhost:8080`
-- WebSocket: `ws://localhost:8765`
+---
 
-프론트 빌드 변수(Compose build args):
-- `VITE_API_BASE_URL` (기본 `/api`, 프론트 Nginx가 backend:8080으로 프록시)
-- `VITE_WS_URL` (기본 비움. 비어 있으면 브라우저 origin 기준 `/ws` 사용)
+## 트러블슈팅
 
-백엔드 헬스체크:
-- `GET /health` → `{ "status": "ok" }`
+### 1) 서버는 켜졌는데 요청이 실패할 때
+- `GET /health`로 서버 상태 확인 (`{"status":"ok"}` 기대)
+- 포트 충돌 여부 확인 (`8080`, `8765`, `3000`)
 
-프론트 Nginx 프록시 경로:
-- `/api/*` -> `backend:8080/*`
-- `/ws` -> `backend:8765` (WebSocket 업그레이드)
+### 2) 모델 호출이 실패할 때
+- `.env`의 provider 설정(`LLM_PROVIDER`, `EMBEDDING_PROVIDER`) 확인
+- provider 서버 상태 확인 (예: Ollama 실행 여부)
+- 모델 이름 오타/미설치 여부 확인
 
+### 3) Ollama를 안 쓰는데 관련 점검이 걸릴 때
+- `.env`에서 provider가 정말 `ollama`가 아닌지 다시 확인
 
-### Python 가상환경 + 의존성 설치
-macOS/Linux:
-```bash
-python -m venv venv
-./venv/bin/python -m pip install -r sttEngine/requirements.txt
-./venv/bin/python -m pip install -r requirements.txt
-# Ollama provider를 사용할 때만 추가 설치
-./venv/bin/python -m pip install -r requirements-ollama.txt
-```
+### 4) 작업이 중간 실패할 때
+- `/progress/<task_id>`의 `error_code`, `failed_step`, `retryable` 확인
+- 입력 파일 형식(특히 음성 파일/세그먼트 생성 가능 여부) 점검
 
-Windows PowerShell:
-```powershell
-python -m venv venv
-venv\Scripts\python.exe -m pip install -r sttEngine\requirements.txt
-venv\Scripts\python.exe -m pip install -r requirements.txt
-# Ollama provider를 사용할 때만 추가 설치
-venv\Scripts\python.exe -m pip install -r requirements-ollama.txt
-```
+### 5) 삭제/초기화 API가 거부될 때
+- 안전 모드 보호 동작일 가능성이 큽니다.
+- 파괴적 API는 토큰/세션 환경변수 설정이 필요합니다.
 
-### 서버 실행
-macOS/Linux:
-```bash
-./venv/bin/python -m sttEngine.server
-```
+### 6) 프론트가 API와 연결되지 않을 때 (Docker)
+- 프론트 컨테이너의 `/api`, `/ws` 프록시 구성과 백엔드 컨테이너 상태를 함께 점검
 
-Windows PowerShell:
-```powershell
-venv\Scripts\python.exe -m sttEngine.server
-```
+---
 
-기본 접속 주소:
-- HTTP(API): `http://localhost:8080`
-- WebSocket: `ws://localhost:8765`
-- (Docker 분리 배포) Frontend: `http://localhost:3000`
-- Windows `run.bat` 실행 시 `8080` 바인딩이 불가하면 자동으로 `18080`으로 대체됩니다.
-
-## 3) 모델/Provider 설정 방법
-
-모델 설정은 `.env` 파일에서 관리합니다(`.env.example` 참고).
-
-### 3-1. LLM/Embedding Provider 선택
-- `LLM_PROVIDER`: 교정/요약 provider (`ollama` 기본, `llamacpp`/`llama_cpp` 지원)
-- `EMBEDDING_PROVIDER`: 임베딩 provider (미지정 시 `LLM_PROVIDER` 상속)
-
-### 3-2. Ollama 사용 시
-1. Ollama 서버 실행
-2. 사용할 모델 pull (예: `gpt-oss:20b`)
-3. 필요 시 `.env`에 Ollama 주소/타임아웃 설정
-
-### 3-3. llama.cpp(In-process / `llama-cpp-python`) 사용 시
-- `pip install -r requirements.txt`로 `llama-cpp-python`을 함께 설치합니다.
-- `LLAMA_CPP_MODEL_PATH` (`.gguf` 모델 경로, 기본값 `./models/default_model.gguf`)
-- 로컬 모델 파일이 없을 때는 `HF_MODEL_REPO_ID` + `HF_MODEL_FILENAME`(선택 `HF_MODEL_REVISION`)를 사용해 Hugging Face에서 자동 다운로드합니다(`HF_TOKEN` 필요).
-- Hugging Face 다운로드 캐시 경로는 `LLAMA_CPP_MODEL_CACHE_DIR`(기본 `./models`)로 지정할 수 있습니다. Docker 사용 시 해당 경로를 볼륨으로 마운트해 영속화하세요.
-- Whisper 모델 다운로드 경로: `WHISPER_MODEL_DIR` (미지정 시 프로젝트 루트 `./models` 사용)
-- 선택 성능 튜닝: `LLAMA_CPP_N_CTX`, `LLAMA_CPP_N_THREADS`, `LLAMA_CPP_N_BATCH`, `LLAMA_CPP_N_GPU_LAYERS`, `LLAMA_CPP_CHAT_FORMAT`
-- 하위 호환용으로 `LLM_BASE_URL`, `EMBEDDING_BASE_URL`, `LLAMA_CPP_COMMAND`를 남겨둘 수 있으나, in-process 모드에서는 무시되며 warning 로그가 남습니다.
-
-### 3-4. 워크플로우 모델 키(`model_settings`)
-`/process` 요청 시 주로 아래 키를 사용합니다.
-- STT: `whisper`
-- 교정: `correct`
-- 요약: `summarize`
-- 공통: `provider`(또는 `llm_provider`), `temperature`, `context_window`, `max_tokens`
-- 화자 분리: `diarization_provider`, `num_speakers`, `min_speakers`, `max_speakers`
-
-## 4) 사용 방법
-
-## 4-1. 파일 업로드
-- 웹 UI에서 업로드하거나 `/upload` API를 사용합니다.
-- 업로드 후 레코드 경로(`DB/uploads/...`) 또는 `record_id`를 기준으로 처리합니다.
-
-## 4-2. 워크플로우 실행(`/process`)
-요청 예시:
-```json
-{
-  "file_path": "DB/uploads/<uuid>/sample.m4a",
-  "steps": ["stt", "correct", "summary"],
-  "record_id": "...",
-  "task_id": "...",
-  "model_settings": {
-    "whisper": "large-v3-turbo",
-    "language": "ko",
-    "device": "auto",
-    "provider": "ollama",
-    "correct": "gpt-oss:20b",
-    "summarize": "gpt-oss:20b"
-  }
-}
-```
-
-실행 상태 확인:
-- `GET /progress/<task_id>`
-- WebSocket 실시간 이벤트 (`ws://localhost:8765`)
-
-## 4-3. 결과 조회
-- 히스토리: `GET /history`
-- 검색: `GET /search`
-- 유사 문서: `GET /similar/<uuid_or_path>` 또는 `POST /similar`
-- 다운로드: `GET /download/<uuid_or_path>`
-
-## 5) 자주 쓰는 운영 명령
+## 자주 사용하는 명령
 
 ### 테스트
 ```bash
@@ -178,7 +157,10 @@ npm install
 npm run build
 ```
 
-## 6) 문제 해결 체크포인트
-- 모델 호출 실패 시: provider 실행 상태와 `.env`의 base URL/timeout을 먼저 확인
-- Ollama 미사용 구성인데 setup/run에서 Ollama 확인이 필요해 보이면: `.env`의 `LLM_PROVIDER`, `EMBEDDING_PROVIDER` 값 점검
-- 파괴적 API 호출 실패 시: 안전 모드 토큰/세션 환경변수 설정 여부 확인
+---
+
+## 문서 안내
+- 사용자/운영 중심 문서: `README.md`
+- 에이전트 개발 규칙 원문: `AGENTS.md`
+- 모델별 요약 문서: `CLAUDE.md`, `GEMINI.md`
+- 백로그: `TODO/TODO.md` 및 `TODO/*`


### PR DESCRIPTION
### Motivation
- Make the repository `README.md` focused on end-user UX and day-1 onboarding instead of implementation or architecture details. 
- Improve discoverability of core product flows (upload → processing → progress → search/similar/download) and reduce friction for new users. 
- Provide clear, actionable troubleshooting pointers for common runtime issues (provider/model, ports, destructive APIs).

### Description
- Replace the top-level `README.md` with an UX-oriented guide that describes capabilities, quick start steps, `.env` provider selection, typical workflow, Docker run options, and troubleshooting. 
- Call out important runtime fields and behaviors such as `progress_percent`, `eta_seconds`, `error_code`/`failed_step` and the default safe-mode protection for destructive APIs. 
- Add concise quick-start commands and examples for macOS/Linux (`./setup.sh`, `./run.sh`), Windows (`run.bat` fallback to `18080`), Docker (`docker compose` with `--profile` options), and common developer commands (`pytest`, frontend build steps).

### Testing
- No automated tests were run because this is a documentation-only change. 
- The updated `README.md` content and structure were manually inspected to verify clarity and completeness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c390a26e0c832e8fee1755569d9c75)