### PR TITLE
feat(frontend): improve drag-and-drop upload interaction

### DIFF
--- a/frontend/src/components/UploadSection.tsx
+++ b/frontend/src/components/UploadSection.tsx
@@ -29,6 +29,7 @@ export function UploadSection() {
   const [uploading, setUploading] = useState(false);
   const [statusMessage, setStatusMessage] = useState<{ text: string; type: 'success' | 'error' | 'info' | 'warning' } | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const dragEnterCounterRef = useRef(0);
 
   const showStatus = useCallback((text: string, type: 'success' | 'error' | 'info' | 'warning' = 'info', duration = 3000) => {
     setStatusMessage({ text, type });
@@ -39,20 +40,33 @@ export function UploadSection() {
 
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = 'copy';
+    setIsDragging(true);
+  };
+
+  const handleDragEnter = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragEnterCounterRef.current += 1;
     setIsDragging(true);
   };
 
   const handleDragLeave = (e: React.DragEvent) => {
     e.preventDefault();
-    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+    e.stopPropagation();
+    dragEnterCounterRef.current = Math.max(0, dragEnterCounterRef.current - 1);
+    if (dragEnterCounterRef.current === 0) {
       setIsDragging(false);
     }
   };
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
+    e.stopPropagation();
     setIsDragging(false);
-    const files = Array.from(e.dataTransfer.files);
+    dragEnterCounterRef.current = 0;
+    const files = Array.from(e.dataTransfer.files).filter(file => file.size > 0);
     addFiles(files);
   };
 
@@ -166,6 +180,7 @@ export function UploadSection() {
 
           {/* Drop Zone */}
           <div
+            onDragEnter={handleDragEnter}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}


### PR DESCRIPTION
### Motivation
- Make the upload panel reliably support drag-and-drop file uploads and avoid flicker or missed drops when dragging across nested elements. 
- Prevent invalid/empty drag payloads from being added as upload candidates and reduce accidental browser default behaviors during drag operations.

### Description
- Added a `dragEnterCounterRef` and `handleDragEnter` to track nested `dragenter`/`dragleave` events and prevent highlight flicker inside the drop zone. 
- Hardened drag event handling by calling `stopPropagation()` on drag events and setting `e.dataTransfer.dropEffect = 'copy'` in `handleDragOver` for clearer UX. 
- Filtered out zero-byte files on drop and reset the enter counter on `drop` to avoid invalid upload candidates. 
- Wired the new `onDragEnter` handler into the drop zone and adjusted `handleDragLeave`/`handleDrop` to use the counter and propagation guards. 
- File changed: `frontend/src/components/UploadSection.tsx`.

### Testing
- Built the frontend to validate the changes with `cd frontend && npm run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6a38cece0832ea14292b3682eb1e1)