### PR TITLE
feat(web): add drag-and-drop audio upload support

### DIFF
--- a/rust/web/app.css
+++ b/rust/web/app.css
@@ -229,6 +229,38 @@ pre {
   color: var(--ink);
 }
 
+.upload-dropzone {
+  display: grid;
+  gap: 4px;
+  padding: 18px 16px;
+  border: 1px dashed rgba(14, 109, 98, 0.55);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.55);
+  cursor: pointer;
+  transition: border-color 140ms ease, background-color 140ms ease;
+}
+
+.upload-dropzone strong {
+  font-size: 0.98rem;
+}
+
+.upload-dropzone p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.upload-dropzone input[type="file"] {
+  border: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.upload-dropzone.is-dragover {
+  border-color: var(--accent);
+  background: rgba(14, 109, 98, 0.12);
+}
+
 .field-wide {
   min-width: 0;
 }

--- a/rust/web/app.js
+++ b/rust/web/app.js
@@ -60,6 +60,7 @@ function captureElements() {
   elements.jobsRefreshButton = document.getElementById("jobs-refresh-button");
   elements.selectedJobRefreshButton = document.getElementById("selected-job-refresh-button");
   elements.uploadForm = document.getElementById("upload-form");
+  elements.uploadDropzone = document.getElementById("upload-dropzone");
   elements.uploadInput = document.getElementById("upload-input");
   elements.uploadSubmitButton = document.getElementById("upload-submit-button");
   elements.sttForm = document.getElementById("stt-form");
@@ -89,6 +90,10 @@ function bindEvents() {
     refreshSelectedJob(state.selectedJobId, { showMessage: true });
   });
   elements.uploadForm.addEventListener("submit", onUploadSubmit);
+  elements.uploadDropzone.addEventListener("dragenter", onUploadDragEnter);
+  elements.uploadDropzone.addEventListener("dragover", onUploadDragOver);
+  elements.uploadDropzone.addEventListener("dragleave", onUploadDragLeave);
+  elements.uploadDropzone.addEventListener("drop", onUploadDrop);
   elements.sttSubmitButton.addEventListener("click", onSttSubmit);
   elements.summarySubmitButton.addEventListener("click", onSummarySubmit);
   elements.embeddingSubmitButton.addEventListener("click", onEmbeddingSubmit);
@@ -129,6 +134,7 @@ async function onUploadSubmit(event) {
       status === 202 ? "info" : "success"
     );
     elements.uploadForm.reset();
+    setUploadDropzoneDragState(false);
     await refreshJobs();
     if (data?.job_id) {
       await refreshSelectedJob(data.job_id, { showMessage: true });
@@ -138,6 +144,45 @@ async function onUploadSubmit(event) {
   } finally {
     setLoading("upload", false);
   }
+}
+
+function onUploadDragEnter(event) {
+  event.preventDefault();
+  setUploadDropzoneDragState(true);
+}
+
+function onUploadDragOver(event) {
+  event.preventDefault();
+  event.dataTransfer.dropEffect = "copy";
+  setUploadDropzoneDragState(true);
+}
+
+function onUploadDragLeave(event) {
+  event.preventDefault();
+  if (event.currentTarget.contains(event.relatedTarget)) {
+    return;
+  }
+  setUploadDropzoneDragState(false);
+}
+
+function onUploadDrop(event) {
+  event.preventDefault();
+  setUploadDropzoneDragState(false);
+
+  const droppedFiles = event.dataTransfer?.files;
+  if (!droppedFiles || droppedFiles.length === 0) {
+    return;
+  }
+
+  const firstFile = droppedFiles[0];
+  const transfer = new DataTransfer();
+  transfer.items.add(firstFile);
+  elements.uploadInput.files = transfer.files;
+  setMessage("upload", `선택된 파일: ${firstFile.name}`, "info");
+}
+
+function setUploadDropzoneDragState(isDragOver) {
+  elements.uploadDropzone.classList.toggle("is-dragover", isDragOver);
 }
 
 async function onSttSubmit() {
@@ -930,4 +975,3 @@ function escapeHtml(value) {
 function escapeAttribute(value) {
   return escapeHtml(value);
 }
-

--- a/rust/web/index.html
+++ b/rust/web/index.html
@@ -49,10 +49,14 @@
           </div>
           <div class="notice" id="upload-message" aria-live="polite"></div>
           <form class="upload-form" id="upload-form">
-            <label class="field">
+            <div class="field">
               <span>Audio File</span>
-              <input id="upload-input" name="file" type="file" accept=".wav,.mp3,.flac,.ogg,audio/*" required />
-            </label>
+              <label class="upload-dropzone" id="upload-dropzone">
+                <input id="upload-input" name="file" type="file" accept=".wav,.mp3,.flac,.ogg,audio/*" required />
+                <strong>파일을 여기로 드래그 앤 드롭</strong>
+                <p>또는 클릭해서 파일 선택</p>
+              </label>
+            </div>
             <button class="primary-button" id="upload-submit-button" type="submit">업로드 후 처리 시작</button>
           </form>
         </section>


### PR DESCRIPTION
### Motivation
- Improve the web console upload UX by allowing users to drag-and-drop audio files into the Upload panel while keeping the existing click-to-select + submit flow intact.

### Description
- Added a dropzone markup in `rust/web/index.html` (`<label class="upload-dropzone" id="upload-dropzone">`) and kept the existing `<input id="upload-input">` so both click and drop selection work.
- Added styles for the dropzone in `rust/web/app.css` (`.upload-dropzone`, `.upload-dropzone.is-dragover`) to provide a dashed border and visual highlight while dragging.
- Implemented drag handlers and integration in `rust/web/app.js` (`onUploadDragEnter`, `onUploadDragOver`, `onUploadDragLeave`, `onUploadDrop`, and `setUploadDropzoneDragState`) and bound them in `bindEvents`, with dropped files transferred into the existing file input and the drop state reset after submit.
- Scope is limited to static frontend assets under `rust/web/*` and preserves the existing upload submission flow and behaviors.

### Testing
- Ran `cargo test --manifest-path rust/Cargo.toml`, which failed in this environment because `rustc 1.87.0` is installed while the `time` crate requires `rustc 1.88.0`, so automated tests could not complete due to the toolchain mismatch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6a4c98af0832e983d03dc1184c847)