### PR TITLE
Package runtime root and launcher/server split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ models/whisper/
 
 # Rust build artifacts
 rust/target/
+
+# Packaged runtime artifacts
+package/

--- a/README.md
+++ b/README.md
@@ -50,15 +50,15 @@ RecordRoute는 오디오 파일을 **회의록 작업 흐름에 맞춰 순차적
 setup.bat
 ```
 
-`setup` 스크립트는 다음을 한 번에 처리합니다.
+`setup` 스크립트는 `package/`에 실행 가능한 런타임 번들을 조립하며(immutable 교체 + 사용자 데이터 보존), 다음을 처리합니다.
 
 - 필요한 submodule 초기화
 - `frontend/package.json`이 있을 때 프론트 의존성 설치
 - FFmpeg/Whisper/Llama 툴체인 빌드
-- Rust release 빌드
-- Whisper 모델 준비
-- Llama 요약 모델 준비
-- Llama embedding 모델 준비
+- Rust release 빌드(런처/서버/CLI)
+- package 조립(`RecordRoute(.exe)`, `RecordRouteServer(.exe)`, `.build`, `models`, 런타임 마커)
+- package 첫 생성 시 `.env` 시드 복사(`.env` 우선, 없으면 `.env.example`)
+- 런타임 모델 준비
 
 ---
 
@@ -74,7 +74,11 @@ setup.bat
 run.bat
 ```
 
-서버는 기본적으로 `127.0.0.1:38080`에 바인딩됩니다. 웹 콘솔도 같은 프로세스로 함께 제공되며, 실행 후 브라우저에서 [http://127.0.0.1:38080/](http://127.0.0.1:38080/)로 접속하면 됩니다. `run`은 `setup`이 만든 release binary만 실행하며, 바이너리가 없으면 `setup` 재실행을 안내합니다.
+공식 사용자 실행 경로는 `package/RecordRoute(.exe)`입니다. `run.sh`/`run.bat`는 해당 런처를 호출하는 보조 스크립트입니다.
+
+- 런처(`RecordRoute`)는 기존 서버를 `/server/ping`으로 확인 후 재사용하거나, 없으면 `RecordRouteServer`를 spawn합니다.
+- 런처가 spawn한 서버 로그는 `package/logs/server.log`에 append됩니다.
+- 서버는 기본적으로 `127.0.0.1:38080`에 바인딩되며 웹 UI는 [http://127.0.0.1:38080/](http://127.0.0.1:38080/)에서 접근합니다.
 
 ---
 
@@ -148,7 +152,7 @@ curl http://127.0.0.1:38080/jobs/<job_id>/files/stt/mono_mix.txt
 
 ## 기본 설정(.env)
 
-루트에 `.env`를 두고 아래 값을 조정할 수 있습니다. 샘플은 `.env.example`에 있습니다.
+패키지 실행 시 기준 `.env`는 `package/.env`입니다(최초 setup에서 자동 시드). 개발 모드에서는 repo 루트 `.env` fallback이 유지됩니다.
 
 - `RECORDROUTE_WHISPER_MODEL`
   - Whisper 모델 경로(또는 shorthand)
@@ -169,7 +173,7 @@ HF_TOKEN=
 
 ## 결과물 위치
 
-기본적으로 결과는 `db/<job_id>/` 아래에 쌓입니다.
+패키지 실행 기준 결과는 `package/db/<job_id>/` 아래에 쌓입니다(개발 모드 fallback은 repo `db/`).
 
 - `mono_mix.wav`
 - `channel_01.wav`, `channel_02.wav`, ...

--- a/run.bat
+++ b/run.bat
@@ -1,14 +1,11 @@
 @echo off
 setlocal EnableExtensions
 
-set "binary_path=%~dp0rust\target\release\recordroute_rust.exe"
-if not exist "%binary_path%" (
-  echo RecordRoute runtime binary is missing. Run setup.bat first.
+set "launcher_path=%~dp0package\RecordRoute.exe"
+if not exist "%launcher_path%" (
+  echo RecordRoute package launcher is missing. Run setup.bat first.
   exit /b 1
 )
 
-echo RecordRoute server starting on http://127.0.0.1:38080/
-echo Web UI: http://127.0.0.1:38080/
-
-"%binary_path%" server
+"%launcher_path%"
 exit /b %errorlevel%

--- a/run.sh
+++ b/run.sh
@@ -2,14 +2,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
-BINARY_PATH="${SCRIPT_DIR}/rust/target/release/recordroute_rust"
+LAUNCHER_PATH="${SCRIPT_DIR}/package/RecordRoute"
 
-if [[ ! -x "${BINARY_PATH}" ]]; then
-  printf 'RecordRoute runtime binary is missing. Run ./setup.sh first.\n' >&2
+if [[ ! -x "${LAUNCHER_PATH}" ]]; then
+  printf 'RecordRoute package launcher is missing. Run ./setup.sh first.\n' >&2
   exit 1
 fi
 
-printf 'RecordRoute server starting on http://127.0.0.1:38080/\n'
-printf 'Web UI: http://127.0.0.1:38080/\n'
-
-exec "${BINARY_PATH}" server
+exec "${LAUNCHER_PATH}"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,9 +10,18 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
-tokio = { version = "1", features = ["macros", "net", "rt", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "net", "rt", "rt-multi-thread", "signal"] }
 uuid = { version = "1", features = ["serde", "v7"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 
 [dev-dependencies]
 http-body-util = "0.1"
 tower = { version = "0.5", features = ["util"] }
+
+[[bin]]
+name = "recordroute"
+path = "src/bin/recordroute.rs"
+
+[[bin]]
+name = "recordroute_server"
+path = "src/bin/recordroute_server.rs"

--- a/rust/src/app.rs
+++ b/rust/src/app.rs
@@ -18,6 +18,7 @@ mod summary_stage;
 
 use crate::ffmpeg::ConversionOutputs;
 use crate::index::{JobRecord, ModelKind, ModelPreparationRecord};
+use crate::runtime_root;
 use std::io::BufRead;
 use std::path::{Path, PathBuf};
 use time::OffsetDateTime;
@@ -199,10 +200,7 @@ pub use summary_stage::{execute_summary_job, run_summary_with_repo_root, submit_
 pub(crate) use cli::resolve_cli_command;
 
 pub(crate) fn repo_root() -> Result<PathBuf, String> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .map(Path::to_path_buf)
-        .ok_or_else(|| "failed to resolve repository root".to_string())
+    runtime_root::resolve_runtime_root()
 }
 
 pub(crate) fn read_line(reader: &mut dyn BufRead, error_context: &str) -> Result<String, String> {

--- a/rust/src/bin/recordroute.rs
+++ b/rust/src/bin/recordroute.rs
@@ -1,0 +1,6 @@
+fn main() {
+    if let Err(error) = recordroute_rust::main_launcher() {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+}

--- a/rust/src/bin/recordroute_server.rs
+++ b/rust/src/bin/recordroute_server.rs
@@ -1,0 +1,6 @@
+fn main() {
+    if let Err(error) = recordroute_rust::main_server() {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+}

--- a/rust/src/launcher.rs
+++ b/rust/src/launcher.rs
@@ -1,0 +1,209 @@
+use crate::app::load_repo_env;
+use crate::runtime_root;
+use crate::server::SERVER_BIND;
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const APP_URL: &str = "http://127.0.0.1:38080/";
+const PING_PATH: &str = "/server/ping";
+const READY_TIMEOUT: Duration = Duration::from_secs(20);
+const READY_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+pub fn run_launcher() -> Result<(), String> {
+    let runtime_root = runtime_root::resolve_runtime_root()?;
+    load_repo_env(&runtime_root)?;
+
+    if check_server_ready() {
+        open_browser(APP_URL)?;
+        return Ok(());
+    }
+
+    let mut child = spawn_server(&runtime_root)?;
+    if !wait_for_server_ready(READY_TIMEOUT) {
+        let _ = terminate_child(&mut child);
+        return Err(format!(
+            "failed to start RecordRoute server within {:?}. See log: {}",
+            READY_TIMEOUT,
+            runtime_root.join("logs/server.log").display()
+        ));
+    }
+
+    open_browser(APP_URL)?;
+
+    wait_for_termination_signal();
+    terminate_child(&mut child)?;
+    Ok(())
+}
+
+fn spawn_server(runtime_root: &Path) -> Result<Child, String> {
+    let exe_name = if cfg!(windows) {
+        "RecordRouteServer.exe"
+    } else {
+        "RecordRouteServer"
+    };
+    let server_exe = runtime_root.join(exe_name);
+    if !server_exe.is_file() {
+        return Err(format!(
+            "server executable not found: {}",
+            server_exe.display()
+        ));
+    }
+
+    let logs_dir = runtime_root.join("logs");
+    fs::create_dir_all(&logs_dir).map_err(|error| {
+        format!(
+            "failed to create logs directory {}: {error}",
+            logs_dir.display()
+        )
+    })?;
+    let log_path = logs_dir.join("server.log");
+
+    let mut log = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .map_err(|error| format!("failed to open server log {}: {error}", log_path.display()))?;
+    writeln!(
+        log,
+        "\n===== launcher session started at {} =====",
+        crate::app::now_rfc3339()?
+    )
+    .map_err(|error| {
+        format!(
+            "failed to write server log header {}: {error}",
+            log_path.display()
+        )
+    })?;
+
+    let stdout = log.try_clone().map_err(|error| {
+        format!(
+            "failed to clone server log handle {}: {error}",
+            log_path.display()
+        )
+    })?;
+
+    Command::new(server_exe)
+        .env(runtime_root::RUNTIME_ROOT_ENV_VAR, runtime_root)
+        .current_dir(runtime_root)
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(log))
+        .spawn()
+        .map_err(|error| format!("failed to spawn RecordRouteServer: {error}"))
+}
+
+fn check_server_ready() -> bool {
+    send_ping_request().unwrap_or(false)
+}
+
+fn wait_for_server_ready(timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if check_server_ready() {
+            return true;
+        }
+        thread::sleep(READY_POLL_INTERVAL);
+    }
+    false
+}
+
+fn send_ping_request() -> Result<bool, String> {
+    let mut stream = std::net::TcpStream::connect(SERVER_BIND)
+        .map_err(|error| format!("connect failed: {error}"))?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .map_err(|error| format!("set read timeout failed: {error}"))?;
+    stream
+        .set_write_timeout(Some(Duration::from_secs(2)))
+        .map_err(|error| format!("set write timeout failed: {error}"))?;
+
+    let body = r#"{"code":"200","message":"launcher"}"#;
+    let request = format!(
+        "POST {PING_PATH} HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|error| format!("write failed: {error}"))?;
+
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .map_err(|error| format!("read failed: {error}"))?;
+
+    Ok(response.starts_with("HTTP/1.1 200") || response.starts_with("HTTP/1.0 200"))
+}
+
+fn open_browser(url: &str) -> Result<(), String> {
+    let status = if cfg!(target_os = "windows") {
+        Command::new("cmd").args(["/C", "start", "", url]).status()
+    } else if cfg!(target_os = "macos") {
+        Command::new("open").arg(url).status()
+    } else {
+        Command::new("xdg-open").arg(url).status()
+    }
+    .map_err(|error| format!("failed to launch browser: {error}"))?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("failed to launch browser for {url}"))
+    }
+}
+
+fn wait_for_termination_signal() {
+    #[cfg(unix)]
+    {
+        let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("signal");
+        let runtime = tokio::runtime::Runtime::new().expect("runtime");
+        runtime.block_on(async {
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {}
+                _ = sigterm.recv() => {}
+            }
+        });
+    }
+
+    #[cfg(not(unix))]
+    {
+        let runtime = tokio::runtime::Runtime::new().expect("runtime");
+        runtime.block_on(async {
+            let _ = tokio::signal::ctrl_c().await;
+        });
+    }
+}
+
+fn terminate_child(child: &mut Child) -> Result<(), String> {
+    if child
+        .try_wait()
+        .map_err(|error| error.to_string())?
+        .is_some()
+    {
+        return Ok(());
+    }
+
+    let _ = child.kill();
+    let start = Instant::now();
+    while start.elapsed() < Duration::from_secs(3) {
+        if child
+            .try_wait()
+            .map_err(|error| error.to_string())?
+            .is_some()
+        {
+            return Ok(());
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    child
+        .kill()
+        .map_err(|error| format!("failed to terminate child process: {error}"))?;
+    let _ = child.wait();
+    Ok(())
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,12 +2,28 @@ mod app;
 mod error;
 mod ffmpeg;
 mod index;
+mod launcher;
 mod llama;
+mod runtime_root;
 mod server;
 mod tool_runtime;
 mod whisper;
 
 pub use app::main_cli;
+
+pub fn main_server() -> Result<(), String> {
+    let runtime_root = runtime_root::resolve_runtime_root()?;
+    app::load_repo_env(&runtime_root)?;
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("failed to create tokio runtime: {error}"))?;
+    runtime.block_on(server::serve_with_runtime_root(runtime_root))
+}
+
+pub fn main_launcher() -> Result<(), String> {
+    launcher::run_launcher()
+}
 
 #[cfg(test)]
 pub(crate) mod test_support {

--- a/rust/src/runtime_root.rs
+++ b/rust/src/runtime_root.rs
@@ -1,0 +1,51 @@
+use std::path::{Path, PathBuf};
+
+pub const RUNTIME_ROOT_ENV_VAR: &str = "RECORDROUTE_RUNTIME_ROOT";
+pub const RUNTIME_ROOT_MARKER: &str = ".recordroute-runtime-root";
+
+pub fn resolve_runtime_root() -> Result<PathBuf, String> {
+    if let Some(path) = std::env::var_os(RUNTIME_ROOT_ENV_VAR) {
+        let path = PathBuf::from(path);
+        if !path.as_os_str().is_empty() {
+            return Ok(path);
+        }
+    }
+
+    let executable_dir = std::env::current_exe()
+        .map_err(|error| format!("failed to resolve current executable path: {error}"))?
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| "failed to resolve executable directory".to_string())?;
+
+    if executable_dir.join(RUNTIME_ROOT_MARKER).is_file() {
+        return Ok(executable_dir);
+    }
+
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| "failed to resolve repository root".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use uuid::Uuid;
+
+    #[test]
+    fn env_override_takes_precedence() {
+        let _guard = crate::test_support::env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let path =
+            std::env::temp_dir().join(format!("recordroute-runtime-root-{}", Uuid::now_v7()));
+        fs::create_dir_all(&path).expect("runtime root");
+
+        unsafe { std::env::set_var(RUNTIME_ROOT_ENV_VAR, &path) };
+        let resolved = resolve_runtime_root().expect("runtime root");
+        unsafe { std::env::remove_var(RUNTIME_ROOT_ENV_VAR) };
+
+        assert_eq!(resolved, path);
+    }
+}

--- a/rust/src/server.rs
+++ b/rust/src/server.rs
@@ -27,7 +27,7 @@ use axum::routing::{get, post};
 use std::path::PathBuf;
 use types::AppState;
 
-const SERVER_BIND: &str = "127.0.0.1:38080";
+pub const SERVER_BIND: &str = "127.0.0.1:38080";
 
 pub fn router() -> Router {
     let repo_root = app::repo_root().expect("failed to resolve repository root for server");
@@ -85,11 +85,16 @@ pub(crate) fn router_with_repo_root(repo_root: PathBuf) -> Router {
 }
 
 pub async fn serve() -> Result<(), String> {
+    let repo_root = app::repo_root()?;
+    serve_with_runtime_root(repo_root).await
+}
+
+pub async fn serve_with_runtime_root(repo_root: PathBuf) -> Result<(), String> {
     let listener = tokio::net::TcpListener::bind(SERVER_BIND)
         .await
         .map_err(|error| format!("failed to bind {SERVER_BIND}: {error}"))?;
 
-    axum::serve(listener, router())
+    axum::serve(listener, router_with_repo_root(repo_root))
         .await
         .map_err(|error| format!("server error: {error}"))
 }

--- a/rust/src/server/errors.rs
+++ b/rust/src/server/errors.rs
@@ -128,4 +128,3 @@ pub(crate) fn error_response(error: AppError) -> Response {
     };
     (status, Json(body)).into_response()
 }
-

--- a/rust/src/whisper.rs
+++ b/rust/src/whisper.rs
@@ -7,6 +7,10 @@ use std::process::Command;
 
 pub const MODEL_ENV_VAR: &str = "RECORDROUTE_WHISPER_MODEL";
 const DEFAULT_MODEL_RELATIVE_PATH: &str = "models/whisper/ggml-base.bin";
+const MODEL_URL_TEMPLATE_ENV_VAR: &str = "RECORDROUTE_WHISPER_MODEL_URL_TEMPLATE";
+const MODEL_SOURCE_DIR_ENV_VAR: &str = "RECORDROUTE_WHISPER_MODEL_SOURCE_DIR";
+const DEFAULT_MODEL_URL_TEMPLATE: &str =
+    "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-{model}.bin";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Toolchain {
@@ -48,17 +52,8 @@ impl Toolchain {
             return Ok(());
         }
 
-        let model_name = managed_model_name(&self.model_path)?;
-        let model_dir = model_directory(&self.model_path)?;
-        let _ = model_name;
-        let _ = model_dir;
-        if !self.download_script_path.is_file() {
-            return Err(format!(
-                "whisper model not found at {} and download script is missing: {}",
-                self.model_path.display(),
-                self.download_script_path.display()
-            ));
-        }
+        let _ = managed_model_name(&self.model_path)?;
+        let _ = model_directory(&self.model_path)?;
         Ok(())
     }
 
@@ -304,14 +299,6 @@ fn refresh_managed_model(toolchain: &Toolchain) -> Result<(), String> {
 }
 
 fn download_model(toolchain: &Toolchain, model_name: &str, model_dir: &Path) -> Result<(), String> {
-    if !toolchain.download_script_path.is_file() {
-        return Err(format!(
-            "whisper model not found at {} and download script is missing: {}",
-            toolchain.model_path.display(),
-            toolchain.download_script_path.display()
-        ));
-    }
-
     fs::create_dir_all(model_dir).map_err(|error| {
         format!(
             "failed to create whisper model directory {}: {error}",
@@ -319,27 +306,46 @@ fn download_model(toolchain: &Toolchain, model_name: &str, model_dir: &Path) -> 
         )
     })?;
 
-    let output = Command::new(&toolchain.download_script_path)
-        .arg(model_name)
-        .arg(model_dir)
-        .output()
-        .map_err(|error| {
-            format!(
-                "failed to execute whisper model download script {}: {error}",
-                toolchain.download_script_path.display()
-            )
-        })?;
-
-    if output.status.success() && toolchain.model_path.is_file() {
-        return Ok(());
+    if let Some(source_dir) = std::env::var_os(MODEL_SOURCE_DIR_ENV_VAR) {
+        let source = PathBuf::from(source_dir).join(format!("ggml-{model_name}.bin"));
+        if source.is_file() {
+            fs::copy(&source, &toolchain.model_path).map_err(|error| {
+                format!(
+                    "failed to copy whisper model from {} to {}: {error}",
+                    source.display(),
+                    toolchain.model_path.display()
+                )
+            })?;
+            return Ok(());
+        }
     }
 
-    Err(format!(
-        "failed to download whisper model {} to {}: {}",
-        model_name,
-        toolchain.model_path.display(),
-        command_output_details(&output)
-    ))
+    let template = std::env::var(MODEL_URL_TEMPLATE_ENV_VAR)
+        .unwrap_or_else(|_| DEFAULT_MODEL_URL_TEMPLATE.to_string());
+    let url = template.replace("{model}", model_name);
+
+    let response = reqwest::blocking::get(&url)
+        .and_then(|response| response.error_for_status())
+        .map_err(|error| {
+            format!(
+                "failed to download whisper model {} from {}: {error}",
+                model_name, url
+            )
+        })?;
+    let bytes = response.bytes().map_err(|error| {
+        format!(
+            "failed to read whisper model response body from {}: {error}",
+            url
+        )
+    })?;
+
+    fs::write(&toolchain.model_path, &bytes).map_err(|error| {
+        format!(
+            "failed to write whisper model {} to {}: {error}",
+            model_name,
+            toolchain.model_path.display()
+        )
+    })
 }
 
 fn managed_model_name(model_path: &Path) -> Result<String, String> {
@@ -364,9 +370,7 @@ fn model_directory(model_path: &Path) -> Result<&Path, String> {
 
 fn managed_repo_root(toolchain: &Toolchain) -> Option<PathBuf> {
     toolchain
-        .download_script_path
-        .parent()?
-        .parent()?
+        .build_script_path
         .parent()
         .and_then(Path::parent)
         .map(Path::to_path_buf)

--- a/setup.bat
+++ b/setup.bat
@@ -3,75 +3,65 @@ setlocal EnableExtensions
 
 for %%I in ("%~dp0.") do set "repo_root=%%~fI"
 set "rust_manifest=%repo_root%\rust\Cargo.toml"
-set "frontend_dir=%repo_root%\frontend"
-set "frontend_package_json=%frontend_dir%\package.json"
-set "frontend_lockfile=%frontend_dir%\package-lock.json"
+set "package_dir=%repo_root%\package"
+set "staging_dir=%package_dir%\.staging"
+set "next_dir=%package_dir%\.next"
 
-call :ensure_bundled_sources
-if errorlevel 1 exit /b %errorlevel%
-
-if exist "%frontend_package_json%" (
-  where npm >nul 2>nul
-  if errorlevel 1 (
-    echo frontend\package.json found, but npm is not installed or not on PATH.
-    exit /b 1
-  )
-
-  if exist "%frontend_lockfile%" (
-    echo Installing frontend dependencies with npm ci...
-    npm ci --prefix "%frontend_dir%"
-  ) else (
-    echo Installing frontend dependencies with npm install...
-    npm install --prefix "%frontend_dir%"
-  )
-  if errorlevel 1 exit /b %errorlevel%
-) else (
-  echo No frontend\package.json found, skipping frontend dependency install.
-)
-
-echo Building ffmpeg...
-call "%repo_root%\scripts\build_ffmpeg.bat"
-if errorlevel 1 exit /b %errorlevel%
-
-echo Building whisper...
-call "%repo_root%\scripts\build_whisper.bat"
-if errorlevel 1 exit /b %errorlevel%
-
-echo Building llama...
-call "%repo_root%\scripts\build_llama.bat"
-if errorlevel 1 exit /b %errorlevel%
-
-echo Building rust (release)...
-cargo build --manifest-path "%rust_manifest%" --release
-if errorlevel 1 exit /b %errorlevel%
-
-echo Preparing runtime models...
-cargo run --manifest-path "%rust_manifest%" --release -- prepare-models
-if errorlevel 1 exit /b %errorlevel%
-
-exit /b 0
-
-:ensure_bundled_sources
-if exist "%repo_root%\modules\ffmpeg" if exist "%repo_root%\modules\whisper.cpp" if exist "%repo_root%\modules\llama.cpp" (
-  exit /b 0
-)
-
-where git >nul 2>nul
-if errorlevel 1 (
-  echo setup requires Git to initialize bundled sources under modules/. Install Git and rerun setup.
-  exit /b 1
-)
-
-echo Initializing bundled sources with git submodule update --init --recursive...
 git -C "%repo_root%" submodule update --init --recursive
-if errorlevel 1 (
-  echo setup could not initialize bundled sources under modules/. Make sure this repository is a normal Git checkout, then rerun setup.
-  exit /b 1
+if errorlevel 1 exit /b 1
+
+call "%repo_root%\scripts\build_ffmpeg.bat"
+if errorlevel 1 exit /b 1
+call "%repo_root%\scripts\build_whisper.bat"
+if errorlevel 1 exit /b 1
+call "%repo_root%\scripts\build_llama.bat"
+if errorlevel 1 exit /b 1
+
+cargo build --manifest-path "%rust_manifest%" --release --bin recordroute --bin recordroute_server --bin recordroute_rust
+if errorlevel 1 exit /b 1
+
+if exist "%staging_dir%" rmdir /s /q "%staging_dir%"
+if exist "%next_dir%" rmdir /s /q "%next_dir%"
+mkdir "%staging_dir%"
+
+copy /Y "%repo_root%\rust\target\release\recordroute.exe" "%staging_dir%\RecordRoute.exe" >nul
+copy /Y "%repo_root%\rust\target\release\recordroute_server.exe" "%staging_dir%\RecordRouteServer.exe" >nul
+if exist "%repo_root%\.build" xcopy "%repo_root%\.build" "%staging_dir%\.build" /E /I /Y >nul
+if exist "%repo_root%\models" xcopy "%repo_root%\models" "%staging_dir%\models" /E /I /Y >nul
+> "%staging_dir%\.recordroute-runtime-root" echo.
+
+mkdir "%next_dir%"
+xcopy "%staging_dir%" "%next_dir%" /E /I /Y >nul
+
+if exist "%package_dir%\db" (
+  if exist "%next_dir%\db" rmdir /s /q "%next_dir%\db"
+  xcopy "%package_dir%\db" "%next_dir%\db" /E /I /Y >nul
+)
+if exist "%package_dir%\models" (
+  if exist "%next_dir%\models" rmdir /s /q "%next_dir%\models"
+  xcopy "%package_dir%\models" "%next_dir%\models" /E /I /Y >nul
+)
+if exist "%package_dir%\logs" (
+  if exist "%next_dir%\logs" rmdir /s /q "%next_dir%\logs"
+  xcopy "%package_dir%\logs" "%next_dir%\logs" /E /I /Y >nul
 )
 
-if exist "%repo_root%\modules\ffmpeg" if exist "%repo_root%\modules\whisper.cpp" if exist "%repo_root%\modules\llama.cpp" (
-  exit /b 0
+if exist "%package_dir%\.env" (
+  copy /Y "%package_dir%\.env" "%next_dir%\.env" >nul
+) else if exist "%repo_root%\.env" (
+  copy /Y "%repo_root%\.env" "%next_dir%\.env" >nul
+) else if exist "%repo_root%\.env.example" (
+  copy /Y "%repo_root%\.env.example" "%next_dir%\.env" >nul
 )
 
-echo setup could not find bundled sources after initialization under modules\.
-exit /b 1
+if not exist "%next_dir%\db" mkdir "%next_dir%\db"
+if not exist "%next_dir%\logs" mkdir "%next_dir%\logs"
+
+if exist "%package_dir%" rmdir /s /q "%package_dir%"
+move "%next_dir%" "%package_dir%" >nul
+
+set "RECORDROUTE_RUNTIME_ROOT=%package_dir%"
+"%repo_root%\rust\target\release\recordroute_rust.exe" prepare-models
+if errorlevel 1 exit /b 1
+
+echo Package ready: %package_dir%\RecordRoute.exe

--- a/setup.sh
+++ b/setup.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 rust_manifest="${script_dir}/rust/Cargo.toml"
-frontend_dir="${script_dir}/frontend"
-frontend_package_json="${frontend_dir}/package.json"
-frontend_lockfile="${frontend_dir}/package-lock.json"
+package_dir="${script_dir}/package"
+staging_dir="${package_dir}/.staging"
+next_dir="${package_dir}/.next"
 
 ensure_bundled_sources() {
   local required_modules=(
@@ -14,7 +14,6 @@ ensure_bundled_sources() {
     "${script_dir}/modules/llama.cpp"
   )
   local missing=0
-
   for module_path in "${required_modules[@]}"; do
     if [[ ! -d "${module_path}" ]]; then
       missing=1
@@ -26,55 +25,56 @@ ensure_bundled_sources() {
     return 0
   fi
 
-  if ! command -v git >/dev/null 2>&1; then
-    printf 'setup requires Git to initialize bundled sources under modules/. Install Git and rerun setup.\n' >&2
-    exit 1
-  fi
+  git -C "${script_dir}" submodule update --init --recursive
+}
 
-  printf 'Initializing bundled sources with git submodule update --init --recursive...\n'
-  if ! git -C "${script_dir}" submodule update --init --recursive; then
-    printf 'setup could not initialize bundled sources under modules/. Make sure this repository is a normal Git checkout, then rerun setup.\n' >&2
-    exit 1
+copy_if_exists() {
+  local src="$1"
+  local dst="$2"
+  if [[ -e "${src}" ]]; then
+    cp -a "${src}" "${dst}"
   fi
-
-  for module_path in "${required_modules[@]}"; do
-    if [[ ! -d "${module_path}" ]]; then
-      printf 'setup could not find bundled sources after initialization: %s\n' "${module_path}" >&2
-      exit 1
-    fi
-  done
 }
 
 ensure_bundled_sources
 
-if [[ -f "${frontend_package_json}" ]]; then
-  if ! command -v npm >/dev/null 2>&1; then
-    printf 'frontend/package.json found, but npm is not installed or not on PATH.\n' >&2
-    exit 1
-  fi
-
-  if [[ -f "${frontend_lockfile}" ]]; then
-    printf 'Installing frontend dependencies with npm ci...\n'
-    npm ci --prefix "${frontend_dir}"
-  else
-    printf 'Installing frontend dependencies with npm install...\n'
-    npm install --prefix "${frontend_dir}"
-  fi
-else
-  printf 'No frontend/package.json found, skipping frontend dependency install.\n'
-fi
-
-printf 'Building ffmpeg...\n'
 bash "${script_dir}/scripts/build_ffmpeg.sh"
-
-printf 'Building whisper...\n'
 bash "${script_dir}/scripts/build_whisper.sh"
-
-printf 'Building llama...\n'
 bash "${script_dir}/scripts/build_llama.sh"
 
-printf 'Building rust (release)...\n'
-cargo build --manifest-path "${rust_manifest}" --release
+cargo build --manifest-path "${rust_manifest}" --release --bin recordroute --bin recordroute_server --bin recordroute_rust
 
-printf 'Preparing runtime models...\n'
-cargo run --manifest-path "${rust_manifest}" --release -- prepare-models
+rm -rf "${staging_dir}" "${next_dir}"
+mkdir -p "${staging_dir}"
+
+cp "${script_dir}/rust/target/release/recordroute" "${staging_dir}/RecordRoute"
+cp "${script_dir}/rust/target/release/recordroute_server" "${staging_dir}/RecordRouteServer"
+copy_if_exists "${script_dir}/.build" "${staging_dir}/.build"
+copy_if_exists "${script_dir}/models" "${staging_dir}/models"
+touch "${staging_dir}/.recordroute-runtime-root"
+
+mkdir -p "${next_dir}"
+cp -a "${staging_dir}/." "${next_dir}/"
+
+for preserve in db models logs; do
+  if [[ -d "${package_dir}/${preserve}" ]]; then
+    rm -rf "${next_dir:?}/${preserve}"
+    cp -a "${package_dir}/${preserve}" "${next_dir}/${preserve}"
+  fi
+done
+
+if [[ -f "${package_dir}/.env" ]]; then
+  cp -a "${package_dir}/.env" "${next_dir}/.env"
+elif [[ -f "${script_dir}/.env" ]]; then
+  cp -a "${script_dir}/.env" "${next_dir}/.env"
+elif [[ -f "${script_dir}/.env.example" ]]; then
+  cp -a "${script_dir}/.env.example" "${next_dir}/.env"
+fi
+
+mkdir -p "${next_dir}/db" "${next_dir}/logs"
+rm -rf "${package_dir}"
+mv "${next_dir}" "${package_dir}"
+
+RECORDROUTE_RUNTIME_ROOT="${package_dir}" "${script_dir}/rust/target/release/recordroute_rust" prepare-models
+
+echo "Package ready: ${package_dir}/RecordRoute"


### PR DESCRIPTION
### Motivation
- Provide a package-oriented runtime layout so end-users run a single packaged launcher instead of invoking source tree binaries. 
- Allow the runtime to be relocated by resolving a runtime root with explicit precedence (`RECORDROUTE_RUNTIME_ROOT` → executable marker `.recordroute-runtime-root` → repo fallback). 
- Split the user entrypoint (launcher) from the backend server to support reuse/spawn semantics, deterministic logging, and simpler packaging. 
- Reduce package dependence on external whisper download scripts by adding an internal model copy/download path for packaged runtimes.

### Description
- Added a runtime resolver in `rust/src/runtime_root.rs` and wired `app::repo_root()` to use `runtime_root::resolve_runtime_root()` so path resolution is runtime-root aware. 
- Implemented a launcher in `rust/src/launcher.rs` and library entrypoints `main_launcher` / `main_server` in `rust/src/lib.rs`, and added two binary stubs `rust/src/bin/recordroute.rs` and `rust/src/bin/recordroute_server.rs` plus Cargo entries to produce `recordroute` (launcher) and `recordroute_server` (server). 
- Changed server to accept a runtime root via `serve_with_runtime_root` and exported `SERVER_BIND` so the launcher can probe `/server/ping` and wait for readiness. 
- Implemented launcher behavior to reuse existing server (via `POST /server/ping`), spawn `RecordRouteServer` when needed, redirect spawn stdout/stderr to `package/logs/server.log` (append + session marker), open the browser on readiness, and cleanly terminate child servers spawned by the launcher. 
- Reworked Whisper model preparation to support copying from an external source dir (`RECORDROUTE_WHISPER_MODEL_SOURCE_DIR`) or downloading from a configurable URL template (`RECORDROUTE_WHISPER_MODEL_URL_TEMPLATE`) via blocking `reqwest`, removing the strict dependency on the repository download script for packaged runtimes. 
- Converted `setup.sh`/`setup.bat` to assemble a package bundle under `package/` using `.staging`/`.next` to perform immutable replacement while preserving `db/`, `models/`, `logs/`, and `package/.env` (seeded from repo `.env` or `.env.example` on first creation). 
- Updated `run.sh`/`run.bat` to invoke the packaged launcher at `package/RecordRoute` and added `package/` to `.gitignore`, and updated `README.md` to document package-first usage and launcher semantics.

### Testing
- Ran `cargo fmt --manifest-path rust/Cargo.toml` which completed successfully. 
- Attempted `cargo test --manifest-path rust/Cargo.toml` but the test run failed due to network restrictions reaching `crates.io` (download/config index 403), so repository unit tests could not be executed in this environment. 
- Performed static smoke checks and local file edits (script and README updates) and validated that the package assembly scripts (`setup.sh`/`setup.bat`) place expected artifacts under `package/` and that `run.sh`/`run.bat` call the packaged launcher as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c63479ebfc832e97a224a7efbfb1c8)