### PR TITLE
docs: clarify wildcard job file route and Content-Type in OpenAPI spec

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -377,9 +377,12 @@ paths:
       tags: [files]
       summary: Download one allowed job file
       description: |
-        `file_name`은 `stt/result.txt`처럼 슬래시를 포함할 수 있습니다.
+        서버 구현(axum)은 와일드카드 라우트(`/jobs/{job_id}/files/{*file_name}`)로 동작합니다.
+        이 명세에서는 OpenAPI 호환성을 위해 `{file_name}`으로 표기합니다.
+        `file_name`은 `stt/result.txt`처럼 슬래시를 포함할 수 있으며,
         클라이언트는 경로를 URL 인코딩해서 전달해야 합니다.
       operationId: getJobFile
+      x-axum-route: /jobs/{job_id}/files/{*file_name}
       parameters:
         - $ref: '#/components/parameters/JobId'
         - name: file_name
@@ -390,7 +393,7 @@ paths:
             type: string
       responses:
         '200':
-          description: Raw file bytes
+          description: Raw file bytes (서버가 Content-Type 헤더를 명시적으로 설정하지 않을 수 있음)
           content:
             application/octet-stream:
               schema:


### PR DESCRIPTION
### Motivation
- Clarify how the server's axum wildcard route maps to the OpenAPI path for job file downloads and document that clients must URL-encode `file_name`, while also noting that the server may not always set a `Content-Type` header for raw file responses.

### Description
- Updated `docs/openapi.yaml` for the `GET /jobs/{job_id}/files/{file_name}` operation to explain the axum wildcard behavior, add the `x-axum-route: /jobs/{job_id}/files/{*file_name}` extension, and adjust the `200` response description to indicate potential absence of an explicit `Content-Type` header.

### Testing
- No automated tests were added or modified for this documentation-only change and the existing automated test suite was not affected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3a7ca8d98832e885f4ec1eb833f73)